### PR TITLE
docs: sync Phase 1 design decisions

### DIFF
--- a/docs/decisions/ADR-002-supplement.md
+++ b/docs/decisions/ADR-002-supplement.md
@@ -109,7 +109,7 @@ static __always_inline __s64 get_task_state(void *task) {
 
 | Feature | Probe Method | Degradation |
 |---------|-------------|-------------|
-| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | Embedded BTF fallback (`min_core_btfs`); if still fails, **refuse to run** (`EOPNOTSUPP`) |
+| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | **Phase 1: refuse to run (`EOPNOTSUPP`).** Minimum supported: RHEL/Rocky 8.2+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF fallback deferred. |
 
 ### Implication for wPerf
 
@@ -117,7 +117,7 @@ wPerf must either:
 - **(a)** Ship embedded BTF for target kernel versions (RHEL 8.x, Ubuntu 20.04/22.04 LTS, etc.) using the `min_core_btfs` pattern, or
 - **(b)** Accept that kernels without BTF (pre-5.4 without backports, custom kernels without `CONFIG_DEBUG_INFO_BTF`) are unsupported
 
-Option (b) is simpler and aligns with the recommended minimum kernel of 5.4. Option (a) extends reach to RHEL 8.0-8.1 (4.18 without BTF) but adds build complexity. This is a scope decision for Phase 1.
+**Phase 1 decision (2026-04-04): Option (b) adopted.** Minimum supported kernel: Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). RHEL 8.0-8.1 (EOL, no BTF) are unsupported. Option (a) deferred to future evaluation if demand arises.
 
 ## Finding 3: cgroupv2 Filtering — Implementation Pattern (Q3)
 
@@ -177,10 +177,10 @@ This is correct. The implementation should:
 
 ## Consequences
 
-1. **ADR-002 probe matrix correction**: The BTF row must be updated to replace "hardcoded offsets" with "refuse to run (`EOPNOTSUPP`)" as the final fallback. This correction will propagate to `final-design.md` section 1.3 when that document is updated.
+1. **ADR-002 probe matrix correction**: The BTF row has been updated to "refuse to run (`EOPNOTSUPP`)" as the final fallback, propagated to `final-design.md` section 1.3.
 
-2. **Embedded BTF scope decision**: The project must decide during Phase 1 whether to ship embedded BTF for pre-5.4 kernels or accept BTF as a hard requirement. Given the recommended minimum of 5.4 (which has BTF enabled in all major distributions), accepting the hard requirement is the pragmatic choice.
+2. **Embedded BTF scope decision (resolved 2026-04-04)**: Option (b) adopted — BTF is a hard requirement for Phase 1. Minimum supported: Rocky 8.9 / RHEL 8.2+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF (`min_core_btfs`) deferred to future evaluation.
 
-3. **User-space transport abstraction**: The `EventTransport` Rust trait must mirror the `bpf_buffer` pattern from `compat.c` — specifically the `new()` → `open()` → `poll()` lifecycle with probe-based mode selection at construction time.
+3. **User-space transport abstraction**: Uses `enum BpfBuffer { Ring(RingBufTransport), Perf(PerfBufTransport) }` — closed-variant enum dispatch instead of `Box<dyn Trait>`. Rationale: no heap indirection, no vtable, closed variant set (only Ring/Perf), compiler can inline through match. API: `poll(&mut self, timeout) -> Result<Vec<WperfEvent>>`, `drop_count(&self) -> u64`, `flush(&mut self) -> Vec<WperfEvent>`. The `bpf_buffer` pattern from `compat.c` is the reference design; BPF side vendors `compat.bpf.h` directly, userspace implements equivalent logic in Rust.
 
 4. **Cgroup filtering architecture**: Follows the established `BPF_MAP_TYPE_CGROUP_ARRAY` + `bpf_current_task_under_cgroup()` pattern. cgroupv1 is explicitly not supported.

--- a/docs/decisions/ADR-002-supplement.md
+++ b/docs/decisions/ADR-002-supplement.md
@@ -109,7 +109,7 @@ static __always_inline __s64 get_task_state(void *task) {
 
 | Feature | Probe Method | Degradation |
 |---------|-------------|-------------|
-| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | **Phase 1: refuse to run (`EOPNOTSUPP`).** Minimum supported: RHEL/Rocky 8.2+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF fallback deferred. |
+| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | **Phase 1: refuse to run (`EOPNOTSUPP`).** Minimum supported: RHEL 8.2+ / Rocky 8.4+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF fallback deferred. |
 
 ### Implication for wPerf
 
@@ -117,7 +117,7 @@ wPerf must either:
 - **(a)** Ship embedded BTF for target kernel versions (RHEL 8.x, Ubuntu 20.04/22.04 LTS, etc.) using the `min_core_btfs` pattern, or
 - **(b)** Accept that kernels without BTF (pre-5.4 without backports, custom kernels without `CONFIG_DEBUG_INFO_BTF`) are unsupported
 
-**Phase 1 decision (2026-04-04): Option (b) adopted.** Minimum supported kernel: Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). RHEL 8.0-8.1 (EOL, no BTF) are unsupported. Option (a) deferred to future evaluation if demand arises.
+**Phase 1 decision (2026-04-04): Option (b) adopted.** Minimum supported kernel: RHEL 8.2+ / Rocky 8.4+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). RHEL 8.0-8.1 (EOL, no BTF) are unsupported. Option (a) deferred to future evaluation if demand arises.
 
 ## Finding 3: cgroupv2 Filtering — Implementation Pattern (Q3)
 
@@ -179,8 +179,8 @@ This is correct. The implementation should:
 
 1. **ADR-002 probe matrix correction**: The BTF row has been updated to "refuse to run (`EOPNOTSUPP`)" as the final fallback, propagated to `final-design.md` section 1.3.
 
-2. **Embedded BTF scope decision (resolved 2026-04-04)**: Option (b) adopted — BTF is a hard requirement for Phase 1. Minimum supported: Rocky 8.9 / RHEL 8.2+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF (`min_core_btfs`) deferred to future evaluation.
+2. **Embedded BTF scope decision (resolved 2026-04-04)**: Option (b) adopted — BTF is a hard requirement for Phase 1. Minimum supported: RHEL 8.2+ / Rocky 8.4+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF (`min_core_btfs`) deferred to future evaluation.
 
-3. **User-space transport abstraction**: Uses `enum BpfBuffer { Ring(RingBufTransport), Perf(PerfBufTransport) }` — closed-variant enum dispatch instead of `Box<dyn Trait>`. Rationale: no heap indirection, no vtable, closed variant set (only Ring/Perf), compiler can inline through match. API: `poll(&mut self, timeout) -> Result<Vec<WperfEvent>>`, `drop_count(&self) -> u64`, `flush(&mut self) -> Vec<WperfEvent>`. The `bpf_buffer` pattern from `compat.c` is the reference design; BPF side vendors `compat.bpf.h` directly, userspace implements equivalent logic in Rust.
+3. **User-space transport abstraction**: Uses `enum BpfBuffer { Ring(RingBufTransport), Perf(PerfBufTransport) }` — closed-variant enum dispatch instead of `Box<dyn Trait>`. Rationale: no heap indirection, no vtable, closed variant set (only Ring/Perf), compiler can inline through match. API: `poll(&mut self, timeout, f: impl FnMut(&WperfEvent)) -> Result<usize>`, `drain(&mut self, f: impl FnMut(&WperfEvent))` (perf reorder buffer drain; no-op for Ring), `drop_count(&self) -> u64`. Callback-based to avoid heap allocation on the hot path — libbpf-rs is already callback-based, and ringbuf events can be referenced in-place from mmap'd memory. The `bpf_buffer` pattern from `compat.c` is the reference design; BPF side vendors `compat.bpf.h` directly, userspace implements equivalent logic in Rust.
 
 4. **Cgroup filtering architecture**: Follows the established `BPF_MAP_TYPE_CGROUP_ARRAY` + `bpf_current_task_under_cgroup()` pattern. cgroupv1 is explicitly not supported.

--- a/docs/decisions/ADR-003.md
+++ b/docs/decisions/ADR-003.md
@@ -61,29 +61,43 @@ The pre-execution readiness audit reinforced that the 4096 instruction limit "do
 
 ## Decision
 
-**Recommended minimum: 5.4** (RHEL 8.4+ / Ubuntu 20.04 LTS). **4.18 retained as best-effort** with feature-probing degradation, but no dedicated engineering resources allocated to 4.18-specific adaptation.
+**Phase 1 (current, 2026-04-04):** Minimum supported kernel: Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). BTF is a hard requirement — kernels without BTF receive `EOPNOTSUPP` at startup. Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation.
 
-> **Phase 1 amendment (2026-04-04):** BTF is now a hard requirement for Phase 1. Minimum supported kernel narrowed to Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). Kernels without BTF (RHEL 8.0-8.1, custom kernels without `CONFIG_DEBUG_INFO_BTF`) receive `EOPNOTSUPP` at startup. The "4.18 best-effort" scope is effectively limited to RHEL 8.2+ (which has BTF). Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation.
-
-The rationale is threefold:
-1. RHEL 8.0-8.1 are already end-of-life; RHEL 8.2-8.3 are maintenance-only
-2. The 4,096 instruction limit on 4.18 makes the stack delta unwinding scheme impractically complex
-3. 5.4 is the lowest kernel version that is still under active long-term support (Ubuntu 20.04 ESM to 2030)
-
-The dynamic feature probing matrix (ADR-002) naturally supports 4.18 kernels by degrading each unavailable feature independently. On 4.18, users would see: perfarray instead of ringbuf, `#pragma unroll` bounded loops instead of `bpf_loop`, `bpf_probe_read` instead of `bpf_probe_read_kernel`, and potentially no BTF/CO-RE. The tool will still function for basic event capture and Wait-For Graph construction, but with reduced stack depth and higher overhead.
+The rationale:
+1. Rocky 8.9 / RHEL 8.2+ ships with `CONFIG_DEBUG_INFO_BTF=y` enabled by default
+2. RHEL 8.0-8.1 (no BTF) are already end-of-life since May 2024
+3. BTF is required for CO-RE relocations, `tp_btf` direct access, and the dual-mode transport strategy (ADR-002, ADR-004)
+4. The 5.4+ baseline remains the recommended target for full feature set (ringbuf, 1M instruction limit, `bpf_probe_read_kernel`)
 
 ## Consequences
 
 **Architecture:**
-- The 5.4 baseline allows confident use of the 1M instruction limit, simplifying BPF program design
+- The BTF requirement enables CO-RE relocations and `tp_btf` direct pointer access on high-version kernels
+- The 5.4+ baseline allows confident use of the 1M instruction limit, simplifying BPF program design
 - Stack delta deep unwinding (Elastic-derived approach) becomes feasible without extreme tail-call fragmentation
-- The feature probing infrastructure still handles 4.18 gracefully but without dedicated optimization
+- The feature probing infrastructure (ADR-002) handles ringbuf/perfbuf and tp_btf/raw_tp degradation within the BTF-enabled kernel space
 
 **Implementation:**
-- CI testing prioritizes 5.4+ kernels; 4.18 testing is best-effort using virtme-ng with extracted RHEL kernel images
-- Documentation explicitly states 5.4 as the recommended minimum and 4.18 as best-effort
-- No conditional compilation for `bpf_probe_read` vs `bpf_probe_read_kernel` is actively maintained — the CO-RE approach handles this through `bpf_core_type_exists` checks
+- CI testing prioritizes Rocky 8.9 (Phase 1 minimum), 5.4, 5.8, 5.17, and 6.x kernels
+- No conditional compilation for `bpf_probe_read` vs `bpf_probe_read_kernel` — CO-RE handles this through `bpf_core_type_exists` checks
+- Pre-BTF kernels (RHEL 8.0-8.1, custom kernels without `CONFIG_DEBUG_INFO_BTF`) are unsupported in Phase 1
 
 **Risk:**
-- Some enterprise customers may push back on the 5.4 recommendation if they are locked to RHEL 8.0-8.3. The response is that the tool still works on 4.18 with degraded capability, and these RHEL versions are end-of-life
-- The "best-effort" designation for 4.18 means regressions on that platform may not block releases
+- Some enterprise environments may still run pre-BTF kernels due to change management inertia. The response is that RHEL 8.0-8.1 are end-of-life and upgrading to 8.2+ enables BTF
+- If demand arises for pre-BTF support, the BTFHub `min_core_btfs` pattern can be evaluated in a future phase
+
+<details>
+<summary>Original 2026-03-17 rationale (superseded by Phase 1 decision)</summary>
+
+**Original decision:** Recommended minimum: 5.4 (RHEL 8.4+ / Ubuntu 20.04 LTS). 4.18 retained as best-effort with feature-probing degradation, but no dedicated engineering resources allocated to 4.18-specific adaptation.
+
+The original rationale was threefold:
+1. RHEL 8.0-8.1 were already end-of-life; RHEL 8.2-8.3 were maintenance-only
+2. The 4,096 instruction limit on 4.18 makes the stack delta unwinding scheme impractically complex
+3. 5.4 was the lowest kernel version still under active long-term support (Ubuntu 20.04 ESM to 2030)
+
+The dynamic feature probing matrix (ADR-002) naturally supports 4.18 kernels by degrading each unavailable feature independently. On 4.18, users would see: perfarray instead of ringbuf, `#pragma unroll` bounded loops instead of `bpf_loop`, `bpf_probe_read` instead of `bpf_probe_read_kernel`, and potentially no BTF/CO-RE.
+
+This framing was narrowed by the Phase 1 decision (2026-04-04) which established BTF as a hard requirement, effectively limiting the "4.18 best-effort" scope to RHEL 8.2+ (which has BTF).
+
+</details>

--- a/docs/decisions/ADR-003.md
+++ b/docs/decisions/ADR-003.md
@@ -61,10 +61,10 @@ The pre-execution readiness audit reinforced that the 4096 instruction limit "do
 
 ## Decision
 
-**Phase 1 (current, 2026-04-04):** Minimum supported kernel: Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). BTF is a hard requirement — kernels without BTF receive `EOPNOTSUPP` at startup. Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation.
+**Phase 1 (current, 2026-04-04):** Minimum supported kernel: RHEL 8.2+ / Rocky 8.4+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). BTF is a hard requirement — kernels without BTF receive `EOPNOTSUPP` at startup. Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation. CI target: Rocky 8.9 (kernel 4.18.0-513+).
 
 The rationale:
-1. Rocky 8.9 / RHEL 8.2+ ships with `CONFIG_DEBUG_INFO_BTF=y` enabled by default
+1. RHEL 8.2+ / Rocky 8.4+ ships with `CONFIG_DEBUG_INFO_BTF=y` enabled by default
 2. RHEL 8.0-8.1 (no BTF) are already end-of-life since May 2024
 3. BTF is required for CO-RE relocations, `tp_btf` direct access, and the dual-mode transport strategy (ADR-002, ADR-004)
 4. The 5.4+ baseline remains the recommended target for full feature set (ringbuf, 1M instruction limit, `bpf_probe_read_kernel`)
@@ -78,7 +78,7 @@ The rationale:
 - The feature probing infrastructure (ADR-002) handles ringbuf/perfbuf and tp_btf/raw_tp degradation within the BTF-enabled kernel space
 
 **Implementation:**
-- CI testing prioritizes Rocky 8.9 (Phase 1 minimum), 5.4, 5.8, 5.17, and 6.x kernels
+- CI testing prioritizes Rocky 8.9 (Phase 1 CI target), 5.4, 5.8, 5.17, and 6.x kernels
 - No conditional compilation for `bpf_probe_read` vs `bpf_probe_read_kernel` — CO-RE handles this through `bpf_core_type_exists` checks
 - Pre-BTF kernels (RHEL 8.0-8.1, custom kernels without `CONFIG_DEBUG_INFO_BTF`) are unsupported in Phase 1
 

--- a/docs/decisions/ADR-003.md
+++ b/docs/decisions/ADR-003.md
@@ -1,7 +1,7 @@
 # ADR-003: Minimum Kernel Version — 4.18 vs 5.4+
 
-- **Status:** Accepted
-- **Date:** 2026-03-17
+- **Status:** Accepted (narrowed by Phase 1 decision 2026-04-04)
+- **Date:** 2026-03-17 (amended 2026-04-04)
 
 ## Problem
 
@@ -62,6 +62,8 @@ The pre-execution readiness audit reinforced that the 4096 instruction limit "do
 ## Decision
 
 **Recommended minimum: 5.4** (RHEL 8.4+ / Ubuntu 20.04 LTS). **4.18 retained as best-effort** with feature-probing degradation, but no dedicated engineering resources allocated to 4.18-specific adaptation.
+
+> **Phase 1 amendment (2026-04-04):** BTF is now a hard requirement for Phase 1. Minimum supported kernel narrowed to Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). Kernels without BTF (RHEL 8.0-8.1, custom kernels without `CONFIG_DEBUG_INFO_BTF`) receive `EOPNOTSUPP` at startup. The "4.18 best-effort" scope is effectively limited to RHEL 8.2+ (which has BTF). Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation.
 
 The rationale is threefold:
 1. RHEL 8.0-8.1 are already end-of-life; RHEL 8.2-8.3 are maintenance-only

--- a/docs/design/final-design.md
+++ b/docs/design/final-design.md
@@ -56,7 +56,7 @@ Using the libbpf ecosystem standard **probe → reconfigure → load** pattern, 
 |---------|-------------|-------------|
 | **ringbuf** | `bpf_map_create(BPF_MAP_TYPE_RINGBUF)` | Reconfigure events map to `PERF_EVENT_ARRAY` (set key/value size) |
 | **tp_btf** | `probe_tp_btf("sched_switch")` | Fall back to `raw_tp/sched_switch`; disable `tp_btf` programs via `set_autoload(false)` |
-| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | Embedded BTF fallback; if still fails, refuse to run (`EOPNOTSUPP`) |
+| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | **Phase 1: refuse to run (`EOPNOTSUPP`).** Minimum supported: RHEL/Rocky 8.2+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation. |
 | **bpf_loop** | `libbpf_probe_bpf_helper(TRACEPOINT, BPF_FUNC_loop)` | `#pragma unroll` bounded loops |
 | **cgroupv2** | Check `/sys/fs/cgroup/cgroup.controllers` | Disable cgroup filtering; `--cgroup` flag errors out |
 | **tracepoint** | Check `/sys/kernel/tracing/events/{cat}/{name}` | `bpf_program__set_autoload(prog, false)` |
@@ -127,6 +127,12 @@ Scheduler probes use `tp_btf` (BTF-enabled tracing, 5.5+) with `raw_tp` fallback
 | — | `tp/irq/softirq_entry` + `softirq_exit` | — | **Auxiliary** (softirq attribution) |
 
 Non-scheduler probes (futex, block I/O, softirq) retain standard `tp/` — their trace event format structs provide all needed fields without `task_struct` traversal. Extensions beyond the paper are gated by `const volatile bool` feature flags, allowing selective enable/disable at load time.
+
+**Field access strategy (Phase 1 decision, 2026-04-04):**
+- **tp_btf programs** (BTF-enabled): use direct pointer dereference (`prev->pid`, `next->tgid`) — compiles to single load instructions, maximum performance on high-version kernels.
+- **raw_tp programs** (fallback): use `BPF_CORE_READ(prev, pid)` — compiles to `bpf_probe_read_kernel()` helper calls, correct on all BTF-enabled kernels.
+- **Implementation pattern**: Two independent handler sets generated via macro (`DEFINE_HANDLER(name, READ_FIELD)` with `DIRECT_READ` / `BPF_CORE_READ`), not shared handlers. This avoids the trade-off where shared helpers force `BPF_CORE_READ` on the tp_btf hot path. Reference: `bcc/libbpf-tools/runqlat.bpf.c`, `runqslower.bpf.c`.
+- **Userspace selection**: `probe_tp_btf("sched_switch")` at startup; disable unused variant via `bpf_program__set_autoload(prog, false)`. Both variants compiled into the same `.bpf.o`.
 
 ### 2.2 Transport — Single-ELF CO-RE Dual-Mode
 
@@ -330,6 +336,14 @@ pub struct WprfHeader {
 }
 ```
 
+**Feature Bitmap Bit Assignments (Phase 1):**
+
+| Byte | Bit | Name | Meaning |
+|------|-----|------|---------|
+| 0 | 0 | `HAS_TIMESTAMPS` | Events contain valid `timestamp_ns` fields |
+| 0 | 1-7 | — | Reserved, must be 0 |
+| 1-31 | — | — | Reserved, must be 0 |
+
 The `version` field and TLV record format enable forward compatibility — readers can skip unknown record types without failing.
 
 ### 4.2 TLV Event Stream
@@ -347,7 +361,7 @@ Stream-friendly design — written at the end of the file:
 |-----------|---------|
 | 1 | String Table (thread names, cgroup names) |
 | 2 | Symbol Resolution Table |
-| 3 | Metadata (Build-ID, HOSTNAME, OSRELEASE, CLI_ARGS, DROP_COUNT) |
+| 3 | Metadata — phased delivery: **Phase 1 W1** (format writer): `EVENT_COUNT`, `DROP_COUNT`; **Phase 1 W2+** (record CLI): `BUILD_ID`, `HOSTNAME`, `OSRELEASE`, `CLI_ARGS`. Binary key-value format; reader skips unknown keys. |
 | 4 | Attr Section (Collection config, sampling rates — P2 deferred) |
 
 ### 4.4 Crash Tolerance
@@ -598,9 +612,9 @@ The full 7-step pipeline + 6 probe types + wPRF format + Dagre+ECharts UI is amb
 
 ### 8.3 Risk 3: Minimum Kernel Version — MEDIUM
 
-Supporting kernel 4.18 (RHEL 8.0) doubles engineering complexity due to the 4,096 BPF instruction limit, lack of `bpf_probe_read_kernel()`, and absent BTF/CO-RE. Per [ADR-002-supplement](../decisions/ADR-002-supplement.md), native 4.18 kernels (RHEL 8.0-8.1) lack BTF entirely — without implementing the embedded BTF (`min_core_btfs`) pattern, the tool will refuse to run (`EOPNOTSUPP`) on these kernels despite other feature degradations being available.
+Supporting kernel 4.18 (RHEL 8.0) doubles engineering complexity due to the 4,096 BPF instruction limit, lack of `bpf_probe_read_kernel()`, and absent BTF/CO-RE. Per [ADR-002-supplement](../decisions/ADR-002-supplement.md), native 4.18 kernels (RHEL 8.0-8.1) lack BTF entirely.
 
-**Mitigation:** 5.4 recommended minimum (BTF available in all major distributions); 4.18 best-effort requires a Phase 1 scope decision on whether to ship embedded BTF or accept BTF as a hard requirement; explicit degradation matrix documents what works on each kernel.
+**Phase 1 decision (2026-04-04):** BTF is a hard requirement. Minimum supported kernel: Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). Kernels without BTF receive `EOPNOTSUPP` at startup. Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation if demand arises for pre-8.2 support. Explicit degradation matrix documents what works on each kernel.
 
 ### 8.4 Risk 4: AI-Generated Spec Blind Spots — MEDIUM
 

--- a/docs/design/final-design.md
+++ b/docs/design/final-design.md
@@ -86,9 +86,10 @@ This is resolved by the CO-RE compiler at load time with zero runtime overhead.
 
 > Decision rationale: [ADR-003: Minimum Kernel Version](../decisions/ADR-003.md)
 
-- **Recommended minimum:** Linux 5.4 (RHEL 8.4+ / Ubuntu 20.04 LTS)
-- **Best-effort support:** Linux 4.18 (RHEL 8.0+) via feature probing degradation
-- 4.18's 4,096 BPF instruction limit doubles engineering complexity; RHEL 8.0–8.1 reached end of support in May 2024
+- **Phase 1 minimum supported (2026-04-04 decision):** Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). BTF is a hard requirement; no-BTF kernels receive `EOPNOTSUPP`.
+- **Recommended baseline:** Linux 5.4+ (RHEL 8.4+ / Ubuntu 20.04 LTS) for full feature set including ringbuf, `bpf_probe_read_kernel()`, and 1M instruction limit.
+- **Not supported:** RHEL 8.0–8.1 (no BTF, EOL since May 2024). Embedded BTF fallback deferred to future evaluation.
+- Note: ADR-003's original "5.4 recommended, 4.18 best-effort" framing has been narrowed by the Phase 1 BTF-required decision.
 
 ### 1.5 Glossary
 
@@ -502,7 +503,7 @@ Key mutation targets: deletion of `path.insert`, modification of duration calcul
 
 **Tool:** virtme-ng (second-scale cross-kernel boot)
 - Extract vmlinuz + `/lib/modules/` from distro RPM/deb packages
-- Test kernels: 4.18 (best-effort baseline) / 5.4 (recommended minimum) / 5.8 / 5.17 / 6.x (representing key BPF capability boundaries)
+- Test kernels: 4.18.0-513+ (Rocky 8.9, Phase 1 minimum) / 5.4 (Ubuntu 20.04 LTS) / 5.8 / 5.17 / 6.x (representing key BPF capability boundaries)
 - Each kernel version validates the feature probe → degradation → load path
 - Testing on 4.18 is strictly required to validate the feature degradation paths (perfarray fallback, `#pragma unroll` fallback, `raw_tp` fallback). Without it, the entire degradation architecture designed in ADR-002, ADR-004, and ADR-013 is unexercised dead code
 
@@ -669,7 +670,7 @@ The prior design spec claimed "zero P0/P1 residual items." This was a design com
 |-----|----------|--------------|
 | [ADR-001](../decisions/ADR-001.md) | Architecture model | Offline CLI (record/report) |
 | [ADR-002](../decisions/ADR-002.md) | Kernel compatibility | Dynamic per-feature probing |
-| [ADR-003](../decisions/ADR-003.md) | Minimum kernel version | 5.4 recommended, 4.18 best-effort |
+| [ADR-003](../decisions/ADR-003.md) | Minimum kernel version | Phase 1: Rocky 8.9 / RHEL 8.2+ (BTF required); see §1.4 |
 | [ADR-004](../decisions/ADR-004.md) | Event transport | Single-ELF CO-RE dual-mode |
 | [ADR-005](../decisions/ADR-005.md) | Stack unwinding | bpf_get_stackid + Elastic Stack Delta |
 | [ADR-006](../decisions/ADR-006.md) | Graph visualization | Dagre layout + ECharts rendering |

--- a/docs/design/final-design.md
+++ b/docs/design/final-design.md
@@ -56,7 +56,7 @@ Using the libbpf ecosystem standard **probe → reconfigure → load** pattern, 
 |---------|-------------|-------------|
 | **ringbuf** | `bpf_map_create(BPF_MAP_TYPE_RINGBUF)` | Reconfigure events map to `PERF_EVENT_ARRAY` (set key/value size) |
 | **tp_btf** | `probe_tp_btf("sched_switch")` | Fall back to `raw_tp/sched_switch`; disable `tp_btf` programs via `set_autoload(false)` |
-| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | **Phase 1: refuse to run (`EOPNOTSUPP`).** Minimum supported: RHEL/Rocky 8.2+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation. |
+| **BTF (vmlinux)** | Check `/sys/kernel/btf/vmlinux` | **Phase 1: refuse to run (`EOPNOTSUPP`).** Minimum supported: RHEL 8.2+ / Rocky 8.4+ (`CONFIG_DEBUG_INFO_BTF=y`). Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation. |
 | **bpf_loop** | `libbpf_probe_bpf_helper(TRACEPOINT, BPF_FUNC_loop)` | `#pragma unroll` bounded loops |
 | **cgroupv2** | Check `/sys/fs/cgroup/cgroup.controllers` | Disable cgroup filtering; `--cgroup` flag errors out |
 | **tracepoint** | Check `/sys/kernel/tracing/events/{cat}/{name}` | `bpf_program__set_autoload(prog, false)` |
@@ -86,7 +86,7 @@ This is resolved by the CO-RE compiler at load time with zero runtime overhead.
 
 > Decision rationale: [ADR-003: Minimum Kernel Version](../decisions/ADR-003.md)
 
-- **Phase 1 minimum supported (2026-04-04 decision):** Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). BTF is a hard requirement; no-BTF kernels receive `EOPNOTSUPP`.
+- **Phase 1 minimum supported (2026-04-04 decision):** RHEL 8.2+ / Rocky 8.4+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). BTF is a hard requirement; no-BTF kernels receive `EOPNOTSUPP`. CI target: Rocky 8.9 (kernel 4.18.0-513+).
 - **Recommended baseline:** Linux 5.4+ (RHEL 8.4+ / Ubuntu 20.04 LTS) for full feature set including ringbuf, `bpf_probe_read_kernel()`, and 1M instruction limit.
 - **Not supported:** RHEL 8.0–8.1 (no BTF, EOL since May 2024). Embedded BTF fallback deferred to future evaluation.
 - Note: ADR-003's original "5.4 recommended, 4.18 best-effort" framing has been narrowed by the Phase 1 BTF-required decision.
@@ -503,7 +503,7 @@ Key mutation targets: deletion of `path.insert`, modification of duration calcul
 
 **Tool:** virtme-ng (second-scale cross-kernel boot)
 - Extract vmlinuz + `/lib/modules/` from distro RPM/deb packages
-- Test kernels: 4.18.0-513+ (Rocky 8.9, Phase 1 minimum) / 5.4 (Ubuntu 20.04 LTS) / 5.8 / 5.17 / 6.x (representing key BPF capability boundaries)
+- Test kernels: 4.18.0-193+ (RHEL 8.2 baseline) / 4.18.0-513+ (Rocky 8.9 CI target) / 5.4 (Ubuntu 20.04 LTS) / 5.8 / 5.17 / 6.x (representing key BPF capability boundaries)
 - Each kernel version validates the feature probe → degradation → load path
 - Testing on 4.18 is strictly required to validate the feature degradation paths (perfarray fallback, `#pragma unroll` fallback, `raw_tp` fallback). Without it, the entire degradation architecture designed in ADR-002, ADR-004, and ADR-013 is unexercised dead code
 
@@ -615,7 +615,7 @@ The full 7-step pipeline + 6 probe types + wPRF format + Dagre+ECharts UI is amb
 
 Supporting kernel 4.18 (RHEL 8.0) doubles engineering complexity due to the 4,096 BPF instruction limit, lack of `bpf_probe_read_kernel()`, and absent BTF/CO-RE. Per [ADR-002-supplement](../decisions/ADR-002-supplement.md), native 4.18 kernels (RHEL 8.0-8.1) lack BTF entirely.
 
-**Phase 1 decision (2026-04-04):** BTF is a hard requirement. Minimum supported kernel: Rocky Linux 8.9 / RHEL 8.2+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). Kernels without BTF receive `EOPNOTSUPP` at startup. Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation if demand arises for pre-8.2 support. Explicit degradation matrix documents what works on each kernel.
+**Phase 1 decision (2026-04-04):** BTF is a hard requirement. Minimum supported kernel: RHEL 8.2+ / Rocky 8.4+ (kernel 4.18.0-193+, `CONFIG_DEBUG_INFO_BTF=y`). Kernels without BTF receive `EOPNOTSUPP` at startup. Embedded BTF fallback (`min_core_btfs`) deferred to future evaluation if demand arises for pre-8.2 support. Explicit degradation matrix documents what works on each kernel.
 
 ### 8.4 Risk 4: AI-Generated Spec Blind Spots — MEDIUM
 
@@ -670,7 +670,7 @@ The prior design spec claimed "zero P0/P1 residual items." This was a design com
 |-----|----------|--------------|
 | [ADR-001](../decisions/ADR-001.md) | Architecture model | Offline CLI (record/report) |
 | [ADR-002](../decisions/ADR-002.md) | Kernel compatibility | Dynamic per-feature probing |
-| [ADR-003](../decisions/ADR-003.md) | Minimum kernel version | Phase 1: Rocky 8.9 / RHEL 8.2+ (BTF required); see §1.4 |
+| [ADR-003](../decisions/ADR-003.md) | Minimum kernel version | Phase 1: RHEL 8.2+ / Rocky 8.4+ (BTF required); see §1.4 |
 | [ADR-004](../decisions/ADR-004.md) | Event transport | Single-ELF CO-RE dual-mode |
 | [ADR-005](../decisions/ADR-005.md) | Stack unwinding | bpf_get_stackid + Elastic Stack Delta |
 | [ADR-006](../decisions/ADR-006.md) | Graph visualization | Dagre layout + ECharts rendering |


### PR DESCRIPTION
## Summary

Aligns authoritative docs with design decisions made in `#p1-dev:65c931fc` discussion (2026-04-04). This is the doc-sync PR required by Critic and Challenger as a prerequisite for PR #72 merge.

**Changes:**

- **BTF policy** (`final-design.md` §1.3, `ADR-002-supplement.md`): Phase 1 BTF hard requirement, minimum Rocky 8.9 / RHEL 8.2+ (`CONFIG_DEBUG_INFO_BTF=y`), embedded BTF deferred
- **Section ID 3 metadata** (`final-design.md` §4.3): Phased delivery — PR #72 (writer) provides `EVENT_COUNT` + `DROP_COUNT`; Task #10 (record CLI) adds `BUILD_ID`, `HOSTNAME`, `OSRELEASE`, `CLI_ARGS`
- **Feature bitmap** (`final-design.md` §4.1): Bit assignment table — bit 0 = `HAS_TIMESTAMPS`, rest reserved
- **BPF probe field access** (`final-design.md` §2.1): tp_btf uses direct pointer access, raw_tp uses `BPF_CORE_READ`, dual handlers via macro (not shared)
- **Transport abstraction** (`ADR-002-supplement.md` §Consequences): `enum BpfBuffer { Ring, Perf }` with `poll(&mut self)` / `drop_count()` / `flush()` API

## Prerequisite for

- PR #72 (format writer) — Challenger BLOCK requires this doc-sync to land first

## Test plan

- [ ] Doc-only changes, no code impact
- [ ] Verify amended sections are internally consistent
- [ ] Critic + Challenger re-review against PR #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)