### PR TITLE
fix(ci): correct dtolnay/rust-toolchain action ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.94
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.94.0
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
@@ -46,7 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.94
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.94"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- `dtolnay/rust-toolchain@1.94` (from #75) conflates the **action git ref** with the **Rust toolchain version** — the `@1.94` tag doesn't exist on the action repo, causing `components: clippy, rustfmt` to silently fail
- Fix: use `@master` as the action ref, specify `toolchain: 1.94.0` in the `with:` block
- Applies to both `check` and `mutants` jobs

This is a hotfix for the `main` CI regression introduced by #75.

## Test plan
- [ ] CI `cargo fmt --check` step passes (was failing with `cargo-fmt not installed`)
- [ ] CI `cargo clippy --all-targets -- -D warnings` passes
- [ ] CI `cargo test` passes