### PR TITLE
refactor(cascade): is_conserved checks I-1 only, cascade_engine returns Result

### DIFF
--- a/src/cascade/engine.rs
+++ b/src/cascade/engine.rs
@@ -19,6 +19,7 @@ use crate::graph::types::*;
 use crate::graph::wfg::WaitForGraph;
 
 use super::invariants;
+pub use super::invariants::ConservationError;
 
 const DEFAULT_MAX_DEPTH: u32 = 10;
 
@@ -27,11 +28,12 @@ const DEFAULT_MAX_DEPTH: u32 = 10;
 /// Each edge's `attributed_delay_ms` is set to `raw_wait - propagated`,
 /// where `propagated` is the weight explained by deeper nodes.
 ///
-/// Invariant checks:
-/// - I-2 (non-amplification): attributed ≤ raw per edge — always checked
-/// - I-3 (non-negativity): attributed ≥ 0 — trivially true for u64
-/// - I-7 (locality): checked in debug builds
-pub fn cascade_engine(graph: &WaitForGraph, max_depth: Option<u32>) -> WaitForGraph {
+/// Returns `Err(ConservationError)` if invariant checks fail.
+/// Never panics — safe for release builds.
+pub fn cascade_engine(
+    graph: &WaitForGraph,
+    max_depth: Option<u32>,
+) -> Result<WaitForGraph, ConservationError> {
     let max_depth = max_depth.unwrap_or(DEFAULT_MAX_DEPTH);
 
     let mut attribution: BTreeMap<EdgeIndex, u64> = BTreeMap::new();
@@ -55,8 +57,8 @@ pub fn cascade_engine(graph: &WaitForGraph, max_depth: Option<u32>) -> WaitForGr
         result.edge_weight_mut(*eidx).attributed_delay_ms = *attributed;
     }
 
-    // I-1: Weight Conservation — production sentinel (always runs)
-    invariants::assert_weight_conserved(graph, &result);
+    // I-1: Production sentinel — verify conservation (never panics)
+    invariants::verify_conservation(graph, &result)?;
 
     // I-3: Non-negativity (trivially true for u64, documents intent)
     debug_assert!(
@@ -70,13 +72,7 @@ pub fn cascade_engine(graph: &WaitForGraph, max_depth: Option<u32>) -> WaitForGr
         "I-4 VIOLATION: cascade changed graph topology"
     );
 
-    result
-}
-
-/// Check if the cascade result is conserved (non-panicking).
-/// Delegates to invariants::is_conserved (I-2 + I-7).
-pub fn is_conserved(original: &WaitForGraph, result: &WaitForGraph) -> bool {
-    invariants::is_conserved(original, result)
+    Ok(result)
 }
 
 /// Recursive cascade computation (ADR-007 pseudocode).
@@ -179,7 +175,7 @@ mod tests {
         g.add_node(ThreadId(2), NodeKind::UserThread);
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let edges = result.all_edges();
         assert_eq!(edges[0].3.attributed_delay_ms, 50);
     }
@@ -187,7 +183,7 @@ mod tests {
     #[test]
     fn cascade_figure4() {
         let g = figure4_graph();
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
 
         let edges = result.all_edges();
         let user_parser = edges
@@ -216,7 +212,7 @@ mod tests {
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100)); // Parser→Network
         g.add_edge(ThreadId(3), ThreadId(4), TimeWindow::new(50, 100)); // Network→Disk
 
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let edges = result.all_edges();
 
         let up = edges
@@ -243,7 +239,7 @@ mod tests {
     #[test]
     fn cascade_leaf_nonzero() {
         let g = figure4_graph();
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let edges = result.all_edges();
         let parser_network = edges
             .iter()
@@ -255,19 +251,19 @@ mod tests {
     #[test]
     fn cascade_no_amplification() {
         let g = figure4_graph();
-        let result = cascade_engine(&g, None);
-        assert!(is_conserved(&g, &result));
+        let result = cascade_engine(&g, None).unwrap();
+        assert!(invariants::is_conserved(&result));
     }
 
     #[test]
     fn is_conserved_false_on_bad_graph() {
         let g = figure4_graph();
-        let mut result = cascade_engine(&g, None);
+        let mut result = cascade_engine(&g, None).unwrap();
         // Corrupt: set attributed > raw on first edge
         let edges = result.all_edges();
         let eidx = edges[0].0;
         result.edge_weight_mut(eidx).attributed_delay_ms = 999;
-        assert!(!is_conserved(&g, &result));
+        assert!(!invariants::is_conserved(&result));
     }
 
     #[test]
@@ -285,7 +281,7 @@ mod tests {
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(0, 100));
         g.add_edge(ThreadId(4), ThreadId(3), TimeWindow::new(0, 100));
 
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let edges = result.all_edges();
 
         let e12 = edges
@@ -310,8 +306,8 @@ mod tests {
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(0, 100));
 
-        let shallow = cascade_engine(&g, Some(1));
-        let deep = cascade_engine(&g, Some(10));
+        let shallow = cascade_engine(&g, Some(1)).unwrap();
+        let deep = cascade_engine(&g, Some(10)).unwrap();
 
         let s_edges = shallow.all_edges();
         let d_edges = deep.all_edges();
@@ -337,7 +333,7 @@ mod tests {
     #[test]
     fn total_attributed_less_than_raw() {
         let g = figure4_graph();
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         // Total attributed should be less than total raw (weight absorbed by cascade)
         assert!(result.total_attributed() < g.total_raw_wait());
         assert!(result.total_attributed() > 0);

--- a/src/cascade/invariants.rs
+++ b/src/cascade/invariants.rs
@@ -1,43 +1,58 @@
 //! Cascade invariant checks (ADR-007).
 //!
-//! I-1 runs in ALL builds (production sentinel).
+//! I-1 (per-entry-edge conservation) runs in ALL builds via
+//! `verify_conservation`, which returns `Result`.
 //! I-2..I-7 are debug_assert only.
+
+use std::fmt;
 
 use crate::graph::wfg::WaitForGraph;
 
-/// I-1: Weight Conservation (production sentinel).
-///
-/// Checks I-2 (non-amplification) + I-7 (locality). This runs in ALL
-/// builds — it is the first line of defense against algorithm bugs.
-///
-/// Note: global sum equality (`Σ attributed == Σ raw`) does NOT hold
-/// after cascade redistribution. The cascade absorbs weight at
-/// intermediate nodes, so `total_attributed ≤ total_raw`. Per-edge
-/// non-amplification (I-2) is the correct conservation check.
-pub fn is_conserved(original: &WaitForGraph, result: &WaitForGraph) -> bool {
-    check_non_amplification(result) && check_locality(original, result)
+/// Error returned when cascade invariant checks fail.
+#[derive(Debug)]
+pub struct ConservationError {
+    pub i2_ok: bool,
+    pub i7_ok: bool,
 }
 
-/// I-1 enforcement: call after every cascade run.
-/// Panics in debug builds, logs warning in release builds.
-/// Returns the conservation status.
-pub fn assert_weight_conserved(original: &WaitForGraph, result: &WaitForGraph) -> bool {
-    let i2 = check_non_amplification(result);
-    let i7 = check_locality(original, result);
-    let conserved = i2 && i7;
-
-    if !conserved {
-        if cfg!(debug_assertions) {
-            panic!(
-                "I-1 VIOLATION: conservation check failed (I-2={}, I-7={})",
-                i2, i7
-            );
-        } else {
-            eprintln!("[wperf] WARNING: I-1 violation (I-2={}, I-7={})", i2, i7);
-        }
+impl fmt::Display for ConservationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "I-1 VIOLATION: conservation check failed (I-2={}, I-7={})",
+            self.i2_ok, self.i7_ok
+        )
     }
+}
 
-    conserved
+impl std::error::Error for ConservationError {}
+
+/// I-1: Per-entry-edge conservation (production sentinel).
+///
+/// Checks non-amplification only: no edge's attributed_delay_ms
+/// exceeds its raw_wait_ms. This is the per-entry-edge invariant
+/// defined in ADR-015.
+pub fn is_conserved(result: &WaitForGraph) -> bool {
+    check_non_amplification(result)
+}
+
+/// Internal engine sentinel: verify I-2 + I-7 after cascade.
+///
+/// Stricter than `is_conserved` (which only checks I-1/I-2). This also
+/// verifies I-7 (locality) to catch algorithm bugs that alter topology.
+/// Returns `Err(ConservationError)` on violation — never panics.
+pub fn verify_conservation(
+    original: &WaitForGraph,
+    result: &WaitForGraph,
+) -> Result<(), ConservationError> {
+    let i2_ok = check_non_amplification(result);
+    let i7_ok = check_locality(original, result);
+
+    if i2_ok && i7_ok {
+        Ok(())
+    } else {
+        Err(ConservationError { i2_ok, i7_ok })
+    }
 }
 
 /// I-2: Non-amplification.
@@ -97,8 +112,8 @@ pub fn check_locality(original: &WaitForGraph, result: &WaitForGraph) -> bool {
 pub fn check_idempotency(graph: &WaitForGraph, max_depth: u32) -> bool {
     use super::engine::cascade_engine;
 
-    let first = cascade_engine(graph, Some(max_depth));
-    let second = cascade_engine(&first, Some(max_depth));
+    let first = cascade_engine(graph, Some(max_depth)).expect("I-5: first cascade failed");
+    let second = cascade_engine(&first, Some(max_depth)).expect("I-5: second cascade failed");
 
     // Compare all attributed_delay_ms values
     let e1 = first.all_edges();
@@ -130,8 +145,8 @@ pub fn check_idempotency(graph: &WaitForGraph, max_depth: u32) -> bool {
 pub fn check_depth_monotonicity(graph: &WaitForGraph) -> bool {
     use super::engine::cascade_engine;
 
-    let shallow = cascade_engine(graph, Some(2));
-    let deep = cascade_engine(graph, Some(10));
+    let shallow = cascade_engine(graph, Some(2)).expect("I-6: shallow cascade failed");
+    let deep = cascade_engine(graph, Some(10)).expect("I-6: deep cascade failed");
 
     deep.total_attributed() <= shallow.total_attributed()
 }
@@ -149,7 +164,7 @@ mod tests {
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
         let result = g.clone_with_reset_attribution();
-        assert!(is_conserved(&g, &result));
+        assert!(is_conserved(&result));
     }
 
     #[test]
@@ -162,8 +177,8 @@ mod tests {
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
 
-        let result = cascade_engine(&g, None);
-        assert!(is_conserved(&g, &result));
+        let result = cascade_engine(&g, None).unwrap();
+        assert!(is_conserved(&result));
     }
 
     #[test]
@@ -178,11 +193,11 @@ mod tests {
         let edges = bad.all_edges();
         let eidx = edges[0].0;
         bad.edge_weight_mut(eidx).attributed_delay_ms = 999;
-        assert!(!is_conserved(&g, &bad));
+        assert!(!is_conserved(&bad));
     }
 
     #[test]
-    fn conservation_detects_locality_violation() {
+    fn verify_conservation_detects_locality_violation() {
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(1), NodeKind::UserThread);
         g.add_node(ThreadId(2), NodeKind::UserThread);
@@ -192,7 +207,7 @@ mod tests {
         let mut bad = g.clone_with_reset_attribution();
         bad.add_node(ThreadId(3), NodeKind::UserThread);
         bad.add_edge(ThreadId(1), ThreadId(3), TimeWindow::new(0, 30));
-        assert!(!is_conserved(&g, &bad));
+        assert!(verify_conservation(&g, &bad).is_err());
     }
 
     #[test]
@@ -302,15 +317,15 @@ mod tests {
     }
 
     #[test]
-    fn assert_weight_conserved_returns_true_on_valid() {
+    fn verify_conservation_returns_ok_on_valid() {
         use crate::cascade::engine::cascade_engine;
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(1), NodeKind::UserThread);
         g.add_node(ThreadId(2), NodeKind::UserThread);
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
-        let result = cascade_engine(&g, None);
-        assert!(assert_weight_conserved(&g, &result));
+        let result = cascade_engine(&g, None).unwrap();
+        assert!(verify_conservation(&g, &result).is_ok());
     }
 
     #[test]
@@ -353,7 +368,7 @@ mod tests {
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
 
         // Verify cascade actually changes attributed values
-        let result = cascade_engine(&g, Some(10));
+        let result = cascade_engine(&g, Some(10)).unwrap();
         let edges = result.all_edges();
         let e12 = edges
             .iter()
@@ -378,8 +393,8 @@ mod tests {
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(0, 100));
 
-        let shallow = cascade_engine(&g, Some(2));
-        let deep = cascade_engine(&g, Some(10));
+        let shallow = cascade_engine(&g, Some(2)).unwrap();
+        let deep = cascade_engine(&g, Some(10)).unwrap();
         // Deep cascade propagates more → less total attributed
         assert!(deep.total_attributed() <= shallow.total_attributed());
         assert!(check_depth_monotonicity(&g));

--- a/src/critical_path/mod.rs
+++ b/src/critical_path/mod.rs
@@ -113,7 +113,7 @@ mod tests {
     use crate::scc::tarjan::build_condensation;
 
     fn run_pipeline(g: &WaitForGraph) -> CriticalPath {
-        let result = cascade_engine(g, None);
+        let result = cascade_engine(g, None).unwrap();
         let mut cdag = build_condensation(&result);
         apply_max_heuristic(&mut cdag, &result);
         critical_path_dp(&cdag).unwrap()

--- a/src/output.rs
+++ b/src/output.rs
@@ -50,7 +50,7 @@ impl CascadeResult {
             graph_metrics: GraphMetrics {
                 total_raw_wait_ms: total_raw,
                 total_attributed_delay_ms: total_attr,
-                is_conserved: invariants::is_conserved(original, result),
+                is_conserved: invariants::is_conserved(result),
                 edge_count: result.edge_count(),
                 node_count: result.node_count(),
             },

--- a/src/scc/heuristic.rs
+++ b/src/scc/heuristic.rs
@@ -73,7 +73,7 @@ mod tests {
         g.add_node(ThreadId(2), NodeKind::UserThread);
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let scc = Scc {
             members: vec![ThreadId(2)],
         };
@@ -107,7 +107,7 @@ mod tests {
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
 
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let mut cdag = build_condensation(&result);
         apply_max_heuristic(&mut cdag, &result);
 
@@ -126,7 +126,7 @@ mod tests {
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
 
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let mut cdag = build_condensation(&result);
         apply_max_heuristic(&mut cdag, &result);
 

--- a/tests/bug_regressions.rs
+++ b/tests/bug_regressions.rs
@@ -3,7 +3,8 @@
 //! Each test constructs the minimal graph triggering the specific bug
 //! and verifies the fix produces correct output.
 
-use wperf::cascade::engine::{cascade_engine, is_conserved};
+use wperf::cascade::engine::cascade_engine;
+use wperf::cascade::invariants::is_conserved;
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
 
@@ -31,7 +32,7 @@ fn bug1_visited_path_scope() {
     g.add_edge(ThreadId(3), ThreadId(5), TimeWindow::new(0, 50)); // C→E
     g.add_edge(ThreadId(4), ThreadId(5), TimeWindow::new(50, 100)); // D→E
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
 
     // A→B: B is busy for the full 100ms (with C then D) → attributed=0
     let edges = result.all_edges();
@@ -62,7 +63,7 @@ fn bug1_visited_path_scope() {
         "D→E must not be zero (BUG-1: E was skipped via D path)"
     );
 
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }
 
 /// BUG-2: propagated_down return value ignored.
@@ -84,7 +85,7 @@ fn bug2_propagated_down_ignored() {
     g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
     g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     let ab = edges
@@ -99,7 +100,7 @@ fn bug2_propagated_down_ignored() {
     );
     assert_eq!(ab.3.attributed_delay_ms, 20);
 
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }
 
 /// BUG-3: multi-edge overlap double-counting.
@@ -124,7 +125,7 @@ fn bug3_multi_edge_overlap() {
     g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(0, 60)); // B→C
     g.add_edge(ThreadId(2), ThreadId(4), TimeWindow::new(20, 80)); // B→D
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     let ab = edges
@@ -142,7 +143,7 @@ fn bug3_multi_edge_overlap() {
     // B is idle during [80,100) → 20ms is B's direct fault
     assert_eq!(ab.3.attributed_delay_ms, 20);
 
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }
 
 /// BUG-4: BUG-2 + BUG-3 combined.
@@ -166,7 +167,7 @@ fn bug4_combined_bug2_bug3() {
     g.add_edge(ThreadId(2), ThreadId(4), TimeWindow::new(20, 80)); // B→D
     g.add_edge(ThreadId(3), ThreadId(5), TimeWindow::new(0, 60)); // C→E
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     let ab = edges
@@ -189,7 +190,7 @@ fn bug4_combined_bug2_bug3() {
         "B→C must propagate weight to E"
     );
 
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }
 
 /// NEW-BUG-1: leaf node zero blame.
@@ -209,7 +210,7 @@ fn new_bug1_leaf_node_zero_blame() {
     g.add_node(ThreadId(2), NodeKind::UserThread);
     g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     // B is a leaf — full attribution belongs to B
@@ -218,5 +219,5 @@ fn new_bug1_leaf_node_zero_blame() {
         "NEW-BUG-1: leaf node must get full attribution"
     );
 
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }

--- a/tests/differential.rs
+++ b/tests/differential.rs
@@ -148,7 +148,7 @@ fn compare_results(rust_graph: &WaitForGraph, python: &OracleOutput, test_name: 
 }
 
 fn run_differential(g: &WaitForGraph, test_name: &str) {
-    let rust_result = cascade_engine(g, None);
+    let rust_result = cascade_engine(g, None).unwrap();
     let input = graph_to_oracle_input(g);
     let python_result = run_python_oracle(&input);
     compare_results(&rust_result, &python_result, test_name);

--- a/tests/figure4.rs
+++ b/tests/figure4.rs
@@ -3,7 +3,8 @@
 //! These are the fundamental correctness tests — if these fail,
 //! the cascade engine is broken.
 
-use wperf::cascade::engine::{cascade_engine, is_conserved};
+use wperf::cascade::engine::cascade_engine;
+use wperf::cascade::invariants::is_conserved;
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
 use wperf::output::CascadeResult;
@@ -23,7 +24,7 @@ fn figure4_graph() -> WaitForGraph {
 #[test]
 fn figure4_attributed_values() {
     let g = figure4_graph();
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     let user_parser = edges
@@ -49,7 +50,7 @@ fn figure4_attributed_values() {
 #[test]
 fn figure4_root_edge_conservation() {
     let g = figure4_graph();
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     let user_parser = edges
@@ -73,14 +74,14 @@ fn figure4_root_edge_conservation() {
 #[test]
 fn figure4_invariants_hold() {
     let g = figure4_graph();
-    let result = cascade_engine(&g, None);
-    assert!(is_conserved(&g, &result), "I-1 sentinel must pass");
+    let result = cascade_engine(&g, None).unwrap();
+    assert!(is_conserved(&result), "I-1 sentinel must pass");
 }
 
 #[test]
 fn figure4_json_output() {
     let g = figure4_graph();
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let output = CascadeResult::from_graph(&g, &result);
 
     assert!(output.graph_metrics.is_conserved);
@@ -104,7 +105,7 @@ fn extended_chain_attributed_values() {
     g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
     g.add_edge(ThreadId(3), ThreadId(4), TimeWindow::new(50, 100));
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     let up = edges
@@ -131,7 +132,7 @@ fn extended_chain_attributed_values() {
     let total = up.3.attributed_delay_ms + pn.3.attributed_delay_ms + nd.3.attributed_delay_ms;
     assert_eq!(total, 100);
 
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }
 
 /// Single edge: leaf node gets full attribution.
@@ -142,10 +143,10 @@ fn single_edge_full_attribution() {
     g.add_node(ThreadId(2), NodeKind::UserThread);
     g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
     assert_eq!(edges[0].3.attributed_delay_ms, 50);
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }
 
 /// Disconnected components: each edge is independent.
@@ -159,7 +160,7 @@ fn disconnected_edges() {
     g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
     g.add_edge(ThreadId(3), ThreadId(4), TimeWindow::new(0, 80));
 
-    let result = cascade_engine(&g, None);
+    let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
 
     let e1 = edges
@@ -174,5 +175,5 @@ fn disconnected_edges() {
     // Both are leaf edges — full attribution
     assert_eq!(e1.3.attributed_delay_ms, 50);
     assert_eq!(e2.3.attributed_delay_ms, 80);
-    assert!(is_conserved(&g, &result));
+    assert!(is_conserved(&result));
 }

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -5,10 +5,10 @@
 
 use proptest::prelude::*;
 
-use wperf::cascade::engine::{cascade_engine, is_conserved};
+use wperf::cascade::engine::cascade_engine;
 use wperf::cascade::invariants::{
     check_idempotency, check_locality, check_non_amplification, check_non_negativity,
-    check_termination,
+    check_termination, is_conserved,
 };
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
@@ -67,10 +67,10 @@ proptest! {
 
     #[test]
     fn all_invariants_hold(g in arb_wfg()) {
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
 
-        // I-1: Production sentinel (I-2 + I-7)
-        prop_assert!(is_conserved(&g, &result), "I-1 (conservation) failed");
+        // I-1: Per-entry-edge conservation (non-amplification)
+        prop_assert!(is_conserved(&result), "I-1 (conservation) failed");
 
         // I-2: Non-amplification
         prop_assert!(check_non_amplification(&result), "I-2 (non-amplification) failed");
@@ -98,7 +98,7 @@ proptest! {
 
     #[test]
     fn condensation_is_acyclic(g in arb_wfg()) {
-        let result = cascade_engine(&g, None);
+        let result = cascade_engine(&g, None).unwrap();
         let cdag = build_condensation(&result);
         // Condensation must be a DAG — toposort should succeed
         prop_assert!(


### PR DESCRIPTION
## Summary
- `is_conserved` checks I-1 only (per-entry-edge non-amplification, ADR-015) — no longer bundles I-7 locality
- `cascade_engine` returns `Result<WaitForGraph, ConservationError>` — never panics in release builds
- `assert_weight_conserved` replaced by `verify_conservation` returning `Result`
- `ConservationError` type with `Display` + `Error` impls for structured error handling

## Test plan
- [x] 68 unit tests pass
- [x] 5 bug regression tests pass
- [x] 6 differential tests pass
- [x] 7 figure4 integration tests pass
- [x] 3 property tests (10K graphs) pass
- [x] clippy clean, fmt clean

Signed-off-by: Adrian Mason <258563901+adrian-mason@users.noreply.github.com>