### PR TITLE
test: mutation kill rate ≥90% (Phase 0 gate 3/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,38 @@ jobs:
 
       - name: differential (Rust vs Python)
         run: cargo test --test differential
+
+  mutants:
+    name: Mutation Testing (≥90% kill rate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+
+      - name: Run cargo-mutants
+        run: cargo mutants --timeout=300 -j 2
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-report
+          path: mutants.out/
+
+      - name: Verify ≥90% kill rate
+        run: |
+          caught=$(wc -l < mutants.out/caught.txt)
+          missed=$(wc -l < mutants.out/missed.txt)
+          total=$((caught + missed))
+          rate=$(( (caught * 100) / total ))
+          echo "Kill rate: ${caught}/${total} = ${rate}%"
+          if [ "$rate" -lt 90 ]; then
+            echo "FAIL: kill rate ${rate}% < 90% threshold"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         run: cargo install cargo-mutants --locked
 
       - name: Run cargo-mutants
+        continue-on-error: true
         run: cargo mutants --timeout=300 -j 2
 
       - name: Upload mutation report

--- a/src/critical_path/mod.rs
+++ b/src/critical_path/mod.rs
@@ -180,6 +180,44 @@ mod tests {
     }
 
     #[test]
+    fn dp_arithmetic_uses_addition() {
+        // Construct a condensation DAG directly to test DP arithmetic
+        // without pipeline interference from heuristic weights.
+        use crate::scc::tarjan::{CondensationDag, SuperNode};
+        use petgraph::graph::DiGraph;
+
+        let mut dag: DiGraph<SuperNode, u64> = DiGraph::new();
+        let a = dag.add_node(SuperNode {
+            scc_index: 0,
+            members: vec![ThreadId(1)],
+            weight: 5,
+        });
+        let b = dag.add_node(SuperNode {
+            scc_index: 1,
+            members: vec![ThreadId(2)],
+            weight: 3,
+        });
+        let c = dag.add_node(SuperNode {
+            scc_index: 2,
+            members: vec![ThreadId(3)],
+            weight: 7,
+        });
+        dag.add_edge(a, b, 10);
+        dag.add_edge(b, c, 20);
+
+        let mut node_map = std::collections::BTreeMap::new();
+        node_map.insert(ThreadId(1), a);
+        node_map.insert(ThreadId(2), b);
+        node_map.insert(ThreadId(3), c);
+
+        let cdag = CondensationDag { dag, node_map };
+        let cp = critical_path_dp(&cdag).unwrap();
+        // dist[a]=5, dist[b]=5+10+3=18, dist[c]=18+20+7=45
+        assert_eq!(cp.total_weight, 45, "DP must use addition");
+        assert_eq!(cp.chain.len(), 3);
+    }
+
+    #[test]
     fn empty_dag() {
         let cdag = build_condensation(&WaitForGraph::new());
         assert!(critical_path_dp(&cdag).is_none());

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -147,6 +147,8 @@ mod tests {
     fn thread_id_display() {
         assert_eq!(format!("{}", ThreadId(-4)), "NIC");
         assert_eq!(format!("{}", ThreadId(-5)), "Disk");
+        assert_eq!(format!("{}", ThreadId(-15)), "HardIRQ");
+        assert_eq!(format!("{}", ThreadId(-16)), "SoftIRQ");
         assert_eq!(format!("{}", ThreadId(1234)), "T1234");
     }
 }

--- a/src/graph/wfg.rs
+++ b/src/graph/wfg.rs
@@ -213,4 +213,27 @@ mod tests {
         assert_eq!(a, b);
         assert_eq!(g.node_count(), 1);
     }
+
+    #[test]
+    fn is_acyclic_linear() {
+        let g = simple_graph();
+        assert!(g.is_acyclic());
+    }
+
+    #[test]
+    fn is_acyclic_cycle() {
+        let mut g = WaitForGraph::new();
+        g.add_node(ThreadId(1), NodeKind::UserThread);
+        g.add_node(ThreadId(2), NodeKind::UserThread);
+        g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 50));
+        g.add_edge(ThreadId(2), ThreadId(1), TimeWindow::new(0, 50));
+        assert!(!g.is_acyclic());
+    }
+
+    #[test]
+    fn total_attributed_matches_raw_before_cascade() {
+        let g = simple_graph();
+        // Before cascade, attributed == raw
+        assert_eq!(g.total_attributed(), 100);
+    }
 }

--- a/src/graph/wfg.rs
+++ b/src/graph/wfg.rs
@@ -234,6 +234,7 @@ mod tests {
     fn total_attributed_matches_raw_before_cascade() {
         let g = simple_graph();
         // Before cascade, attributed == raw
+        assert_eq!(g.total_attributed(), g.total_raw_wait());
         assert_eq!(g.total_attributed(), 100);
     }
 }

--- a/src/scc/tarjan.rs
+++ b/src/scc/tarjan.rs
@@ -298,4 +298,23 @@ mod tests {
         // T1→T2 and T2→T1 are internal
         assert_eq!(int_edges.len(), 2);
     }
+
+    #[test]
+    fn all_super_nodes_covers_all_threads() {
+        let mut g = WaitForGraph::new();
+        g.add_node(ThreadId(1), NodeKind::UserThread);
+        g.add_node(ThreadId(2), NodeKind::UserThread);
+        g.add_node(ThreadId(3), NodeKind::UserThread);
+        g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
+        g.add_edge(ThreadId(2), ThreadId(3), TimeWindow::new(20, 100));
+
+        let cdag = build_condensation(&g);
+        let all = cdag.all_super_nodes();
+        assert_eq!(all.len(), 3);
+        // Every thread appears in exactly one super-node
+        let all_members: Vec<_> = all.iter().flat_map(|(_, sn)| &sn.members).collect();
+        assert!(all_members.contains(&&ThreadId(1)));
+        assert!(all_members.contains(&&ThreadId(2)));
+        assert!(all_members.contains(&&ThreadId(3)));
+    }
 }

--- a/src/scc/tarjan.rs
+++ b/src/scc/tarjan.rs
@@ -32,7 +32,7 @@ pub struct SuperNode {
 /// Edges carry the max attributed_delay among parallel cross-SCC edges.
 pub struct CondensationDag {
     pub dag: DiGraph<SuperNode, u64>,
-    node_map: BTreeMap<ThreadId, NodeIndex>,
+    pub(crate) node_map: BTreeMap<ThreadId, NodeIndex>,
 }
 
 impl CondensationDag {
@@ -297,6 +297,17 @@ mod tests {
         let int_edges = internal_edges(&g, cycle);
         // T1→T2 and T2→T1 are internal
         assert_eq!(int_edges.len(), 2);
+    }
+
+    #[test]
+    fn scc_of_missing_thread_returns_none() {
+        let mut g = WaitForGraph::new();
+        g.add_node(ThreadId(1), NodeKind::UserThread);
+        g.add_node(ThreadId(2), NodeKind::UserThread);
+        g.add_edge(ThreadId(1), ThreadId(2), TimeWindow::new(0, 100));
+
+        let cdag = build_condensation(&g);
+        assert_eq!(cdag.scc_of(&ThreadId(999)), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds targeted unit tests to raise `cargo-mutants` kill rate from **89.9%** (124/138) to **95.7%** (132/138)
- Adds `cargo-mutants` CI job with ≥90% gate threshold and artifact upload for auditable evidence
- Clears the Phase 0 gate threshold of ≥90% mutation kill rate

### Tests added
- HARDIRQ/SOFTIRQ ThreadId display constants
- `WaitForGraph::is_acyclic` (true/false paths)
- `total_attributed` pre-cascade identity
- `CondensationDag::all_super_nodes` coverage
- `CondensationDag::scc_of` negative lookup (returns `None`)
- `critical_path_dp` DP arithmetic on handcrafted DAG

## Mutation Results
| Metric | Before | After |
|--------|--------|-------|
| Caught | 124 | 132 |
| Missed | 14 | 6 |
| Unviable | 18 | 18 |
| **Kill rate** | **89.9%** | **95.7%** |

Remaining 6 misses: `main()` (untestable), `> → >=` (equivalent mutant — tie-breaking), `depth+1 → depth*1` (equivalent on acyclic graphs), Display impl (cosmetic), `check_idempotency → true` / `check_depth_monotonicity → true` (always true on valid inputs).

## Test plan
- [x] `cargo test` — all 74 unit + 10 integration + 3 property tests pass
- [x] `cargo mutants` — 132/138 = 95.7% kill rate
- [x] `cargo fmt --check` — clean
- [x] CI job added: `Mutation Testing (≥90% kill rate)` with artifact upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)