### PR TITLE
ci: add supply-chain job (cargo-deny + cargo-audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "phase*/*", "fix/*"]
+    branches: [main, "phase*/*", "fix/*", "infra/*"]
   pull_request:
     branches: [main]
 
@@ -49,6 +49,27 @@ jobs:
 
       - name: differential (Rust vs Python)
         run: cargo test --test differential
+
+  supply-chain:
+    name: Supply Chain (cargo-deny + cargo-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: cargo audit
+        run: cargo audit
 
   mutants:
     name: Mutation Testing (≥90% kill rate)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wperf"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [features]
 bpf = ["libbpf-rs", "libbpf-sys", "libc"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+]
+all-features = true
+
+# Advisory database — check for known vulnerabilities
+[advisories]
+# Uses default RustSec advisory-db
+
+# License policy — only permissive licenses allowed
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "BSL-1.0",
+    "ISC",
+]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = true
+
+# Ban policy
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+# Source policy
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
- Adds `deny.toml` with license allow-list, advisory checks, strict source policy, and ban rules
- Adds `supply-chain` CI job running `cargo-deny` (via EmbarkStudios/cargo-deny-action@v2) and `cargo-audit`
- Adds `publish = false` to Cargo.toml so cargo-deny's `licenses.private.ignore` applies to our workspace crate

Closes C1 (`#p1-infra` task #1: "CI: 接入 cargo-deny + cargo-audit")

## Verified locally
- `cargo deny check` — all 4 checks pass (advisories, bans, licenses, sources)
- `cargo audit` — 0 vulnerabilities found

## Test plan
- [ ] CI `supply-chain` job passes on this PR
- [ ] Existing `check` and `mutants` jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)