### PR TITLE
infra: lessons registry, CI bpf validation, PR review checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+<!-- 1-3 bullet points describing the change -->
+
+## Dependency Checklist
+<!-- Required when adding or modifying direct dependencies -->
+- [ ] New/modified dependency versions are aligned with baseline in `docs/lessons/REGISTRY.md`
+- [ ] If deviating from baseline, rationale is documented in this PR description
+- [ ] If introducing a new Cargo feature, CI validates both default and feature-on builds
+
+## Test Plan
+<!-- How was this tested? -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install BPF build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libelf-dev zlib1g-dev
+
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.94.0
@@ -31,6 +34,12 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo check (bpf feature)
+        run: cargo check --features bpf
+
+      - name: cargo clippy (bpf feature)
+        run: cargo clippy --all-targets --features bpf -- -D warnings
 
       - name: cargo test
         run: cargo test

--- a/docs/lessons/L-001-bpf-dep-baseline.md
+++ b/docs/lessons/L-001-bpf-dep-baseline.md
@@ -1,0 +1,31 @@
+---
+id: L-001
+source: Gate 0
+applies_to: Phase 1+
+status: active
+---
+
+# L-001: BPF Userspace Dependency Baseline
+
+## What we learned
+
+Gate 0 prototype validated `libbpf-rs 0.26.1` with `libbpf-sys 1.7.0`. The 0.26.x API
+surface differs significantly from earlier versions (0.24 and below): skeleton open requires
+`MaybeUninit<OpenObject>`, map operations use `MapHandle::create()` (not `MapBuilder`),
+and trait imports (`SkelBuilder`, `OpenSkel`, `Skel`, `MapCore`) are explicit.
+
+During Phase 1 W1, `libbpf-rs 0.24` was mistakenly selected without cross-referencing
+Gate 0 signoff, causing a compile failure on the `bpf` feature path.
+
+## Contract
+
+- Phase 1 BPF userspace dependencies MUST be pinned to Gate 0 validated versions:
+  - `libbpf-rs = "0.26"` (resolves to 0.26.1)
+  - `libbpf-sys = "1.7"`
+- Any deviation requires an explicit ADR or team sign-off with rationale.
+
+## Verification
+
+- `Cargo.toml` pins are the source of truth.
+- CI runs `cargo check --features bpf` and `cargo clippy --all-targets --features bpf -- -D warnings`.
+- PR review checklist requires baseline cross-check when BPF dependencies are added or modified.

--- a/docs/lessons/L-002-libbpf-api-patterns.md
+++ b/docs/lessons/L-002-libbpf-api-patterns.md
@@ -1,0 +1,32 @@
+---
+id: L-002
+source: Gate 0
+applies_to: Phase 1+
+status: active
+---
+
+# L-002: libbpf-rs 0.26 API Patterns
+
+## What we learned
+
+Gate 0 prototype documented several libbpf-rs 0.26.1 API patterns that differ from
+documentation examples or older versions:
+
+1. **Skeleton open**: requires `MaybeUninit<OpenObject>` — not a simple `::open()`.
+2. **Trait imports**: `SkelBuilder`, `OpenSkel`, `Skel`, `MapCore` must be explicitly imported.
+3. **Packed struct fields**: copy field to local variable before formatting (`format!`),
+   otherwise Rust's reference rules conflict with packed repr.
+4. **`RingBufferBuilder`**: requires mutable binding before `.build()`.
+5. **Map creation**: use `MapHandle::create()`, not `MapBuilder` (which does not exist).
+
+## Contract
+
+When writing code against `libbpf-rs 0.26.x`:
+- Follow the patterns documented in `docs/gate0/ebpf-prototype.md` §5-6.
+- Do not assume API compatibility with older versions or generic examples.
+
+## Verification
+
+- Code review: reviewer should cross-check libbpf-rs API usage against this lesson
+  and Gate 0 prototype notes when reviewing BPF-facing code.
+- `cargo check --features bpf` catches compile-time mismatches.

--- a/docs/lessons/L-003-feature-on-ci.md
+++ b/docs/lessons/L-003-feature-on-ci.md
@@ -1,0 +1,27 @@
+---
+id: L-003
+source: Phase 1 W1
+applies_to: Phase 1+
+status: active
+---
+
+# L-003: Feature-Gated Code Must Have CI Validation
+
+## What we learned
+
+PR #77 introduced an optional `bpf` feature with `cfg(feature = "bpf")` gated code.
+The default build passed CI, but `cargo check --features bpf` failed due to a
+nonexistent API (`MapBuilder`). This was only caught during manual reviewer verification,
+not by CI.
+
+## Contract
+
+When a PR introduces or modifies a Cargo feature:
+- CI MUST validate both the default build AND the feature-on build.
+- At minimum: `cargo check --features <feature>` and `cargo clippy --all-targets --features <feature> -- -D warnings`.
+
+## Verification
+
+- `.github/workflows/ci.yml` includes `cargo check --features bpf` and
+  `cargo clippy --all-targets --features bpf -- -D warnings` steps.
+- PR review checklist: if a new feature is introduced, verify CI covers it.

--- a/docs/lessons/L-004-dep-baseline-review.md
+++ b/docs/lessons/L-004-dep-baseline-review.md
@@ -1,0 +1,28 @@
+---
+id: L-004
+source: Phase 1 W1
+applies_to: Phase 1+
+status: active
+---
+
+# L-004: Dependency Changes Require Baseline Cross-Check
+
+## What we learned
+
+Gate 0 signoff documented `libbpf-rs 0.26.1` as the validated baseline, but this was
+recorded as a historical observation, not an authoritative contract. When PR #77
+introduced `libbpf-rs 0.24`, neither the author nor three reviewers caught the
+mismatch — review focused on API correctness and code logic, not version alignment.
+
+## Contract
+
+When a PR adds or modifies a direct dependency (especially BPF/toolchain/FFI crates):
+1. Author MUST cross-check the version against the toolchain baseline in `docs/lessons/REGISTRY.md`.
+2. If the version deviates from baseline, the PR description MUST include a rationale.
+3. Reviewer MUST verify dependency versions against baseline as a checklist item.
+
+## Verification
+
+- PR template includes a dependency baseline checklist item.
+- Review checklist: "If this PR adds/modifies dependencies, are versions aligned with
+  the baseline in `docs/lessons/REGISTRY.md`?"

--- a/docs/lessons/REGISTRY.md
+++ b/docs/lessons/REGISTRY.md
@@ -1,0 +1,35 @@
+# Lessons Registry
+
+Cumulative lessons promoted from phase signoffs. Each lesson is classified as:
+
+- **Contract**: must be inherited by subsequent phases unless explicitly superseded
+- **Enforcement**: automated via CI, tooling, or checklist
+- **Observation**: historical context, not binding
+
+## Active Contracts
+
+| ID | Source | Title | Enforcement |
+|----|--------|-------|-------------|
+| L-001 | Gate 0 | [BPF userspace dependency baseline](L-001-bpf-dep-baseline.md) | CI `--features bpf`, Cargo.toml pin |
+| L-002 | Gate 0 | [libbpf-rs 0.26 API patterns](L-002-libbpf-api-patterns.md) | Review checklist |
+| L-003 | Phase 1 W1 | [Feature-gated code must have CI validation](L-003-feature-on-ci.md) | CI `cargo check --features bpf` |
+| L-004 | Phase 1 W1 | [Dependency changes require baseline cross-check](L-004-dep-baseline-review.md) | PR checklist |
+
+## Phase 1 Toolchain Baseline
+
+Authoritative baseline for Phase 1. Deviations require ADR or explicit team sign-off.
+
+| Component | Version | Source |
+|-----------|---------|--------|
+| Rust | 1.94.0 | `rust-toolchain.toml` |
+| `libbpf-rs` | 0.26.x (resolves to 0.26.1) | Gate 0 signoff |
+| `libbpf-sys` | 1.7.x | Gate 0 signoff |
+| `clang` | 22.1 | Gate 0 signoff (enforced when #5 lands) |
+| `libc` | 0.2.x (stable) | — |
+
+## Carry-Forward Rules
+
+1. Each Phase closeout must produce a "Promoted Lessons" section classifying new lessons as Contract / Enforcement / Observation.
+2. Next Phase kickoff imports all active Contracts into its plan.
+3. Machine-checkable constraints go into CI/tooling, not just docs.
+4. Non-automatable lessons go into the review checklist.


### PR DESCRIPTION
## Summary
- Establishes a **phase carry-forward mechanism** (`docs/lessons/`) to prevent Gate 0 validated baselines from silently drifting — root cause of the `libbpf-rs 0.24` vs `0.26.1` incident in PR #77
- **4 promoted lessons** (L-001 through L-004): BPF dep baseline, libbpf-rs API patterns, feature-on CI requirement, dependency review checklist
- **CI**: adds `cargo check --features bpf` + `cargo clippy --features bpf` steps with `libelf-dev`/`zlib1g-dev` build deps
- **PR template**: adds dependency baseline checklist so reviewers have a hard gate on version alignment

## Dependency Checklist
- [x] No new dependencies added
- [x] N/A — infrastructure/docs only

## Test Plan
- [ ] CI `cargo check --features bpf` step passes (requires PR #77 to be merged first for the `bpf` feature to exist, OR this PR merges first and #77 rebases)
- [ ] CI default build continues to pass
- [ ] Review: lessons content aligns with team discussion in `#p1-dev:65c931fc`