### PR TITLE
fix(probe): use tracefs path for available_filter_functions

### DIFF
--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -110,9 +110,7 @@ impl Default for ProbePaths<'_> {
             cgroup_controllers: Path::new("/sys/fs/cgroup/cgroup.controllers"),
             tracing_events: Path::new("/sys/kernel/tracing/events"),
             kprobe_blacklist: Path::new("/sys/kernel/debug/kprobes/blacklist"),
-            available_filter_functions: Path::new(
-                "/sys/kernel/debug/tracing/available_filter_functions",
-            ),
+            available_filter_functions: Path::new("/sys/kernel/tracing/available_filter_functions"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Change `available_filter_functions` default path from `/sys/kernel/debug/tracing/` to `/sys/kernel/tracing/` for consistency with `tracing_events` and to avoid `debugfs` mount dependency
- Adopted from Gemini code review comment on PR #77

## Dependency Checklist
- [x] No new dependencies
- [x] N/A — no deviation from baseline
- [x] N/A — no new Cargo feature

## Test Plan
- `cargo clippy --all-targets --features bpf -- -D warnings` passes
- `cargo test -- probe` passes
- Path change is cosmetic for test suite (tests use injected paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)