### PR TITLE
infra(ci): pin toolchain to 1.94 and enable clippy pedantic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@1.94
         with:
-          toolchain: "1.94"
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
@@ -30,7 +29,7 @@ jobs:
         run: cargo check
 
       - name: cargo clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: cargo test
         run: cargo test
@@ -47,9 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.94"
+      - uses: dtolnay/rust-toolchain@1.94
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.94"
           components: clippy, rustfmt
-
-      - name: Verify toolchain components
-        run: rustup component add rustfmt clippy 2>/dev/null || true
 
       - uses: Swatinem/rust-cache@v2
 
@@ -49,7 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,12 @@ serde_json = "1"
 
 [dev-dependencies]
 proptest = "1.11"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# Allow-list: low-signal pedantic lints that add noise without catching real bugs.
+module_name_repetitions = "allow"
+must_use_candidate      = "allow"
+return_self_not_must_use = "allow"
+missing_errors_doc      = "allow"
+missing_panics_doc      = "allow"

--- a/src/cascade/engine.rs
+++ b/src/cascade/engine.rs
@@ -2,11 +2,11 @@
 //!
 //! Implements Step 4 of the algorithm pipeline (§3.4).
 //! Pure function: takes immutable graph, returns new graph with
-//! attributed_delay_ms computed.
+//! `attributed_delay_ms` computed.
 //!
 //! Each edge is processed independently:
-//!   attributed_delay = raw_wait - propagated_downstream
-//! This means attributed_delay represents the DIRECT fault of the
+//!   `attributed_delay` = `raw_wait` - `propagated_downstream`
+//! This means `attributed_delay` represents the DIRECT fault of the
 //! destination node, excluding what deeper nodes are responsible for.
 
 use std::collections::BTreeMap;
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 use petgraph::graph::EdgeIndex;
 
 use crate::graph::sweep::sweep_line_partition;
-use crate::graph::types::*;
+use crate::graph::types::{ThreadId, TimeWindow};
 use crate::graph::wfg::WaitForGraph;
 
 use super::invariants;
@@ -138,9 +138,8 @@ fn compute_cascade(
 }
 
 fn count_concurrent_waiters(graph: &WaitForGraph, target: ThreadId, window: &TimeWindow) -> u64 {
-    let node_idx = match graph.node_index(&target) {
-        Some(idx) => idx,
-        None => return 1,
+    let Some(node_idx) = graph.node_index(&target) else {
+        return 1;
     };
 
     let count = graph

--- a/src/cascade/invariants.rs
+++ b/src/cascade/invariants.rs
@@ -2,7 +2,7 @@
 //!
 //! The production sentinel check (I-2 ∧ I-7) runs in all builds. It is
 //! implemented by `verify_engine_postconditions` (returns `Result`) and `invariants_ok` (returns `bool`).
-//! I-3, I-4 are debug_assert only. I-5, I-6 are test-only.
+//! I-3, I-4 are `debug_assert` only. I-5, I-6 are test-only.
 
 use std::fmt;
 
@@ -30,7 +30,7 @@ impl std::error::Error for InvariantError {}
 /// Production sentinel: I-2 (non-amplification) ∧ I-7 (locality).
 ///
 /// Structural postcondition guard per ADR-016. Checks that no edge's
-/// attributed_delay_ms exceeds its raw_wait_ms (I-2) and that graph
+/// `attributed_delay_ms` exceeds its `raw_wait_ms` (I-2) and that graph
 /// topology is preserved (I-7). Catches 0/5 known bugs by construction;
 /// its value is defense-in-depth against future regressions.
 pub fn invariants_ok(original: &WaitForGraph, result: &WaitForGraph) -> bool {
@@ -56,7 +56,7 @@ pub fn verify_engine_postconditions(
 }
 
 /// I-2: Non-amplification.
-/// No edge's attributed_delay_ms may exceed its raw_wait_ms.
+/// No edge's `attributed_delay_ms` may exceed its `raw_wait_ms`.
 pub fn check_non_amplification(result: &WaitForGraph) -> bool {
     result
         .all_edges()
@@ -65,7 +65,7 @@ pub fn check_non_amplification(result: &WaitForGraph) -> bool {
 }
 
 /// I-3: Non-negativity.
-/// All attributed_delay_ms >= 0. Trivially true for u64, but documents intent.
+/// All `attributed_delay_ms` >= 0. Trivially true for u64, but documents intent.
 pub fn check_non_negativity(_result: &WaitForGraph) -> bool {
     true // u64 is always >= 0
 }
@@ -79,7 +79,7 @@ pub fn check_termination(original: &WaitForGraph, result: &WaitForGraph) -> bool
 
 /// I-7: Locality.
 /// Every edge in result must correspond to an edge in original with
-/// the same (src, dst) and time_window.
+/// the same (src, dst) and `time_window`.
 pub fn check_locality(original: &WaitForGraph, result: &WaitForGraph) -> bool {
     let orig_edges = original.all_edges();
     let res_edges = result.all_edges();
@@ -131,12 +131,12 @@ pub fn check_idempotency(graph: &WaitForGraph, max_depth: u32) -> bool {
 /// I-6: Depth monotonicity (simple chains only).
 ///
 /// For simple chains (no fan-out, no concurrent waiters): increasing
-/// max_depth propagates more weight downstream, so
+/// `max_depth` propagates more weight downstream, so
 /// `total_attributed(deep) ≤ total_attributed(shallow)`.
 ///
-/// Does NOT hold in general because the corrected child_absorbed
+/// Does NOT hold in general because the corrected `child_absorbed`
 /// computation (`prop_down + child_blame`) can be less than
-/// `window.duration()` when fan-out (target_count > 1) or concurrent
+/// `window.duration()` when fan-out (`target_count` > 1) or concurrent
 /// waiters divide the transfer amount. This means deeper recursion
 /// may propagate less weight downstream than the depth-truncation
 /// base case, which returns full `(0, window.duration())`.

--- a/src/critical_path/mod.rs
+++ b/src/critical_path/mod.rs
@@ -229,7 +229,7 @@ mod tests {
             g.add_node(ThreadId(i), NodeKind::UserThread);
         }
         for i in 0..99i64 {
-            let start = (i * 10) as u64;
+            let start = i.unsigned_abs() * 10;
             let end = start + 100;
             g.add_edge(ThreadId(i), ThreadId(i + 1), TimeWindow::new(start, end));
         }

--- a/src/critical_path/mod.rs
+++ b/src/critical_path/mod.rs
@@ -31,7 +31,7 @@ pub struct CriticalPathNode {
 /// Compute the critical (longest) path through the condensation DAG.
 ///
 /// Algorithm: topological sort + DP.
-/// For each node in topo order: dist[v] = max(dist[u] + edge_weight + v.weight)
+/// For each node in topo order: dist[v] = max(dist[u] + `edge_weight` + v.weight)
 /// over all predecessors u.
 ///
 /// Returns None if the DAG is empty.
@@ -40,12 +40,9 @@ pub fn critical_path_dp(cdag: &CondensationDag) -> Option<CriticalPath> {
         return None;
     }
 
-    let topo = match toposort(&cdag.dag, None) {
-        Ok(order) => order,
-        Err(_) => {
-            // Should never happen — condensation is acyclic by construction
-            panic!("condensation DAG has a cycle — this is a bug");
-        }
+    let Ok(topo) = toposort(&cdag.dag, None) else {
+        // Should never happen — condensation is acyclic by construction
+        panic!("condensation DAG has a cycle — this is a bug");
     };
 
     let node_count = cdag.dag.node_count();

--- a/src/graph/sweep.rs
+++ b/src/graph/sweep.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeSet;
 
-use super::types::*;
+use super::types::{ElementaryInterval, ThreadId, TimeWindow};
 use super::wfg::WaitForGraph;
 
 use petgraph::Direction;
@@ -19,7 +19,7 @@ use petgraph::visit::EdgeRef;
 /// 1. Clip each outgoing edge to its intersection with `window`
 /// 2. Collect all distinct start/end points
 /// 3. Sweep left-to-right: between consecutive points, emit an
-///    ElementaryInterval listing active targets
+///    `ElementaryInterval` listing active targets
 ///
 /// Returns empty Vec if no outgoing edges overlap `window`.
 pub fn sweep_line_partition(
@@ -27,9 +27,8 @@ pub fn sweep_line_partition(
     node: ThreadId,
     window: &TimeWindow,
 ) -> Vec<ElementaryInterval> {
-    let node_idx = match graph.node_index(&node) {
-        Some(idx) => idx,
-        None => return Vec::new(),
+    let Some(node_idx) = graph.node_index(&node) else {
+        return Vec::new();
     };
 
     // Collect clipped intervals: (clipped_window, target_tid)

--- a/src/graph/wfg.rs
+++ b/src/graph/wfg.rs
@@ -1,6 +1,6 @@
-//! Wait-For Graph — wraps petgraph::DiGraph with ThreadId-based lookup.
+//! Wait-For Graph — wraps `petgraph::DiGraph` with ThreadId-based lookup.
 //!
-//! Uses BTreeMap for deterministic iteration order (ADR-007).
+//! Uses `BTreeMap` for deterministic iteration order (ADR-007).
 
 use std::collections::BTreeMap;
 
@@ -8,7 +8,7 @@ use petgraph::Direction;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 
-use super::types::*;
+use super::types::{EdgeWeight, NodeKind, NodeWeight, ThreadId, TimeWindow};
 
 /// The Wait-For Graph. Directed graph where:
 /// - Nodes = threads (or pseudo-threads)
@@ -27,7 +27,7 @@ impl WaitForGraph {
         }
     }
 
-    /// Add a node (thread). Returns the NodeIndex. Idempotent — returns
+    /// Add a node (thread). Returns the `NodeIndex`. Idempotent — returns
     /// existing index if tid already present.
     pub fn add_node(&mut self, tid: ThreadId, kind: NodeKind) -> NodeIndex {
         if let Some(&idx) = self.node_map.get(&tid) {
@@ -46,17 +46,17 @@ impl WaitForGraph {
             .add_edge(src_idx, dst_idx, EdgeWeight::new(window))
     }
 
-    /// Get the ThreadId for a NodeIndex.
+    /// Get the `ThreadId` for a `NodeIndex`.
     pub fn thread_id(&self, idx: NodeIndex) -> ThreadId {
         self.graph[idx].tid
     }
 
-    /// Get NodeIndex for a ThreadId.
+    /// Get `NodeIndex` for a `ThreadId`.
     pub fn node_index(&self, tid: &ThreadId) -> Option<NodeIndex> {
         self.node_map.get(tid).copied()
     }
 
-    /// Get all outgoing edges from `node` as (EdgeIndex, dst_ThreadId, &EdgeWeight).
+    /// Get all outgoing edges from `node` as (`EdgeIndex`, `dst_ThreadId`, &`EdgeWeight`).
     pub fn outgoing_edges(&self, node: NodeIndex) -> Vec<(EdgeIndex, ThreadId, &EdgeWeight)> {
         self.graph
             .edges_directed(node, Direction::Outgoing)
@@ -72,7 +72,7 @@ impl WaitForGraph {
             .collect()
     }
 
-    /// Iterate all edges as (EdgeIndex, src_tid, dst_tid, &EdgeWeight).
+    /// Iterate all edges as (`EdgeIndex`, `src_tid`, `dst_tid`, &`EdgeWeight`).
     /// BTreeMap-ordered by source tid for determinism.
     pub fn all_edges(&self) -> Vec<(EdgeIndex, ThreadId, ThreadId, &EdgeWeight)> {
         let mut result: Vec<_> = self
@@ -118,18 +118,18 @@ impl WaitForGraph {
         &self.graph[idx]
     }
 
-    /// All node indices, sorted by ThreadId for determinism.
+    /// All node indices, sorted by `ThreadId` for determinism.
     pub fn node_indices(&self) -> Vec<NodeIndex> {
         self.node_map.values().copied().collect()
     }
 
     /// Clone the graph structure with the same topology but reset
-    /// attributed_delay_ms to raw_wait_ms on all edges.
+    /// `attributed_delay_ms` to `raw_wait_ms` on all edges.
     pub fn clone_with_reset_attribution(&self) -> Self {
         let mut new = Self::new();
         // Clone nodes
-        for (&tid, &_idx) in &self.node_map {
-            new.add_node(tid, self.graph[_idx].kind);
+        for (&tid, &idx) in &self.node_map {
+            new.add_node(tid, self.graph[idx].kind);
         }
         // Clone edges
         for eidx in self.graph.edge_indices() {
@@ -142,7 +142,7 @@ impl WaitForGraph {
         new
     }
 
-    /// Sum of all raw_wait_ms across all edges.
+    /// Sum of all `raw_wait_ms` across all edges.
     pub fn total_raw_wait(&self) -> u64 {
         self.graph
             .edge_indices()
@@ -155,7 +155,7 @@ impl WaitForGraph {
         petgraph::algo::toposort(&self.graph, None).is_ok()
     }
 
-    /// Sum of all attributed_delay_ms across all edges.
+    /// Sum of all `attributed_delay_ms` across all edges.
     pub fn total_attributed(&self) -> u64 {
         self.graph
             .edge_indices()

--- a/src/scc/heuristic.rs
+++ b/src/scc/heuristic.rs
@@ -1,7 +1,7 @@
 //! MAX heuristic for super-node weights (step 6, §3.5).
 //!
-//! Super-node weight = MAX(attributed_delay of all internal edges).
-//! For singleton SCCs, weight = max attributed_delay of incident edges.
+//! Super-node weight = `MAX(attributed_delay` of all internal edges).
+//! For singleton SCCs, weight = max `attributed_delay` of incident edges.
 //! This is explicitly a sorting heuristic, not mathematical truth
 //! (ADR-008).
 
@@ -10,9 +10,9 @@ use crate::graph::wfg::WaitForGraph;
 use super::tarjan::{CondensationDag, Scc, internal_edges};
 
 /// Compute MAX heuristic weight for an SCC.
-/// Returns the maximum attributed_delay_ms among all internal edges.
+/// Returns the maximum `attributed_delay_ms` among all internal edges.
 /// For singleton SCCs with no internal edges, returns the max
-/// attributed_delay of any edge touching the member.
+/// `attributed_delay` of any edge touching the member.
 pub fn max_heuristic_weight(graph: &WaitForGraph, scc: &Scc) -> u64 {
     let int_edges = internal_edges(graph, scc);
 

--- a/src/scc/knot.rs
+++ b/src/scc/knot.rs
@@ -53,10 +53,13 @@ pub fn detect_knots(cdag: &CondensationDag, graph: &WaitForGraph) -> Vec<Knot> {
 
 /// Check if a thread has a self-loop in the WFG.
 fn has_self_loop(graph: &WaitForGraph, tid: ThreadId) -> bool {
+    let Some(idx) = graph.node_index(&tid) else {
+        return false;
+    };
     graph
-        .all_edges()
+        .outgoing_edges(idx)
         .iter()
-        .any(|(_, src, dst, _)| *src == tid && *dst == tid)
+        .any(|(_, dst, _)| *dst == tid)
 }
 
 /// Check if ALL members of an SCC are kernel threads.

--- a/src/scc/knot.rs
+++ b/src/scc/knot.rs
@@ -5,7 +5,7 @@
 
 use petgraph::graph::NodeIndex;
 
-use crate::graph::types::*;
+use crate::graph::types::{NodeKind, ThreadId};
 use crate::graph::wfg::WaitForGraph;
 
 use super::tarjan::CondensationDag;
@@ -30,7 +30,7 @@ pub fn detect_knots(cdag: &CondensationDag, graph: &WaitForGraph) -> Vec<Knot> {
             let sn = cdag.super_node(idx);
 
             // Rule 1: exclude trivial singletons (no self-loop)
-            if sn.members.len() == 1 && !has_self_loop(graph, &sn.members[0]) {
+            if sn.members.len() == 1 && !has_self_loop(graph, sn.members[0]) {
                 return false;
             }
 
@@ -52,11 +52,11 @@ pub fn detect_knots(cdag: &CondensationDag, graph: &WaitForGraph) -> Vec<Knot> {
 }
 
 /// Check if a thread has a self-loop in the WFG.
-fn has_self_loop(graph: &WaitForGraph, tid: &ThreadId) -> bool {
+fn has_self_loop(graph: &WaitForGraph, tid: ThreadId) -> bool {
     graph
         .all_edges()
         .iter()
-        .any(|(_, src, dst, _)| src == tid && dst == tid)
+        .any(|(_, src, dst, _)| *src == tid && *dst == tid)
 }
 
 /// Check if ALL members of an SCC are kernel threads.
@@ -70,6 +70,7 @@ fn is_pure_kernel_scc(graph: &WaitForGraph, members: &[ThreadId]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph::types::TimeWindow;
     use crate::scc::tarjan::build_condensation;
 
     #[test]

--- a/src/scc/tarjan.rs
+++ b/src/scc/tarjan.rs
@@ -1,7 +1,7 @@
 //! Tarjan SCC identification and condensation DAG construction.
 //!
 //! Step 5 of the 7-step pipeline (§3.5).
-//! petgraph::algo::tarjan_scc returns components in reverse topological
+//! `petgraph::algo::tarjan_scc` returns components in reverse topological
 //! order (sink SCCs first).
 
 use std::collections::BTreeMap;
@@ -11,7 +11,7 @@ use petgraph::algo::tarjan_scc;
 use petgraph::graph::{DiGraph, NodeIndex};
 use serde::Serialize;
 
-use crate::graph::types::*;
+use crate::graph::types::{EdgeWeight, ThreadId};
 use crate::graph::wfg::WaitForGraph;
 
 /// A strongly connected component.
@@ -29,7 +29,7 @@ pub struct SuperNode {
 }
 
 /// The condensation DAG — acyclic graph of super-nodes.
-/// Edges carry the max attributed_delay among parallel cross-SCC edges.
+/// Edges carry the max `attributed_delay` among parallel cross-SCC edges.
 pub struct CondensationDag {
     pub dag: DiGraph<SuperNode, u64>,
     pub(crate) node_map: BTreeMap<ThreadId, NodeIndex>,
@@ -73,7 +73,7 @@ impl CondensationDag {
         self.dag.edges_directed(idx, Direction::Outgoing).count()
     }
 
-    /// Sink super-nodes (out_degree == 0).
+    /// Sink super-nodes (`out_degree` == 0).
     pub fn sinks(&self) -> Vec<NodeIndex> {
         self.dag
             .node_indices()
@@ -101,7 +101,7 @@ pub fn find_sccs(graph: &WaitForGraph) -> Vec<Scc> {
 /// Build an acyclic condensation DAG from the Wait-For Graph.
 ///
 /// Each SCC becomes a super-node (weight=0, filled by heuristic).
-/// Cross-SCC edges become DAG edges with weight = max attributed_delay
+/// Cross-SCC edges become DAG edges with weight = max `attributed_delay`
 /// among all parallel edges between the same pair of SCCs.
 pub fn build_condensation(graph: &WaitForGraph) -> CondensationDag {
     let sccs = find_sccs(graph);
@@ -162,6 +162,7 @@ pub fn internal_edges<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph::types::{NodeKind, TimeWindow};
 
     #[test]
     fn acyclic_graph_all_singleton_sccs() {

--- a/tests/bug_regressions.rs
+++ b/tests/bug_regressions.rs
@@ -8,12 +8,12 @@ use wperf::cascade::invariants::invariants_ok;
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
 
-/// BUG-1: visited_path scope leak across DFS branches.
+/// BUG-1: `visited_path` scope leak across DFS branches.
 ///
 /// Bug mechanism: if the cycle-detection path set persists across
 /// sibling branches in the DFS tree, a node reachable via two paths
 /// is incorrectly skipped on the second visit. The fix uses
-/// path.insert()/path.remove() so each branch gets a clean path.
+/// `path.insert()/path.remove()` so each branch gets a clean path.
 ///
 /// Graph: A→B [0,100), B→C [0,50), B→D [50,100), C→E [0,50), D→E [50,100)
 /// E is reachable from B via C and via D in different time windows.
@@ -66,10 +66,10 @@ fn bug1_visited_path_scope() {
     assert!(invariants_ok(&g, &result));
 }
 
-/// BUG-2: propagated_down return value ignored.
+/// BUG-2: `propagated_down` return value ignored.
 ///
 /// Bug mechanism: if the parent does not subtract the weight
-/// propagated to its children, it claims the full raw_wait
+/// propagated to its children, it claims the full `raw_wait`
 /// as its own attribution — inflating blame on intermediate nodes.
 ///
 /// Graph: A→B [0,100), B→C [20,100)
@@ -149,7 +149,7 @@ fn bug3_multi_edge_overlap() {
 /// BUG-4: BUG-2 + BUG-3 combined.
 ///
 /// Bug mechanism: chain with overlapping edges at intermediate node
-/// triggers both propagated_down ignored AND double-counting.
+/// triggers both `propagated_down` ignored AND double-counting.
 ///
 /// Graph: A→B [0,100), B→C [0,60), B→D [20,80), C→E [0,60)
 /// Both bugs amplify the error at intermediate nodes.
@@ -196,7 +196,7 @@ fn bug4_combined_bug2_bug3() {
 /// NEW-BUG-1: leaf node zero blame.
 ///
 /// Bug mechanism: when a node has no outgoing edges (leaf),
-/// compute_cascade returns 0 propagated. If the parent uses
+/// `compute_cascade` returns 0 propagated. If the parent uses
 /// only the propagated value (not interval duration) to determine
 /// how much the child absorbs, the leaf gets zero credit and
 /// the parent keeps all the blame.

--- a/tests/differential.rs
+++ b/tests/differential.rs
@@ -1,7 +1,7 @@
 //! Differential testing: Rust vs Python oracle.
 //!
 //! Runs the same synthetic graphs through both implementations and
-//! verifies per-edge attributed_delay agrees within 1.0ms tolerance.
+//! verifies per-edge `attributed_delay` agrees within 1.0ms tolerance.
 
 use std::process::Command;
 
@@ -113,25 +113,19 @@ fn compare_results(rust_graph: &WaitForGraph, python: &OracleOutput, test_name: 
     assert_eq!(
         rust_edges.len(),
         python.edges.len(),
-        "{}: edge count mismatch",
-        test_name
+        "{test_name}: edge count mismatch"
     );
 
     for (i, (_, src, dst, ew)) in rust_edges.iter().enumerate() {
         let py = &python.edges[i];
-        assert_eq!(src.0, py.src, "{}: edge {} src mismatch", test_name, i);
-        assert_eq!(dst.0, py.dst, "{}: edge {} dst mismatch", test_name, i);
+        assert_eq!(src.0, py.src, "{test_name}: edge {i} src mismatch");
+        assert_eq!(dst.0, py.dst, "{test_name}: edge {i} dst mismatch");
         assert_eq!(
             ew.raw_wait_ms, py.raw_wait_ms,
-            "{}: edge {} raw_wait mismatch",
-            test_name, i
+            "{test_name}: edge {i} raw_wait mismatch"
         );
 
-        let diff = if ew.attributed_delay_ms > py.attributed_delay_ms {
-            ew.attributed_delay_ms - py.attributed_delay_ms
-        } else {
-            py.attributed_delay_ms - ew.attributed_delay_ms
-        };
+        let diff = ew.attributed_delay_ms.abs_diff(py.attributed_delay_ms);
 
         assert!(
             diff <= TOLERANCE_MS,

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -39,11 +39,11 @@ fn arb_wfg() -> impl Strategy<Value = WaitForGraph> {
                 } else {
                     match i % 5 {
                         0 => NodeKind::KernelThread,
-                        1 | 2 | 3 => NodeKind::UserThread,
+                        1..=3 => NodeKind::UserThread,
                         _ => NodeKind::PseudoDisk,
                     }
                 };
-                g.add_node(ThreadId(i as i64), kind);
+                g.add_node(ThreadId(i64::try_from(i).unwrap()), kind);
             }
 
             for (src, dst, start, dur) in edges {
@@ -51,8 +51,8 @@ fn arb_wfg() -> impl Strategy<Value = WaitForGraph> {
                     // Skip self-loops for simpler graphs
                     let end = start + dur;
                     g.add_edge(
-                        ThreadId(src as i64),
-                        ThreadId(dst as i64),
+                        ThreadId(i64::try_from(src).unwrap()),
+                        ThreadId(i64::try_from(dst).unwrap()),
                         TimeWindow::new(start, end),
                     );
                 }


### PR DESCRIPTION
## Summary
- **Pin CI toolchain to 1.94** — both `check` and `mutants` jobs now use `dtolnay/rust-toolchain@master` with explicit `toolchain: "1.94"`, matching `rust-toolchain.toml`. Eliminates local/CI formatting drift caused by `@stable` installing a newer rustfmt.
- **Enable `clippy::pedantic` as CI gate** — configured in `[lints.clippy]` in `Cargo.toml` so local and CI behavior are identical. Allow-list for low-signal lints: `module_name_repetitions`, `must_use_candidate`, `return_self_not_must_use`, `missing_errors_doc`, `missing_panics_doc`.
- **Fix all existing pedantic warnings** — `doc_markdown` backticks, `wildcard_imports`, `manual_let_else`, `trivially_copy_pass_by_ref`, `used_underscore_binding`, `match_wild_err_arm`.

## Motivation
CI was using `dtolnay/rust-toolchain@stable` which installs the latest stable Rust, not the repo-pinned 1.94. This caused `cargo fmt --check` failures on PR #72 despite local checks passing. Pedantic clippy gate ensures idiomatic Rust from day one of Phase 1, with Maestro running pedantic locally before every push.

## Test plan
- [ ] CI `cargo fmt --check` passes (previously failing)
- [ ] CI `cargo clippy -- -D warnings` passes with pedantic enabled
- [ ] All 95 tests pass
- [ ] Mutation testing still runs on pinned 1.94

🤖 Generated with [Claude Code](https://claude.com/claude-code)