### PR TITLE
refactor(cascade): rename is_conserved → invariants_ok (ADR-016)

### DIFF
--- a/src/cascade/engine.rs
+++ b/src/cascade/engine.rs
@@ -19,7 +19,7 @@ use crate::graph::types::*;
 use crate::graph::wfg::WaitForGraph;
 
 use super::invariants;
-pub use super::invariants::ConservationError;
+pub use super::invariants::InvariantError;
 
 const DEFAULT_MAX_DEPTH: u32 = 10;
 
@@ -28,12 +28,12 @@ const DEFAULT_MAX_DEPTH: u32 = 10;
 /// Each edge's `attributed_delay_ms` is set to `raw_wait - propagated`,
 /// where `propagated` is the weight explained by deeper nodes.
 ///
-/// Returns `Err(ConservationError)` if invariant checks fail.
+/// Returns `Err(InvariantError)` if invariant checks fail.
 /// Never panics — safe for release builds.
 pub fn cascade_engine(
     graph: &WaitForGraph,
     max_depth: Option<u32>,
-) -> Result<WaitForGraph, ConservationError> {
+) -> Result<WaitForGraph, InvariantError> {
     let max_depth = max_depth.unwrap_or(DEFAULT_MAX_DEPTH);
 
     let mut attribution: BTreeMap<EdgeIndex, u64> = BTreeMap::new();
@@ -57,8 +57,8 @@ pub fn cascade_engine(
         result.edge_weight_mut(*eidx).attributed_delay_ms = *attributed;
     }
 
-    // I-1: Production sentinel — verify conservation (never panics)
-    invariants::verify_conservation(graph, &result)?;
+    // Production sentinel — verify I-2 ∧ I-7 postconditions (never panics)
+    invariants::verify_engine_postconditions(graph, &result)?;
 
     // I-3: Non-negativity (trivially true for u64, documents intent)
     debug_assert!(
@@ -249,21 +249,21 @@ mod tests {
     }
 
     #[test]
-    fn cascade_no_amplification() {
+    fn cascade_invariants_ok() {
         let g = figure4_graph();
         let result = cascade_engine(&g, None).unwrap();
-        assert!(invariants::is_conserved(&result));
+        assert!(invariants::invariants_ok(&g, &result));
     }
 
     #[test]
-    fn is_conserved_false_on_bad_graph() {
+    fn invariants_ok_false_on_bad_graph() {
         let g = figure4_graph();
         let mut result = cascade_engine(&g, None).unwrap();
         // Corrupt: set attributed > raw on first edge
         let edges = result.all_edges();
         let eidx = edges[0].0;
         result.edge_weight_mut(eidx).attributed_delay_ms = 999;
-        assert!(!invariants::is_conserved(&result));
+        assert!(!invariants::invariants_ok(&g, &result));
     }
 
     #[test]

--- a/src/cascade/engine.rs
+++ b/src/cascade/engine.rs
@@ -81,10 +81,11 @@ pub fn cascade_engine(
 /// - `total_propagated`: weight pushed to deeper nodes via outgoing edges
 /// - `self_blame`: time in `window` not covered by any outgoing edge
 ///
-/// Per-entry-edge conservation (I-1, ADR-015): for each entry edge,
-/// `propagated + self_blame <= window.duration()`. Equality holds when
-/// no fan-out or concurrent-waiter scaling is applied; integer division
-/// truncation may cause the sum to be strictly less.
+/// Internal tuple accounting: `propagated + self_blame <= window.duration()`.
+/// Equality holds when no fan-out or concurrent-waiter scaling is applied;
+/// integer division truncation may cause the sum to be strictly less.
+/// Note: I-1 (conservation) was retired by ADR-016. This property is
+/// by-construction (attributed = raw - propagated), not an external invariant.
 fn compute_cascade(
     graph: &WaitForGraph,
     current: ThreadId,

--- a/src/cascade/invariants.rs
+++ b/src/cascade/invariants.rs
@@ -1,7 +1,7 @@
 //! Cascade invariant checks (ADR-007, ADR-016).
 //!
-//! Production sentinel `invariants_ok` (I-2 ∧ I-7) runs in ALL builds
-//! via `verify_engine_postconditions`, which returns `Result`.
+//! The production sentinel check (I-2 ∧ I-7) runs in all builds. It is
+//! implemented by `verify_engine_postconditions` (returns `Result`) and `invariants_ok` (returns `bool`).
 //! I-3, I-4 are debug_assert only. I-5, I-6 are test-only.
 
 use std::fmt;

--- a/src/cascade/invariants.rs
+++ b/src/cascade/invariants.rs
@@ -1,8 +1,8 @@
-//! Cascade invariant checks (ADR-007).
+//! Cascade invariant checks (ADR-007, ADR-016).
 //!
-//! I-1 (per-entry-edge conservation) runs in ALL builds via
-//! `verify_conservation`, which returns `Result`.
-//! I-2..I-7 are debug_assert only.
+//! Production sentinel `invariants_ok` (I-2 ∧ I-7) runs in ALL builds
+//! via `verify_engine_postconditions`, which returns `Result`.
+//! I-3, I-4 are debug_assert only. I-5, I-6 are test-only.
 
 use std::fmt;
 
@@ -10,48 +10,48 @@ use crate::graph::wfg::WaitForGraph;
 
 /// Error returned when cascade invariant checks fail.
 #[derive(Debug)]
-pub struct ConservationError {
+pub struct InvariantError {
     pub i2_ok: bool,
     pub i7_ok: bool,
 }
 
-impl fmt::Display for ConservationError {
+impl fmt::Display for InvariantError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "I-1 VIOLATION: conservation check failed (I-2={}, I-7={})",
+            "INVARIANT VIOLATION: postcondition check failed (I-2={}, I-7={})",
             self.i2_ok, self.i7_ok
         )
     }
 }
 
-impl std::error::Error for ConservationError {}
+impl std::error::Error for InvariantError {}
 
-/// I-1: Per-entry-edge conservation (production sentinel).
+/// Production sentinel: I-2 (non-amplification) ∧ I-7 (locality).
 ///
-/// Checks non-amplification only: no edge's attributed_delay_ms
-/// exceeds its raw_wait_ms. This is the per-entry-edge invariant
-/// defined in ADR-015.
-pub fn is_conserved(result: &WaitForGraph) -> bool {
-    check_non_amplification(result)
+/// Structural postcondition guard per ADR-016. Checks that no edge's
+/// attributed_delay_ms exceeds its raw_wait_ms (I-2) and that graph
+/// topology is preserved (I-7). Catches 0/5 known bugs by construction;
+/// its value is defense-in-depth against future regressions.
+pub fn invariants_ok(original: &WaitForGraph, result: &WaitForGraph) -> bool {
+    check_non_amplification(result) && check_locality(original, result)
 }
 
-/// Internal engine sentinel: verify I-2 + I-7 after cascade.
+/// Engine postcondition check: verify I-2 + I-7 after cascade.
 ///
-/// Stricter than `is_conserved` (which only checks I-1/I-2). This also
-/// verifies I-7 (locality) to catch algorithm bugs that alter topology.
-/// Returns `Err(ConservationError)` on violation — never panics.
-pub fn verify_conservation(
+/// Returns `Err(InvariantError)` on violation — never panics.
+/// Called inside `cascade_engine` before returning.
+pub fn verify_engine_postconditions(
     original: &WaitForGraph,
     result: &WaitForGraph,
-) -> Result<(), ConservationError> {
+) -> Result<(), InvariantError> {
     let i2_ok = check_non_amplification(result);
     let i7_ok = check_locality(original, result);
 
     if i2_ok && i7_ok {
         Ok(())
     } else {
-        Err(ConservationError { i2_ok, i7_ok })
+        Err(InvariantError { i2_ok, i7_ok })
     }
 }
 
@@ -157,18 +157,18 @@ mod tests {
     use crate::graph::types::*;
 
     #[test]
-    fn conservation_passes_on_identity() {
+    fn invariants_ok_passes_on_identity() {
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(1), NodeKind::UserThread);
         g.add_node(ThreadId(2), NodeKind::UserThread);
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
         let result = g.clone_with_reset_attribution();
-        assert!(is_conserved(&result));
+        assert!(invariants_ok(&g, &result));
     }
 
     #[test]
-    fn conservation_passes_on_cascade_result() {
+    fn invariants_ok_passes_on_cascade_result() {
         use crate::cascade::engine::cascade_engine;
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(1), NodeKind::UserThread);
@@ -178,11 +178,11 @@ mod tests {
         g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
 
         let result = cascade_engine(&g, None).unwrap();
-        assert!(is_conserved(&result));
+        assert!(invariants_ok(&g, &result));
     }
 
     #[test]
-    fn conservation_detects_amplification() {
+    fn invariants_ok_detects_amplification() {
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(1), NodeKind::UserThread);
         g.add_node(ThreadId(2), NodeKind::UserThread);
@@ -193,11 +193,11 @@ mod tests {
         let edges = bad.all_edges();
         let eidx = edges[0].0;
         bad.edge_weight_mut(eidx).attributed_delay_ms = 999;
-        assert!(!is_conserved(&bad));
+        assert!(!invariants_ok(&g, &bad));
     }
 
     #[test]
-    fn verify_conservation_detects_locality_violation() {
+    fn verify_postconditions_detects_locality_violation() {
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(1), NodeKind::UserThread);
         g.add_node(ThreadId(2), NodeKind::UserThread);
@@ -207,7 +207,7 @@ mod tests {
         let mut bad = g.clone_with_reset_attribution();
         bad.add_node(ThreadId(3), NodeKind::UserThread);
         bad.add_edge(ThreadId(1), ThreadId(3), TimeWindow::new(0, 30));
-        assert!(verify_conservation(&g, &bad).is_err());
+        assert!(verify_engine_postconditions(&g, &bad).is_err());
     }
 
     #[test]
@@ -317,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_conservation_returns_ok_on_valid() {
+    fn verify_postconditions_returns_ok_on_valid() {
         use crate::cascade::engine::cascade_engine;
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(1), NodeKind::UserThread);
@@ -325,7 +325,7 @@ mod tests {
         g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
 
         let result = cascade_engine(&g, None).unwrap();
-        assert!(verify_conservation(&g, &result).is_ok());
+        assert!(verify_engine_postconditions(&g, &result).is_ok());
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -24,7 +24,7 @@ pub struct EdgeOutput {
 pub struct GraphMetrics {
     pub total_raw_wait_ms: u64,
     pub total_attributed_delay_ms: u64,
-    pub is_conserved: bool,
+    pub invariants_ok: bool,
     pub edge_count: usize,
     pub node_count: usize,
 }
@@ -50,7 +50,7 @@ impl CascadeResult {
             graph_metrics: GraphMetrics {
                 total_raw_wait_ms: total_raw,
                 total_attributed_delay_ms: total_attr,
-                is_conserved: invariants::is_conserved(result),
+                invariants_ok: invariants::invariants_ok(original, result),
                 edge_count: result.edge_count(),
                 node_count: result.node_count(),
             },

--- a/tests/bug_regressions.rs
+++ b/tests/bug_regressions.rs
@@ -4,7 +4,7 @@
 //! and verifies the fix produces correct output.
 
 use wperf::cascade::engine::cascade_engine;
-use wperf::cascade::invariants::is_conserved;
+use wperf::cascade::invariants::invariants_ok;
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
 
@@ -63,7 +63,7 @@ fn bug1_visited_path_scope() {
         "D→E must not be zero (BUG-1: E was skipped via D path)"
     );
 
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }
 
 /// BUG-2: propagated_down return value ignored.
@@ -100,7 +100,7 @@ fn bug2_propagated_down_ignored() {
     );
     assert_eq!(ab.3.attributed_delay_ms, 20);
 
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }
 
 /// BUG-3: multi-edge overlap double-counting.
@@ -143,7 +143,7 @@ fn bug3_multi_edge_overlap() {
     // B is idle during [80,100) → 20ms is B's direct fault
     assert_eq!(ab.3.attributed_delay_ms, 20);
 
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }
 
 /// BUG-4: BUG-2 + BUG-3 combined.
@@ -190,7 +190,7 @@ fn bug4_combined_bug2_bug3() {
         "B→C must propagate weight to E"
     );
 
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }
 
 /// NEW-BUG-1: leaf node zero blame.
@@ -219,5 +219,5 @@ fn new_bug1_leaf_node_zero_blame() {
         "NEW-BUG-1: leaf node must get full attribution"
     );
 
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }

--- a/tests/figure4.rs
+++ b/tests/figure4.rs
@@ -4,7 +4,7 @@
 //! the cascade engine is broken.
 
 use wperf::cascade::engine::cascade_engine;
-use wperf::cascade::invariants::is_conserved;
+use wperf::cascade::invariants::invariants_ok;
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
 use wperf::output::CascadeResult;
@@ -75,7 +75,7 @@ fn figure4_root_edge_conservation() {
 fn figure4_invariants_hold() {
     let g = figure4_graph();
     let result = cascade_engine(&g, None).unwrap();
-    assert!(is_conserved(&result), "I-1 sentinel must pass");
+    assert!(invariants_ok(&g, &result), "invariants_ok sentinel must pass");
 }
 
 #[test]
@@ -84,13 +84,13 @@ fn figure4_json_output() {
     let result = cascade_engine(&g, None).unwrap();
     let output = CascadeResult::from_graph(&g, &result);
 
-    assert!(output.graph_metrics.is_conserved);
+    assert!(output.graph_metrics.invariants_ok);
     assert_eq!(output.graph_metrics.edge_count, 2);
     assert_eq!(output.graph_metrics.node_count, 3);
 
     // Verify JSON roundtrip
     let json = serde_json::to_string(&output).unwrap();
-    assert!(json.contains("\"is_conserved\":true"));
+    assert!(json.contains("\"invariants_ok\":true"));
 }
 
 /// Extended 3-node chain: User→Parser→Network→Disk.
@@ -132,7 +132,7 @@ fn extended_chain_attributed_values() {
     let total = up.3.attributed_delay_ms + pn.3.attributed_delay_ms + nd.3.attributed_delay_ms;
     assert_eq!(total, 100);
 
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }
 
 /// Single edge: leaf node gets full attribution.
@@ -146,7 +146,7 @@ fn single_edge_full_attribution() {
     let result = cascade_engine(&g, None).unwrap();
     let edges = result.all_edges();
     assert_eq!(edges[0].3.attributed_delay_ms, 50);
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }
 
 /// Disconnected components: each edge is independent.
@@ -175,5 +175,5 @@ fn disconnected_edges() {
     // Both are leaf edges — full attribution
     assert_eq!(e1.3.attributed_delay_ms, 50);
     assert_eq!(e2.3.attributed_delay_ms, 80);
-    assert!(is_conserved(&result));
+    assert!(invariants_ok(&g, &result));
 }

--- a/tests/figure4.rs
+++ b/tests/figure4.rs
@@ -75,7 +75,10 @@ fn figure4_root_edge_conservation() {
 fn figure4_invariants_hold() {
     let g = figure4_graph();
     let result = cascade_engine(&g, None).unwrap();
-    assert!(invariants_ok(&g, &result), "invariants_ok sentinel must pass");
+    assert!(
+        invariants_ok(&g, &result),
+        "invariants_ok sentinel must pass"
+    );
 }
 
 #[test]

--- a/tests/fixtures/cascade_oracle.py
+++ b/tests/fixtures/cascade_oracle.py
@@ -12,7 +12,7 @@ the Rust production implementation (src/graph/sweep.rs) is authoritative.
 This script is a validation fixture, not a general-purpose differential
 testing oracle. Phase 0 differential testing (Issue #20) should restrict
 test inputs to non-overlapping topologies when comparing against this
-script, and rely on I-1/I-2 invariant assertions for complex graphs.
+script, and rely on invariant assertions (I-2 through I-7, ADR-016) for complex graphs.
 
 Validates:
 1. SCC/Knot detection using NetworkX

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -1,4 +1,4 @@
-//! Property-based tests: 10K random graphs, all 7 invariants.
+//! Property-based tests: 10K random graphs, invariants I-2 through I-5, I-7 (ADR-016).
 //!
 //! Uses proptest to generate random WFGs biased toward realistic
 //! characteristics: sparse, mostly acyclic, depth 3-8.

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -8,7 +8,7 @@ use proptest::prelude::*;
 use wperf::cascade::engine::cascade_engine;
 use wperf::cascade::invariants::{
     check_idempotency, check_locality, check_non_amplification, check_non_negativity,
-    check_termination, is_conserved,
+    check_termination, invariants_ok,
 };
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
@@ -69,8 +69,8 @@ proptest! {
     fn all_invariants_hold(g in arb_wfg()) {
         let result = cascade_engine(&g, None).unwrap();
 
-        // I-1: Per-entry-edge conservation (non-amplification)
-        prop_assert!(is_conserved(&result), "I-1 (conservation) failed");
+        // Production sentinel: I-2 ∧ I-7 (ADR-016)
+        prop_assert!(invariants_ok(&g, &result), "invariants_ok (I-2 ∧ I-7) failed");
 
         // I-2: Non-amplification
         prop_assert!(check_non_amplification(&result), "I-2 (non-amplification) failed");


### PR DESCRIPTION
## Summary

One-shot breaking rename per ADR-016 migration strategy (pre-1.0, no alias):

- `is_conserved()` → `invariants_ok(original, result)`: now checks **I-2 ∧ I-7** (was I-2 only). Restores I-7 locality check in production sentinel.
- `verify_conservation()` → `verify_engine_postconditions()`
- `ConservationError` → `InvariantError`
- `GraphMetrics.is_conserved` → `GraphMetrics.invariants_ok`
- JSON field: `"is_conserved"` → `"invariants_ok"`
- All test references updated (figure4, bug_regressions, property_tests, engine, invariants)

## Key change

The production sentinel `invariants_ok` now checks **both I-2 and I-7**, not just I-2. This restores the I-7 locality check that was removed in PR #66 when `is_conserved` was narrowed to I-2 only.

## Test plan

- [x] `cargo test` — all 89 tests pass (68 lib + 7 figure4 + 5 bug_regressions + 6 differential + 3 property)
- [x] Zero remaining references to `is_conserved`, `verify_conservation`, or `ConservationError` in src/ or tests/
- [ ] Team review

Signed-off-by: Adrian Mason <258563901+adrian-mason@users.noreply.github.com>