### PR TITLE
ci: pin action refs to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,17 @@ jobs:
     name: Check + Clippy + Test + Fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # 34e11487
 
       - name: Install BPF build dependencies
         run: sudo apt-get update && sudo apt-get install -y libelf-dev zlib1g-dev
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
         with:
           toolchain: 1.94.0
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2 # 42dc69e1
 
       - name: cargo fmt
         run: cargo fmt --check
@@ -57,14 +57,14 @@ jobs:
     name: Coverage (cargo-llvm-cov)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
         with:
           toolchain: 1.94.0
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2 # 42dc69e1
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -73,7 +73,7 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4 # ea165f8d
         with:
           name: coverage-report
           path: lcov.info
@@ -85,16 +85,16 @@ jobs:
     name: Supply Chain (cargo-deny + cargo-audit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # 34e11487
 
       - name: cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@v2 # 82eb9f62
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
         with:
           toolchain: 1.94.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2 # 42dc69e1
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -106,13 +106,13 @@ jobs:
     name: Mutation Testing (≥90% kill rate)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
         with:
           toolchain: 1.94.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2 # 42dc69e1
 
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload mutation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4 # ea165f8d
         with:
           name: mutants-report
           path: mutants.out/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install BPF build dependencies
         run: sudo apt-get update && sudo apt-get install -y libelf-dev zlib1g-dev
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.94.0
           components: clippy, rustfmt
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.94.0
           components: llvm-tools-preview
@@ -90,7 +90,7 @@ jobs:
       - name: cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2 # 82eb9f62
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.94.0
 
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.94.0
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@5b842231 # nightly
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           components: rust-src
 
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.94.0
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,5 @@
+# Nightly CI — visibility and periodic deep checks only.
+# NOT a merge gate. Do not add to branch protection required checks.
 name: Nightly
 
 on:
@@ -17,13 +19,13 @@ jobs:
       matrix:
         sanitizer: [address, thread]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@5b842231 # nightly
         with:
           components: rust-src
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2 # 42dc69e1
         with:
           key: sanitizer-${{ matrix.sanitizer }}
 
@@ -39,13 +41,13 @@ jobs:
     name: Benchmark Regression (iai-callgrind)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # 34e11487
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea2 # master
         with:
           toolchain: 1.94.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2 # 42dc69e1
 
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind


### PR DESCRIPTION
## Summary
- Pins `dtolnay/rust-toolchain` to commit SHAs (`master`: `3c5f7ea2`, `nightly`: `5b842231`) — prevents silent action drift
- Other actions keep tag refs (`@v4`, `@v2`) with SHA comments for auditability
- Adds header comment to `nightly.yml`: "NOT a merge gate. Do not add to branch protection required checks."

Addresses the recurring non-blocking warning from Challenger/Critic across PRs #80-#84.

## Test plan
- [ ] CI passes with pinned refs
- [ ] Nightly workflow file has semantics comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)