### PR TITLE
bench: add iai-callgrind instruction-count benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,15 @@ serde_json = "1"
 
 [dev-dependencies]
 criterion = { version = "0.6", features = ["html_reports"] }
+iai-callgrind = "0.16"
 proptest = "1.11"
 
 [[bench]]
 name = "cascade"
+harness = false
+
+[[bench]]
+name = "cascade_iai"
 harness = false
 
 [lints.clippy]

--- a/benches/cascade_iai.rs
+++ b/benches/cascade_iai.rs
@@ -1,0 +1,68 @@
+//! iai-callgrind benchmarks for the cascade redistribution engine.
+//!
+//! Instruction-count benchmarks — deterministic, no noise from CI.
+//! Requires valgrind + iai-callgrind-runner.
+
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use wperf::cascade::engine::cascade_engine;
+use wperf::graph::types::{NodeKind, ThreadId, TimeWindow};
+use wperf::graph::wfg::WaitForGraph;
+
+fn build_chain(n: i64) -> WaitForGraph {
+    let mut g = WaitForGraph::new();
+    for i in 0..n {
+        g.add_node(ThreadId(i), NodeKind::UserThread);
+    }
+    for i in 0..n - 1 {
+        g.add_edge(ThreadId(i), ThreadId(i + 1), TimeWindow::new(0, 100));
+    }
+    g
+}
+
+fn build_fan_out(n: i64) -> WaitForGraph {
+    let mut g = WaitForGraph::new();
+    for i in 0..n {
+        g.add_node(ThreadId(i), NodeKind::UserThread);
+    }
+    for i in 1..n {
+        g.add_edge(ThreadId(0), ThreadId(i), TimeWindow::new(0, 100));
+    }
+    g
+}
+
+fn setup_chain_16() -> WaitForGraph {
+    build_chain(16)
+}
+
+fn setup_chain_64() -> WaitForGraph {
+    build_chain(64)
+}
+
+fn setup_fan_out_16() -> WaitForGraph {
+    build_fan_out(16)
+}
+
+fn setup_fan_out_64() -> WaitForGraph {
+    build_fan_out(64)
+}
+
+#[library_benchmark]
+#[bench::chain_16(setup_chain_16())]
+#[bench::chain_64(setup_chain_64())]
+fn bench_cascade_chain(g: WaitForGraph) {
+    let _ = cascade_engine(&g, None);
+}
+
+#[library_benchmark]
+#[bench::fan_out_16(setup_fan_out_16())]
+#[bench::fan_out_64(setup_fan_out_64())]
+fn bench_cascade_fan_out(g: WaitForGraph) {
+    let _ = cascade_engine(&g, None);
+}
+
+library_benchmark_group!(
+    name = cascade_iai;
+    benchmarks = bench_cascade_chain, bench_cascade_fan_out
+);
+
+main!(library_benchmark_groups = cascade_iai);

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,9 @@ all-features = true
 # Advisory database — check for known vulnerabilities
 [advisories]
 # Uses default RustSec advisory-db
+# bincode 1.3.3 is unmaintained (RUSTSEC-2025-0141) but only used as a
+# transitive dev-dependency of iai-callgrind. No security impact.
+ignore = ["RUSTSEC-2025-0141"]
 
 # License policy — only permissive licenses allowed
 [licenses]


### PR DESCRIPTION
## Summary
- Adds `iai-callgrind` (v0.16) as dev-dependency
- Creates `benches/cascade_iai.rs` with 4 instruction-count benchmarks:
  - **chain** 16 and 64 nodes
  - **fan_out** 16 and 64 nodes
- Instruction counts are deterministic — no CI noise, suitable for regression detection
- Adds `RUSTSEC-2025-0141` ignore in `deny.toml` (unmaintained bincode, transitive dev-dep of iai-callgrind only)

Completes the iai-callgrind half of C3 (`#p1-infra` task #3)

## Verified locally
- `cargo bench --bench cascade_iai` — 4 benchmarks pass in 0.42s
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo deny check` — clean (advisory ignored)

## Baseline numbers (local)
| Benchmark | Instructions | Est. Cycles |
|-----------|-------------|-------------|
| chain/16  | 244K        | 361K        |
| chain/64  | 1.4M        | 2.0M        |
| fan_out/16 | 25K        | 40K         |
| fan_out/64 | 115K       | 164K        |

## Test plan
- [ ] CI passes (compile check includes new bench)
- [ ] Existing jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)