### PR TITLE
feat(probe): dynamic feature probing module (W1 #6)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,21 @@
+# cargo-mutants configuration
+# See https://mutants.rs/mutants-toml.html
+
+# Exclude Tier 2/3 BPF probe functions from mutation testing.
+#
+# These functions exist in two versions via cfg(feature = "bpf"):
+# - The real implementations use libbpf-rs syscalls (compiled only with --features bpf)
+# - The stubs return hardcoded fallback values (compiled in default build)
+#
+# Problem: cargo-mutants runs against the default build. The bpf-gated versions
+# are compiled out by cfg, so body-replacement mutations are invisible to tests
+# (false MISSED). Excluding by function name also removes the stub mutations,
+# but those are trivial one-liners already covered by integration tests.
+#
+# Re-evaluate when adding --features bpf to the mutation testing job.
+exclude_re = [
+    "probe_ringbuf",
+    "probe_bpf_loop",
+    "probe_tp_btf",
+    "probe_fentry",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,10 +36,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "equivalent"
@@ -62,6 +78,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -158,6 +180,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libbpf-rs"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93edd9cd673087fa7518fd63ad6c87be2cd9b4e35034b1873f3e3258c018275b"
+dependencies = [
+ "bitflags",
+ "libbpf-sys",
+ "libc",
+ "vsprintf",
+]
+
+[[package]]
+name = "libbpf-sys"
+version = "1.7.0+v1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a109478760b2900aa2a6f2087e9d0de1d9c535b1758602af2845d5d2ccfaed7c"
+dependencies = [
+ "cc",
+ "nix",
+ "pkg-config",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +225,18 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-traits"
@@ -207,6 +264,12 @@ dependencies = [
  "indexmap",
  "serde",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "ppv-lite86"
@@ -401,6 +464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +510,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "vsprintf"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec2f81b75ca063294776b4f7e8da71d1d5ae81c2b1b149c8d89969230265d63"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -610,6 +689,9 @@ dependencies = [
 name = "wperf"
 version = "0.1.0"
 dependencies = [
+ "libbpf-rs",
+ "libbpf-sys",
+ "libc",
  "petgraph",
  "proptest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbpf-rs"
-version = "0.24.8"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93edd9cd673087fa7518fd63ad6c87be2cd9b4e35034b1873f3e3258c018275b"
+checksum = "a6af29f679fd713ba4466b0296436268f573f6c5a8ef2f316d237eb3019c3c6f"
 dependencies = [
  "bitflags",
  "libbpf-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 bpf = ["libbpf-rs", "libbpf-sys", "libc"]
 
 [dependencies]
-libbpf-rs = { version = "0.24", optional = true }
-libbpf-sys = { version = "1.5", optional = true }
+libbpf-rs = { version = "0.26", optional = true }
+libbpf-sys = { version = "1.7", optional = true }
 libc = { version = "0.2", optional = true }
 petgraph = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,13 @@ name = "wperf"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+bpf = ["libbpf-rs", "libbpf-sys", "libc"]
+
 [dependencies]
+libbpf-rs = { version = "0.24", optional = true }
+libbpf-sys = { version = "1.5", optional = true }
+libc = { version = "0.2", optional = true }
 petgraph = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod critical_path;
 pub mod format;
 pub mod graph;
 pub mod output;
+pub mod probe;
 pub mod scc;

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -541,7 +541,7 @@ mod tests {
         assert!(matches!(err, ProbeError::BtfRequired));
     }
 
-    // -- Display --
+    // -- Error trait --
 
     #[test]
     fn error_display() {
@@ -549,5 +549,78 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("BTF not available"));
         assert!(msg.contains("RHEL 8.2+"));
+    }
+
+    #[test]
+    fn error_display_io() {
+        let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "no access");
+        let err = ProbeError::Io(io_err);
+        let msg = err.to_string();
+        assert!(msg.contains("I/O error"));
+    }
+
+    #[test]
+    fn error_display_syscall() {
+        let err = ProbeError::Syscall("test failure".to_string());
+        let msg = err.to_string();
+        assert!(msg.contains("syscall probe failed"));
+    }
+
+    #[test]
+    fn error_source_io_returns_some() {
+        let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "no access");
+        let err = ProbeError::Io(io_err);
+        assert!(std::error::Error::source(&err).is_some());
+    }
+
+    #[test]
+    fn error_source_btf_required_returns_none() {
+        let err = ProbeError::BtfRequired;
+        assert!(std::error::Error::source(&err).is_none());
+    }
+
+    // -- file_contains_line edge cases --
+
+    #[test]
+    fn file_contains_line_permission_denied_propagates() {
+        // Create a directory where a file name exists but can't be read.
+        // On most systems, trying to open a directory as a file gives an error
+        // that is NOT NotFound — it should propagate, not return Ok(false).
+        let dir = TempDir::new("perm_denied");
+        let target = dir.path().join("unreadable");
+        fs::create_dir_all(&target).unwrap();
+        // Opening a directory as a regular file returns an error on Linux.
+        let result = file_contains_line(&target, "anything");
+        // The error should propagate (not silently return false).
+        assert!(result.is_err());
+    }
+
+    // -- Stub return value discrimination --
+
+    #[test]
+    fn ringbuf_stub_not_ringbuf() {
+        // Ensure the stub specifically returns PerfArray, not RingBuf.
+        let result = probe_ringbuf().unwrap();
+        assert_ne!(result, TransportMode::RingBuf);
+    }
+
+    #[test]
+    fn bpf_loop_stub_specifically_false() {
+        // Ensure the stub returns exactly false, not true.
+        let result = probe_bpf_loop().unwrap();
+        assert!(!result);
+    }
+
+    // -- probe_all cgroupv2 false path --
+
+    #[test]
+    fn probe_all_without_cgroupv2() {
+        let dir = TempDir::new("probe_all_nocgroup");
+        fs::write(dir.path().join("btf_vmlinux"), b"").unwrap();
+        // No cgroup_controllers file
+        let paths = test_paths(dir.path());
+
+        let matrix = probe_all(&paths).unwrap();
+        assert!(!matrix.has_cgroupv2);
     }
 }

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -193,6 +193,7 @@ fn file_contains_line(path: &Path, needle: &str) -> Result<bool, ProbeError> {
 ///
 /// Requires `CAP_BPF` or `CAP_SYS_ADMIN`.
 #[cfg(feature = "bpf")]
+#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_ringbuf() -> Result<TransportMode, ProbeError> {
     use libbpf_rs::MapType;
 
@@ -221,6 +222,7 @@ pub fn probe_ringbuf() -> Result<TransportMode, ProbeError> {
 /// Uses `libbpf_probe_bpf_helper` to check `BPF_FUNC_loop` availability
 /// for `BPF_PROG_TYPE_TRACEPOINT` programs.
 #[cfg(feature = "bpf")]
+#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_bpf_loop() -> Result<bool, ProbeError> {
     // libbpf_probe_bpf_helper(BPF_PROG_TYPE_TRACEPOINT, BPF_FUNC_loop, NULL)
     // libbpf-rs exposes this via libbpf_sys.
@@ -258,6 +260,7 @@ pub fn probe_bpf_loop() -> Result<bool, ProbeError> {
 ///
 /// Full implementation depends on skeleton infrastructure from task #5.
 #[cfg(feature = "bpf")]
+#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
     // TODO(probe): Implement minimal tp_btf attach test once skeleton infra lands.
     // For now, attempt detection via BTF type existence as a proxy:
@@ -278,6 +281,7 @@ pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
 /// Requires loading a minimal BPF program that attaches via fentry.
 /// Full implementation depends on skeleton infrastructure from task #5.
 #[cfg(feature = "bpf")]
+#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_fentry() -> Result<bool, ProbeError> {
     // TODO(probe): Implement minimal fentry attach test once skeleton infra lands.
     Ok(false)
@@ -583,15 +587,17 @@ mod tests {
 
     #[test]
     fn file_contains_line_permission_denied_propagates() {
-        // Create a directory where a file name exists but can't be read.
-        // On most systems, trying to open a directory as a file gives an error
-        // that is NOT NotFound — it should propagate, not return Ok(false).
+        use std::os::unix::fs::PermissionsExt;
+
         let dir = TempDir::new("perm_denied");
         let target = dir.path().join("unreadable");
-        fs::create_dir_all(&target).unwrap();
-        // Opening a directory as a regular file returns an error on Linux.
+        fs::write(&target, "some content\n").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o000)).unwrap();
+
         let result = file_contains_line(&target, "anything");
-        // The error should propagate (not silently return false).
+        // Restore permissions before assert so cleanup succeeds.
+        let _ = fs::set_permissions(&target, fs::Permissions::from_mode(0o644));
+        // Non-NotFound errors (PermissionDenied) must propagate, not return Ok(false).
         assert!(result.is_err());
     }
 

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -193,7 +193,6 @@ fn file_contains_line(path: &Path, needle: &str) -> Result<bool, ProbeError> {
 ///
 /// Requires `CAP_BPF` or `CAP_SYS_ADMIN`.
 #[cfg(feature = "bpf")]
-#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_ringbuf() -> Result<TransportMode, ProbeError> {
     use libbpf_rs::MapType;
 
@@ -222,7 +221,6 @@ pub fn probe_ringbuf() -> Result<TransportMode, ProbeError> {
 /// Uses `libbpf_probe_bpf_helper` to check `BPF_FUNC_loop` availability
 /// for `BPF_PROG_TYPE_TRACEPOINT` programs.
 #[cfg(feature = "bpf")]
-#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_bpf_loop() -> Result<bool, ProbeError> {
     // libbpf_probe_bpf_helper(BPF_PROG_TYPE_TRACEPOINT, BPF_FUNC_loop, NULL)
     // libbpf-rs exposes this via libbpf_sys.
@@ -260,7 +258,6 @@ pub fn probe_bpf_loop() -> Result<bool, ProbeError> {
 ///
 /// Full implementation depends on skeleton infrastructure from task #5.
 #[cfg(feature = "bpf")]
-#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
     // TODO(probe): Implement minimal tp_btf attach test once skeleton infra lands.
     // For now, attempt detection via BTF type existence as a proxy:
@@ -281,7 +278,6 @@ pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
 /// Requires loading a minimal BPF program that attaches via fentry.
 /// Full implementation depends on skeleton infrastructure from task #5.
 #[cfg(feature = "bpf")]
-#[mutants::skip] // cfg-gated out in default build; mutation has no observable effect on tests
 pub fn probe_fentry() -> Result<bool, ProbeError> {
     // TODO(probe): Implement minimal fentry attach test once skeleton infra lands.
     Ok(false)

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -1,0 +1,537 @@
+//! Dynamic feature probing for kernel eBPF capabilities.
+//!
+//! Implements the ADR-002 per-feature probing matrix. Each feature is tested
+//! independently at startup between skeleton `open()` and `load()`.
+//!
+//! Probes are organized into three tiers:
+//! - **Tier 1** (filesystem checks): BTF, cgroupv2, tracepoint existence, kprobe existence
+//! - **Tier 2** (syscall-level): ringbuf map creation, `bpf_loop` helper availability
+//! - **Tier 3** (attach-based): `tp_btf` attach test, `fentry` attach test
+
+use std::io;
+use std::path::Path;
+
+/// Errors that can occur during feature probing.
+#[derive(Debug)]
+pub enum ProbeError {
+    /// BTF is required but not available on this kernel.
+    BtfRequired,
+    /// An I/O error occurred during probing.
+    Io(io::Error),
+    /// A syscall-level probe failed in an unexpected way.
+    Syscall(String),
+}
+
+impl std::fmt::Display for ProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BtfRequired => write!(
+                f,
+                "BTF not available: /sys/kernel/btf/vmlinux not found. \
+                 Minimum supported: RHEL 8.2+ / Rocky 8.4+ with CONFIG_DEBUG_INFO_BTF=y"
+            ),
+            Self::Io(e) => write!(f, "I/O error during feature probing: {e}"),
+            Self::Syscall(msg) => write!(f, "syscall probe failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ProbeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::BtfRequired | Self::Syscall(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for ProbeError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Transport mode selected by the ringbuf probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportMode {
+    /// Ring buffer available (kernel 5.8+). Zero-copy path via `bpf_ringbuf_reserve`/`submit`.
+    RingBuf,
+    /// Perfarray fallback. Requires percpu-array staging + Min-Heap Reorder Buffer in userspace.
+    PerfArray,
+}
+
+/// Scheduler tracepoint attachment mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TracepointMode {
+    /// `tp_btf/sched_switch` + `tp_btf/sched_wakeup` (kernel 5.5+).
+    /// Direct `task_struct *` access without casts.
+    TpBtf,
+    /// `raw_tp/sched_switch` + `raw_tp/sched_wakeup` (kernel 4.17+).
+    /// Requires `bpf_probe_read_kernel` for field access.
+    RawTp,
+}
+
+/// Result of probing all kernel eBPF features at startup.
+///
+/// Consumed by the skeleton reconfiguration step between `open()` and `load()`.
+/// See ADR-002 §Decision for the full probe matrix.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct FeatureMatrix {
+    /// Transport mode: `RingBuf` (preferred) or `PerfArray` (fallback).
+    pub transport: TransportMode,
+    /// Scheduler tracepoint mode: `TpBtf` (preferred) or `RawTp` (fallback).
+    pub tracepoint: TracepointMode,
+    /// Whether `/sys/kernel/btf/vmlinux` is present. Hard requirement for Phase 1.
+    pub has_btf: bool,
+    /// Whether `bpf_loop` helper is available (kernel 5.17+).
+    pub has_bpf_loop: bool,
+    /// Whether cgroupv2 is mounted and functional.
+    pub has_cgroupv2: bool,
+    /// Whether `fentry` attachment is supported (kernel 5.5+).
+    pub has_fentry: bool,
+}
+
+/// Sysfs/tracefs paths used by the probing layer.
+///
+/// Extracted as a struct so tests can override paths without touching the real filesystem.
+pub struct ProbePaths<'a> {
+    pub btf_vmlinux: &'a Path,
+    pub cgroup_controllers: &'a Path,
+    pub tracing_events: &'a Path,
+    pub kprobe_blacklist: &'a Path,
+    pub available_filter_functions: &'a Path,
+}
+
+impl Default for ProbePaths<'_> {
+    fn default() -> Self {
+        Self {
+            btf_vmlinux: Path::new("/sys/kernel/btf/vmlinux"),
+            cgroup_controllers: Path::new("/sys/fs/cgroup/cgroup.controllers"),
+            tracing_events: Path::new("/sys/kernel/tracing/events"),
+            kprobe_blacklist: Path::new("/sys/kernel/debug/kprobes/blacklist"),
+            available_filter_functions: Path::new(
+                "/sys/kernel/debug/tracing/available_filter_functions",
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1: Filesystem-based probes
+// ---------------------------------------------------------------------------
+
+/// Check whether BTF is available via `/sys/kernel/btf/vmlinux`.
+///
+/// This is a hard requirement for Phase 1. Returns `Err(ProbeError::BtfRequired)`
+/// if BTF is not found — the caller should abort startup.
+pub fn probe_btf(paths: &ProbePaths<'_>) -> Result<bool, ProbeError> {
+    if paths.btf_vmlinux.exists() {
+        Ok(true)
+    } else {
+        Err(ProbeError::BtfRequired)
+    }
+}
+
+/// Check whether cgroupv2 is mounted by testing `/sys/fs/cgroup/cgroup.controllers`.
+pub fn probe_cgroupv2(paths: &ProbePaths<'_>) -> bool {
+    paths.cgroup_controllers.exists()
+}
+
+/// Check whether a specific tracepoint exists in tracefs.
+///
+/// Probes `/sys/kernel/tracing/events/{category}/{name}`.
+pub fn probe_tracepoint(paths: &ProbePaths<'_>, category: &str, name: &str) -> bool {
+    paths.tracing_events.join(category).join(name).exists()
+}
+
+/// Check whether a kernel function is available for kprobe attachment.
+///
+/// A function is kprobe-eligible if it appears in `available_filter_functions`
+/// and does NOT appear in the kprobe blacklist.
+pub fn probe_kprobe(paths: &ProbePaths<'_>, function: &str) -> Result<bool, ProbeError> {
+    let in_blacklist = file_contains_line(paths.kprobe_blacklist, function)?;
+    if in_blacklist {
+        return Ok(false);
+    }
+    file_contains_line(paths.available_filter_functions, function)
+}
+
+/// Scan a file line-by-line for a line containing `needle`.
+///
+/// Returns `Ok(false)` if the file does not exist (non-fatal for optional debugfs files).
+fn file_contains_line(path: &Path, needle: &str) -> Result<bool, ProbeError> {
+    use std::io::BufRead;
+
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(ProbeError::Io(e)),
+    };
+
+    let reader = io::BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        // available_filter_functions format: "func_name [module]"
+        // kprobe blacklist format: "0xaddr\tfunc_name"
+        // In both cases, check if the function name appears as a word boundary.
+        if line.split_whitespace().any(|word| word == needle) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: Syscall-level probes (require libbpf-rs at runtime)
+// ---------------------------------------------------------------------------
+
+/// Probe whether `BPF_MAP_TYPE_RINGBUF` is supported by the running kernel.
+///
+/// Attempts `bpf_map_create(BPF_MAP_TYPE_RINGBUF, ...)` and closes the fd on success.
+/// This follows the `probe_ringbuf()` pattern from libbpf-tools `trace_helpers.c`.
+///
+/// Requires `CAP_BPF` or `CAP_SYS_ADMIN`.
+#[cfg(feature = "bpf")]
+pub fn probe_ringbuf() -> Result<TransportMode, ProbeError> {
+    use libbpf_rs::MapType;
+
+    // Attempt to create a minimal ringbuf map. Page-size is the minimum.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
+    let opts = libbpf_rs::MapBuilder::new()
+        .map_type(MapType::RingBuf)
+        .max_entries(page_size);
+
+    match opts.create() {
+        Ok(_map) => Ok(TransportMode::RingBuf), // fd closed on drop
+        Err(_) => Ok(TransportMode::PerfArray),
+    }
+}
+
+/// Stub for environments without `libbpf-rs`. Always returns `PerfArray`.
+#[cfg(not(feature = "bpf"))]
+#[allow(clippy::unnecessary_wraps)]
+pub fn probe_ringbuf() -> Result<TransportMode, ProbeError> {
+    Ok(TransportMode::PerfArray)
+}
+
+/// Probe whether the `bpf_loop` helper is available (kernel 5.17+).
+///
+/// Uses `libbpf_probe_bpf_helper` to check `BPF_FUNC_loop` availability
+/// for `BPF_PROG_TYPE_TRACEPOINT` programs.
+#[cfg(feature = "bpf")]
+pub fn probe_bpf_loop() -> Result<bool, ProbeError> {
+    // libbpf_probe_bpf_helper(BPF_PROG_TYPE_TRACEPOINT, BPF_FUNC_loop, NULL)
+    // libbpf-rs exposes this via libbpf_sys.
+    let ret = unsafe {
+        libbpf_sys::libbpf_probe_bpf_helper(
+            libbpf_sys::BPF_PROG_TYPE_TRACEPOINT,
+            libbpf_sys::BPF_FUNC_loop,
+            std::ptr::null(),
+        )
+    };
+    match ret {
+        1 => Ok(true),  // supported
+        0 => Ok(false), // not supported
+        neg => Err(ProbeError::Syscall(format!(
+            "libbpf_probe_bpf_helper returned {neg}"
+        ))),
+    }
+}
+
+/// Stub for environments without `libbpf-rs`. Always returns `false`.
+#[cfg(not(feature = "bpf"))]
+#[allow(clippy::unnecessary_wraps)]
+pub fn probe_bpf_loop() -> Result<bool, ProbeError> {
+    Ok(false)
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3: Attach-based probes (require minimal BPF program loading)
+// ---------------------------------------------------------------------------
+
+/// Probe whether `tp_btf` attachment is supported for scheduler tracepoints.
+///
+/// Requires loading a minimal BPF program that attaches to `tp_btf/sched_switch`.
+/// Falls back to `RawTp` if the attach fails.
+///
+/// Full implementation depends on skeleton infrastructure from task #5.
+#[cfg(feature = "bpf")]
+pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
+    // TODO(probe): Implement minimal tp_btf attach test once skeleton infra lands.
+    // For now, attempt detection via BTF type existence as a proxy:
+    // if /sys/kernel/btf/vmlinux exists and kernel >= 5.5, tp_btf is likely available.
+    // The real test will use an actual attach attempt.
+    Ok(TracepointMode::RawTp)
+}
+
+/// Stub without `libbpf-rs`. Always returns `RawTp`.
+#[cfg(not(feature = "bpf"))]
+#[allow(clippy::unnecessary_wraps)]
+pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
+    Ok(TracepointMode::RawTp)
+}
+
+/// Probe whether `fentry` attachment is supported.
+///
+/// Requires loading a minimal BPF program that attaches via fentry.
+/// Full implementation depends on skeleton infrastructure from task #5.
+#[cfg(feature = "bpf")]
+pub fn probe_fentry() -> Result<bool, ProbeError> {
+    // TODO(probe): Implement minimal fentry attach test once skeleton infra lands.
+    Ok(false)
+}
+
+/// Stub without `libbpf-rs`. Always returns `false`.
+#[cfg(not(feature = "bpf"))]
+#[allow(clippy::unnecessary_wraps)]
+pub fn probe_fentry() -> Result<bool, ProbeError> {
+    Ok(false)
+}
+
+// ---------------------------------------------------------------------------
+// Composite: Run all probes and build the FeatureMatrix
+// ---------------------------------------------------------------------------
+
+/// Run the full feature probing sequence and return a `FeatureMatrix`.
+///
+/// This is the main entry point, called once at startup between skeleton
+/// `open()` and `load()`.
+///
+/// # Errors
+///
+/// Returns `ProbeError::BtfRequired` if BTF is not available (hard requirement).
+/// Other probe failures result in degraded features, not errors.
+pub fn probe_all(paths: &ProbePaths<'_>) -> Result<FeatureMatrix, ProbeError> {
+    // BTF is a hard requirement — fail fast.
+    probe_btf(paths)?;
+
+    let transport = probe_ringbuf().unwrap_or(TransportMode::PerfArray);
+    let tracepoint = probe_tp_btf().unwrap_or(TracepointMode::RawTp);
+    let has_bpf_loop = probe_bpf_loop().unwrap_or(false);
+    let has_cgroupv2 = probe_cgroupv2(paths);
+    let has_fentry = probe_fentry().unwrap_or(false);
+
+    Ok(FeatureMatrix {
+        transport,
+        tracepoint,
+        has_btf: true, // we passed the BTF check above
+        has_bpf_loop,
+        has_cgroupv2,
+        has_fentry,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir()
+                .join(format!("wperf_probe_test_{name}_{}", std::process::id()));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn test_paths(dir: &Path) -> ProbePaths<'_> {
+        // We can't easily return ProbePaths with references to owned PathBufs,
+        // so we use leaked strings for test convenience. Tests are short-lived.
+        // Instead, create the files at known subpaths and use a helper.
+        ProbePaths {
+            btf_vmlinux: dir.join("btf_vmlinux").leak(),
+            cgroup_controllers: dir.join("cgroup_controllers").leak(),
+            tracing_events: dir.join("events").leak(),
+            kprobe_blacklist: dir.join("kprobe_blacklist").leak(),
+            available_filter_functions: dir.join("available_filter_functions").leak(),
+        }
+    }
+
+    // -- Tier 1: BTF --
+
+    #[test]
+    fn btf_present() {
+        let dir = TempDir::new("btf_present");
+        fs::write(dir.path().join("btf_vmlinux"), b"").unwrap();
+        let paths = test_paths(dir.path());
+        assert!(probe_btf(&paths).is_ok());
+    }
+
+    #[test]
+    fn btf_missing_returns_error() {
+        let dir = TempDir::new("btf_missing");
+        let paths = test_paths(dir.path());
+        let err = probe_btf(&paths).unwrap_err();
+        assert!(matches!(err, ProbeError::BtfRequired));
+    }
+
+    // -- Tier 1: cgroupv2 --
+
+    #[test]
+    fn cgroupv2_present() {
+        let dir = TempDir::new("cgroup_present");
+        fs::write(dir.path().join("cgroup_controllers"), b"cpu memory").unwrap();
+        let paths = test_paths(dir.path());
+        assert!(probe_cgroupv2(&paths));
+    }
+
+    #[test]
+    fn cgroupv2_missing() {
+        let dir = TempDir::new("cgroup_missing");
+        let paths = test_paths(dir.path());
+        assert!(!probe_cgroupv2(&paths));
+    }
+
+    // -- Tier 1: tracepoint --
+
+    #[test]
+    fn tracepoint_exists() {
+        let dir = TempDir::new("tp_exists");
+        let tp_dir = dir.path().join("events").join("sched").join("sched_switch");
+        fs::create_dir_all(&tp_dir).unwrap();
+        let paths = test_paths(dir.path());
+        assert!(probe_tracepoint(&paths, "sched", "sched_switch"));
+    }
+
+    #[test]
+    fn tracepoint_missing() {
+        let dir = TempDir::new("tp_missing");
+        fs::create_dir_all(dir.path().join("events")).unwrap();
+        let paths = test_paths(dir.path());
+        assert!(!probe_tracepoint(&paths, "sched", "sched_switch"));
+    }
+
+    // -- Tier 1: kprobe --
+
+    #[test]
+    fn kprobe_available() {
+        let dir = TempDir::new("kprobe_avail");
+        fs::write(
+            dir.path().join("available_filter_functions"),
+            "do_sys_open\nvfs_read\nvfs_write\n",
+        )
+        .unwrap();
+        let paths = test_paths(dir.path());
+        assert!(probe_kprobe(&paths, "vfs_read").unwrap());
+    }
+
+    #[test]
+    fn kprobe_blacklisted() {
+        let dir = TempDir::new("kprobe_blacklist");
+        fs::write(dir.path().join("available_filter_functions"), "vfs_read\n").unwrap();
+        fs::write(
+            dir.path().join("kprobe_blacklist"),
+            "0xffffffff81234567\tvfs_read\n",
+        )
+        .unwrap();
+        let paths = test_paths(dir.path());
+        assert!(!probe_kprobe(&paths, "vfs_read").unwrap());
+    }
+
+    #[test]
+    fn kprobe_not_in_available() {
+        let dir = TempDir::new("kprobe_notfound");
+        fs::write(
+            dir.path().join("available_filter_functions"),
+            "do_sys_open\nvfs_write\n",
+        )
+        .unwrap();
+        let paths = test_paths(dir.path());
+        assert!(!probe_kprobe(&paths, "vfs_read").unwrap());
+    }
+
+    #[test]
+    fn kprobe_no_files_returns_false() {
+        let dir = TempDir::new("kprobe_nofiles");
+        let paths = test_paths(dir.path());
+        // Both files missing — should return false, not error.
+        assert!(!probe_kprobe(&paths, "vfs_read").unwrap());
+    }
+
+    // -- Tier 2 stubs (no bpf feature) --
+
+    #[test]
+    fn ringbuf_stub_returns_perfarray() {
+        let result = probe_ringbuf().unwrap();
+        assert_eq!(result, TransportMode::PerfArray);
+    }
+
+    #[test]
+    fn bpf_loop_stub_returns_false() {
+        assert!(!probe_bpf_loop().unwrap());
+    }
+
+    // -- Tier 3 stubs --
+
+    #[test]
+    fn tp_btf_stub_returns_raw_tp() {
+        let result = probe_tp_btf().unwrap();
+        assert_eq!(result, TracepointMode::RawTp);
+    }
+
+    #[test]
+    fn fentry_stub_returns_false() {
+        assert!(!probe_fentry().unwrap());
+    }
+
+    // -- Composite: probe_all --
+
+    #[test]
+    fn probe_all_with_btf_succeeds() {
+        let dir = TempDir::new("probe_all_ok");
+        fs::write(dir.path().join("btf_vmlinux"), b"").unwrap();
+        fs::write(dir.path().join("cgroup_controllers"), b"cpu memory").unwrap();
+        fs::create_dir_all(dir.path().join("events")).unwrap();
+        let paths = test_paths(dir.path());
+
+        let matrix = probe_all(&paths).unwrap();
+        assert!(matrix.has_btf);
+        assert!(matrix.has_cgroupv2);
+        // Stubs: no bpf feature compiled
+        assert_eq!(matrix.transport, TransportMode::PerfArray);
+        assert_eq!(matrix.tracepoint, TracepointMode::RawTp);
+        assert!(!matrix.has_bpf_loop);
+        assert!(!matrix.has_fentry);
+    }
+
+    #[test]
+    fn probe_all_without_btf_fails() {
+        let dir = TempDir::new("probe_all_nobtf");
+        let paths = test_paths(dir.path());
+
+        let err = probe_all(&paths).unwrap_err();
+        assert!(matches!(err, ProbeError::BtfRequired));
+    }
+
+    // -- Display --
+
+    #[test]
+    fn error_display() {
+        let err = ProbeError::BtfRequired;
+        let msg = err.to_string();
+        assert!(msg.contains("BTF not available"));
+        assert!(msg.contains("RHEL 8.2+"));
+    }
+}

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -197,12 +197,13 @@ pub fn probe_ringbuf() -> Result<TransportMode, ProbeError> {
     use libbpf_rs::MapType;
 
     // Attempt to create a minimal ringbuf map. Page-size is the minimum.
-    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
-    let opts = libbpf_rs::MapBuilder::new()
-        .map_type(MapType::RingBuf)
-        .max_entries(page_size);
+    // Mirrors trace_helpers.c probe_ringbuf(): bpf_map_create(RINGBUF, NULL, 0, 0, page_size, NULL)
+    let page_size_raw = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    let page_size = u32::try_from(page_size_raw).unwrap_or(4096);
+    let mut opts: libbpf_sys::bpf_map_create_opts = unsafe { std::mem::zeroed() };
+    opts.sz = std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t;
 
-    match opts.create() {
+    match libbpf_rs::MapHandle::create(MapType::RingBuf, None::<&str>, 0, 0, page_size, &opts) {
         Ok(_map) => Ok(TransportMode::RingBuf), // fd closed on drop
         Err(_) => Ok(TransportMode::PerfArray),
     }
@@ -301,16 +302,31 @@ pub fn probe_fentry() -> Result<bool, ProbeError> {
 /// # Errors
 ///
 /// Returns `ProbeError::BtfRequired` if BTF is not available (hard requirement).
-/// Other probe failures result in degraded features, not errors.
+/// Other probe failures degrade gracefully to the fallback value, with a
+/// diagnostic printed to stderr. This is intentional: a probe that fails
+/// unexpectedly (e.g., `EPERM` on `bpf_map_create`) is treated the same as
+/// "feature not available" — the tool still runs, just with reduced capabilities.
 pub fn probe_all(paths: &ProbePaths<'_>) -> Result<FeatureMatrix, ProbeError> {
     // BTF is a hard requirement — fail fast.
     probe_btf(paths)?;
 
-    let transport = probe_ringbuf().unwrap_or(TransportMode::PerfArray);
-    let tracepoint = probe_tp_btf().unwrap_or(TracepointMode::RawTp);
-    let has_bpf_loop = probe_bpf_loop().unwrap_or(false);
+    let transport = probe_ringbuf().unwrap_or_else(|e| {
+        eprintln!("probe: ringbuf probe failed ({e}), falling back to perfarray");
+        TransportMode::PerfArray
+    });
+    let tracepoint = probe_tp_btf().unwrap_or_else(|e| {
+        eprintln!("probe: tp_btf probe failed ({e}), falling back to raw_tp");
+        TracepointMode::RawTp
+    });
+    let has_bpf_loop = probe_bpf_loop().unwrap_or_else(|e| {
+        eprintln!("probe: bpf_loop probe failed ({e}), assuming unavailable");
+        false
+    });
     let has_cgroupv2 = probe_cgroupv2(paths);
-    let has_fentry = probe_fentry().unwrap_or(false);
+    let has_fentry = probe_fentry().unwrap_or_else(|e| {
+        eprintln!("probe: fentry probe failed ({e}), assuming unavailable");
+        false
+    });
 
     Ok(FeatureMatrix {
         transport,

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -1,0 +1,7 @@
+mod features;
+
+pub use features::{
+    FeatureMatrix, ProbeError, ProbePaths, TracepointMode, TransportMode, probe_all,
+    probe_bpf_loop, probe_btf, probe_cgroupv2, probe_fentry, probe_kprobe, probe_ringbuf,
+    probe_tp_btf, probe_tracepoint,
+};


### PR DESCRIPTION
## Summary

- Implement ADR-002 per-feature probing matrix as `src/probe/` module
- **Tier 1** (filesystem checks, zero deps): `probe_btf`, `probe_cgroupv2`, `probe_tracepoint`, `probe_kprobe`
- **Tier 2** (syscall-level, behind `cfg(feature = "bpf")`): `probe_ringbuf` via `bpf_map_create`, `probe_bpf_loop` via `libbpf_probe_bpf_helper`
- **Tier 3** (attach-based, stubbed pending #5 skeleton infra): `probe_tp_btf`, `probe_fentry`
- `FeatureMatrix` struct consumed by future `open() → reconfigure → load()` step
- `ProbePaths` struct injects sysfs/tracefs paths for testability without real `/sys`
- BTF fail-fast: `probe_btf` returns `Err(BtfRequired)` per ADR-002-supplement Phase 1 decision
- Added optional `bpf` feature in `Cargo.toml` gating `libbpf-rs`/`libbpf-sys`/`libc` deps
- 17 new unit tests covering all tiers (temp-dir path injection for Tier 1, stub validation for Tier 2/3)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — pedantic clean
- [x] `cargo test` — 128 tests pass (111 existing + 17 new)
- [ ] CI: Check + Clippy + Test + Fmt
- [ ] Reviewer: verify Tier 2 `#[cfg(feature = "bpf")]` code compiles with `cargo check --features bpf` (requires libbpf-rs build deps)

## Dependencies

- Depends on task #5 (W1 #5 BPF probe architecture) for skeleton wiring — Tier 3 stubs will be filled once skeleton lands
- No runtime dependency on any other W1 task

🤖 Generated with [Claude Code](https://claude.com/claude-code)