### PR TITLE
fix(cascade): correct compute_cascade recursive return values (ADR-007)

### DIFF
--- a/scripts/cascade_oracle.py
+++ b/scripts/cascade_oracle.py
@@ -83,28 +83,31 @@ def count_concurrent_waiters(graph, target, w_start, w_end):
 
 
 def compute_cascade(graph, current, w_start, w_end, depth, path):
-    """Recursive cascade computation. Returns total propagated weight."""
+    """Recursive cascade computation. Returns (total_propagated, self_blame)."""
+    duration = w_end - w_start
     if depth >= MAX_DEPTH or current in path:
-        return 0
+        return (0, duration)
 
     outgoing = graph["outgoing"].get(current, [])
 
     intervals = sweep_line_partition(outgoing, w_start, w_end)
     if not intervals:
-        return 0
+        return (0, duration)
 
     path.add(current)
     total_propagated = 0
+    coverage = 0
 
     for i_start, i_end, targets in intervals:
         target_count = max(len(targets), 1)
-        duration = i_end - i_start
+        interval_duration = i_end - i_start
+        coverage += interval_duration
 
         for next_node in targets:
-            compute_cascade(
+            prop_down, child_blame = compute_cascade(
                 graph, next_node, i_start, i_end, depth + 1, path
             )
-            child_absorbed = duration
+            child_absorbed = prop_down + child_blame
             external = count_concurrent_waiters(
                 graph, next_node, i_start, i_end
             )
@@ -112,7 +115,8 @@ def compute_cascade(graph, current, w_start, w_end, depth, path):
             total_propagated += transfer
 
     path.remove(current)
-    return total_propagated
+    self_blame = max(0, duration - coverage)
+    return (total_propagated, self_blame)
 
 
 def cascade_engine(graph):
@@ -122,7 +126,7 @@ def cascade_engine(graph):
     for src, dst, e_start, e_end in graph["edge_list"]:
         raw_wait = e_end - e_start
         path = {src}
-        propagated = compute_cascade(
+        propagated, _self_blame = compute_cascade(
             graph, dst, e_start, e_end, 1, path
         )
         attributed = max(0, raw_wait - propagated)

--- a/src/cascade/engine.rs
+++ b/src/cascade/engine.rs
@@ -43,7 +43,8 @@ pub fn cascade_engine(graph: &WaitForGraph, max_depth: Option<u32>) -> WaitForGr
         let mut path = BTreeSet::new();
         path.insert(src_tid);
 
-        let propagated = compute_cascade(graph, dst_tid, &window, 1, max_depth, &mut path);
+        let (propagated, _self_blame) =
+            compute_cascade(graph, dst_tid, &window, 1, max_depth, &mut path);
 
         let attributed = raw_wait.saturating_sub(propagated);
         attribution.insert(eidx, attributed);
@@ -79,7 +80,15 @@ pub fn is_conserved(original: &WaitForGraph, result: &WaitForGraph) -> bool {
 }
 
 /// Recursive cascade computation (ADR-007 pseudocode).
-/// Returns total weight propagated to deeper nodes.
+///
+/// Returns `(total_propagated, self_blame)`:
+/// - `total_propagated`: weight pushed to deeper nodes via outgoing edges
+/// - `self_blame`: time in `window` not covered by any outgoing edge
+///
+/// Per-entry-edge conservation (I-1, ADR-015): for each entry edge,
+/// `propagated + self_blame <= window.duration()`. Equality holds when
+/// no fan-out or concurrent-waiter scaling is applied; integer division
+/// truncation may cause the sum to be strictly less.
 fn compute_cascade(
     graph: &WaitForGraph,
     current: ThreadId,
@@ -87,24 +96,26 @@ fn compute_cascade(
     depth: u32,
     max_depth: u32,
     path: &mut BTreeSet<ThreadId>,
-) -> u64 {
+) -> (u64, u64) {
     if depth >= max_depth || path.contains(&current) {
-        return 0;
+        return (0, window.duration());
     }
 
     let intervals = sweep_line_partition(graph, current, window);
     if intervals.is_empty() {
-        return 0;
+        return (0, window.duration());
     }
 
     path.insert(current);
     let mut total_propagated: u64 = 0;
+    let mut coverage: u64 = 0;
 
     for interval in &intervals {
         let target_count = interval.targets.len() as u64;
+        coverage += interval.window.duration();
 
         for &next_node in &interval.targets {
-            let _ = compute_cascade(
+            let (prop_down, child_blame) = compute_cascade(
                 graph,
                 next_node,
                 &interval.window,
@@ -113,21 +124,20 @@ fn compute_cascade(
                 path,
             );
 
-            // NEW-BUG-1 FIX: The child's subtree absorbs the entire interval duration.
-            // This correctly attributes blame to leaf nodes, which would otherwise be zero.
-            let child_subtree_absorbed = interval.window.duration();
+            let child_absorbed = prop_down + child_blame;
 
             let external_waiters = count_concurrent_waiters(graph, next_node, &interval.window);
             let scale_target = target_count.max(1);
             let scale_external = external_waiters.max(1);
 
-            let transfer = child_subtree_absorbed / scale_target / scale_external;
+            let transfer = child_absorbed / scale_target / scale_external;
             total_propagated += transfer;
         }
     }
 
     path.remove(&current);
-    total_propagated
+    let self_blame = window.duration().saturating_sub(coverage);
+    (total_propagated, self_blame)
 }
 
 fn count_concurrent_waiters(graph: &WaitForGraph, target: ThreadId, window: &TimeWindow) -> u64 {

--- a/src/cascade/invariants.rs
+++ b/src/cascade/invariants.rs
@@ -113,10 +113,20 @@ pub fn check_idempotency(graph: &WaitForGraph, max_depth: u32) -> bool {
         .all(|(a, b)| a.3.attributed_delay_ms == b.3.attributed_delay_ms)
 }
 
-/// I-6: Depth monotonicity.
-/// Increasing max_depth propagates more weight downstream, so
-/// total_attributed(deep) ≤ total_attributed(shallow).
-/// Test-only — runs cascade at two depths.
+/// I-6: Depth monotonicity (simple chains only).
+///
+/// For simple chains (no fan-out, no concurrent waiters): increasing
+/// max_depth propagates more weight downstream, so
+/// `total_attributed(deep) ≤ total_attributed(shallow)`.
+///
+/// Does NOT hold in general because the corrected child_absorbed
+/// computation (`prop_down + child_blame`) can be less than
+/// `window.duration()` when fan-out (target_count > 1) or concurrent
+/// waiters divide the transfer amount. This means deeper recursion
+/// may propagate less weight downstream than the depth-truncation
+/// base case, which returns full `(0, window.duration())`.
+///
+/// Test-only — runs cascade at two depths. Only valid on simple chains.
 pub fn check_depth_monotonicity(graph: &WaitForGraph) -> bool {
     use super::engine::cascade_engine;
 

--- a/src/graph/wfg.rs
+++ b/src/graph/wfg.rs
@@ -150,6 +150,11 @@ impl WaitForGraph {
             .sum()
     }
 
+    /// Returns true if the graph has no directed cycles.
+    pub fn is_acyclic(&self) -> bool {
+        petgraph::algo::toposort(&self.graph, None).is_ok()
+    }
+
     /// Sum of all attributed_delay_ms across all edges.
     pub fn total_attributed(&self) -> u64 {
         self.graph

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -7,8 +7,8 @@ use proptest::prelude::*;
 
 use wperf::cascade::engine::{cascade_engine, is_conserved};
 use wperf::cascade::invariants::{
-    check_depth_monotonicity, check_idempotency, check_locality, check_non_amplification,
-    check_non_negativity, check_termination,
+    check_idempotency, check_locality, check_non_amplification, check_non_negativity,
+    check_termination,
 };
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
@@ -91,11 +91,10 @@ proptest! {
         prop_assert!(check_idempotency(&g, 10), "I-5 (idempotency) failed");
     }
 
-    #[test]
-    fn depth_monotonicity_holds(g in arb_wfg()) {
-        // I-6: Separate test — runs cascade at two depths
-        prop_assert!(check_depth_monotonicity(&g), "I-6 (depth monotonicity) failed");
-    }
+    // I-6 (depth monotonicity) removed from property testing.
+    // It only holds for simple chains — fan-out and concurrent waiters
+    // cause child_absorbed < window.duration(), breaking monotonicity.
+    // See invariants.rs I-6 doc. Unit tests cover the chain case.
 
     #[test]
     fn condensation_is_acyclic(g in arb_wfg()) {


### PR DESCRIPTION
## Summary
- `compute_cascade` returns `(propagated, self_blame)` tuple per ADR-007 pseudocode instead of just `propagated`
- `child_absorbed` now uses `prop_down + child_blame` (actual recursive result) instead of `interval.window.duration()` (always full interval), fixing incorrect weight attribution
- Python oracle (`scripts/cascade_oracle.py`) synchronized with the same algorithmic fix
- I-6 depth monotonicity narrowed to simple chains only — fan-out and concurrent waiters cause `child_absorbed < window.duration()`, breaking monotonicity in the general case
- Removed I-6 from 10K property tests; unit tests on simple chains retained

## Test plan
- [x] 68 unit tests pass
- [x] 5 bug regression tests pass
- [x] 6 differential tests (Rust vs Python oracle) pass
- [x] 7 figure4 integration tests pass
- [x] 3 property tests (10K graphs each) pass — I-1/I-2/I-3/I-4/I-5/I-7 + idempotency + condensation
- [x] clippy clean, fmt clean

Closes #8

Signed-off-by: Adrian Mason <258563901+adrian-mason@users.noreply.github.com>