### PR TITLE
feat(bpf): sched_switch + sched_wakeup tracepoint probes

### DIFF
--- a/scripts/sync-libbpf-compat.sh
+++ b/scripts/sync-libbpf-compat.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# sync-libbpf-compat.sh — Sync compat.bpf.h from bcc/libbpf-tools
+# sync-libbpf-compat.sh — Sync compat.bpf.h + core_fixes.bpf.h from bcc/libbpf-tools
 #
-# This script documents the provenance of src/bpf/compat.bpf.h.
-# The vendored file is NOT a verbatim copy — it is adapted for wPerf:
-#   - Map declarations are in wperf.bpf.c (wperf-specific types/sizes)
-#   - Drop counter instrumentation added to reserve_buf()
+# This script documents the provenance of vendored BPF headers:
+#   - src/bpf/compat.bpf.h  (reserve_buf/submit_buf transport abstraction)
+#   - src/bpf/core_fixes.bpf.h (CO-RE field rename fixes, e.g. state/__state)
 #
-# When updating, diff the upstream changes and manually apply relevant
-# fixes to src/bpf/compat.bpf.h.
+# Vendored files are NOT verbatim copies — they are adapted for wPerf.
+# When updating, diff the upstream changes and manually apply relevant fixes.
 #
 # Usage: ./scripts/sync-libbpf-compat.sh [bcc-repo-path]
 
@@ -16,7 +15,7 @@ set -euo pipefail
 # Resolve paths before any cd
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-VENDORED_FILE="$REPO_ROOT/src/bpf/compat.bpf.h"
+VENDORED_COMPAT="$REPO_ROOT/src/bpf/compat.bpf.h"
 
 BCC_REPO="${1:-/workspace/kernel/bcc}"
 UPSTREAM_FILE="$BCC_REPO/libbpf-tools/compat.bpf.h"
@@ -37,11 +36,27 @@ CURRENT_COMMIT=$(git log --format='%H' -1 -- libbpf-tools/compat.bpf.h)
 echo "Latest upstream commit: $CURRENT_COMMIT"
 echo ""
 
-echo "=== Diff: upstream vs vendored ==="
-diff -u "$UPSTREAM_FILE" "$VENDORED_FILE" || true
+echo "=== Diff: compat.bpf.h (upstream vs vendored) ==="
+diff -u "$UPSTREAM_FILE" "$VENDORED_COMPAT" || true
 echo ""
-echo "Review the diff above and manually apply any upstream fixes to:"
-echo "  $VENDORED_FILE"
+
+# core_fixes.bpf.h
+UPSTREAM_CORE="$BCC_REPO/libbpf-tools/core_fixes.bpf.h"
+VENDORED_CORE="$REPO_ROOT/src/bpf/core_fixes.bpf.h"
+
+if [[ -f "$UPSTREAM_CORE" ]]; then
+    echo "=== core_fixes.bpf.h provenance ==="
+    git log --oneline -3 -- libbpf-tools/core_fixes.bpf.h
+    CORE_COMMIT=$(git log --format='%H' -1 -- libbpf-tools/core_fixes.bpf.h)
+    echo "Latest upstream commit: $CORE_COMMIT"
+    echo ""
+    echo "=== Diff: core_fixes.bpf.h (upstream vs vendored) ==="
+    diff -u "$UPSTREAM_CORE" "$VENDORED_CORE" || true
+    echo ""
+fi
+
+echo "Review the diffs above and manually apply any upstream fixes to:"
+echo "  $VENDORED_COMPAT"
+echo "  $VENDORED_CORE"
 echo ""
-echo "Then update the 'Upstream commit' line in the file header to:"
-echo "  $CURRENT_COMMIT"
+echo "Then update the 'Upstream commit' lines in the file headers."

--- a/scripts/sync-libbpf-compat.sh
+++ b/scripts/sync-libbpf-compat.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# sync-libbpf-compat.sh — Sync compat.bpf.h from bcc/libbpf-tools
+#
+# This script documents the provenance of src/bpf/compat.bpf.h.
+# The vendored file is NOT a verbatim copy — it is adapted for wPerf:
+#   - Map declarations are in wperf.bpf.c (wperf-specific types/sizes)
+#   - Drop counter instrumentation added to reserve_buf()
+#
+# When updating, diff the upstream changes and manually apply relevant
+# fixes to src/bpf/compat.bpf.h.
+#
+# Usage: ./scripts/sync-libbpf-compat.sh [bcc-repo-path]
+
+set -euo pipefail
+
+BCC_REPO="${1:-/workspace/kernel/bcc}"
+UPSTREAM_FILE="$BCC_REPO/libbpf-tools/compat.bpf.h"
+
+if [[ ! -f "$UPSTREAM_FILE" ]]; then
+    echo "Error: $UPSTREAM_FILE not found"
+    echo "Usage: $0 [path-to-bcc-repo]"
+    exit 1
+fi
+
+# Show upstream provenance
+echo "=== Upstream provenance ==="
+cd "$BCC_REPO"
+git log --oneline -3 -- libbpf-tools/compat.bpf.h
+echo ""
+
+CURRENT_COMMIT=$(git log --format='%H' -1 -- libbpf-tools/compat.bpf.h)
+echo "Latest upstream commit: $CURRENT_COMMIT"
+echo ""
+
+# Show diff between upstream and our vendored version
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+VENDORED_FILE="$REPO_ROOT/src/bpf/compat.bpf.h"
+
+echo "=== Diff: upstream vs vendored ==="
+diff -u "$UPSTREAM_FILE" "$VENDORED_FILE" || true
+echo ""
+echo "Review the diff above and manually apply any upstream fixes to:"
+echo "  $VENDORED_FILE"
+echo ""
+echo "Then update the 'Upstream commit' line in the file header to:"
+echo "  $CURRENT_COMMIT"

--- a/scripts/sync-libbpf-compat.sh
+++ b/scripts/sync-libbpf-compat.sh
@@ -6,45 +6,75 @@
 #   - src/bpf/core_fixes.bpf.h (CO-RE field rename fixes, e.g. state/__state)
 #
 # Fetches directly from iovisor/bcc GitHub repo (no local clone needed).
+# By default, fetches at the pinned upstream commits recorded in the vendored
+# file headers. Pass --ref <sha-or-branch> to compare against a different ref.
+#
 # Vendored files are NOT verbatim copies — they are adapted for wPerf.
 # When updating, diff the upstream changes and manually apply relevant fixes.
 #
-# Usage: ./scripts/sync-libbpf-compat.sh [--apply]
-#   Without --apply: shows diffs only (dry run)
-#   With --apply: downloads upstream files to a temp dir for manual diffing
+# Usage: ./scripts/sync-libbpf-compat.sh [--ref <sha-or-branch>]
+#   Default: fetches at the pinned upstream commits from vendored file headers
+#   --ref master: compare against latest upstream HEAD
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-GITHUB_RAW="https://raw.githubusercontent.com/iovisor/bcc/master/libbpf-tools"
-GITHUB_LOG="https://api.github.com/repos/iovisor/bcc/commits"
-
 VENDORED_COMPAT="$REPO_ROOT/src/bpf/compat.bpf.h"
 VENDORED_CORE="$REPO_ROOT/src/bpf/core_fixes.bpf.h"
+
+# Pinned upstream commits — must match the "Upstream commit:" lines in vendored headers
+COMPAT_PIN="7f394c6d6775b9df68cac30b8147f9ab8a611ba7"
+CORE_PIN="82ad428c40cb270fda6c0de5a9914705c94dd4c7"
+
+# Parse args
+REF_OVERRIDE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ref)
+            REF_OVERRIDE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--ref <sha-or-branch>]"
+            exit 1
+            ;;
+    esac
+done
+
+COMPAT_REF="${REF_OVERRIDE:-$COMPAT_PIN}"
+CORE_REF="${REF_OVERRIDE:-$CORE_PIN}"
+
+GITHUB_RAW="https://raw.githubusercontent.com/iovisor/bcc"
+GITHUB_LOG="https://api.github.com/repos/iovisor/bcc/commits"
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Fetch upstream files
+# Fetch upstream files at pinned (or overridden) refs
 echo "=== Fetching upstream files from iovisor/bcc ==="
+echo "  compat.bpf.h    @ ${COMPAT_REF:0:12}"
+echo "  core_fixes.bpf.h @ ${CORE_REF:0:12}"
+echo ""
 
-curl -sfL "$GITHUB_RAW/compat.bpf.h" -o "$TMPDIR/compat.bpf.h" || {
-    echo "Error: failed to fetch compat.bpf.h from GitHub"
+curl -sfL "$GITHUB_RAW/$COMPAT_REF/libbpf-tools/compat.bpf.h" \
+    -o "$TMPDIR/compat.bpf.h" || {
+    echo "Error: failed to fetch compat.bpf.h at ref $COMPAT_REF"
     exit 1
 }
-echo "  Downloaded compat.bpf.h"
 
-curl -sfL "$GITHUB_RAW/core_fixes.bpf.h" -o "$TMPDIR/core_fixes.bpf.h" || {
-    echo "Error: failed to fetch core_fixes.bpf.h from GitHub"
+curl -sfL "$GITHUB_RAW/$CORE_REF/libbpf-tools/core_fixes.bpf.h" \
+    -o "$TMPDIR/core_fixes.bpf.h" || {
+    echo "Error: failed to fetch core_fixes.bpf.h at ref $CORE_REF"
     exit 1
 }
-echo "  Downloaded core_fixes.bpf.h"
+echo "  Downloaded both files"
 echo ""
 
 # Show upstream provenance via GitHub API
-echo "=== Upstream provenance ==="
+echo "=== Upstream provenance (recent commits) ==="
 echo "compat.bpf.h:"
 curl -sf "$GITHUB_LOG?path=libbpf-tools/compat.bpf.h&per_page=3" | \
     python3 -c "
@@ -68,16 +98,20 @@ for c in json.load(sys.stdin):
 echo ""
 
 # Show diffs
-echo "=== Diff: compat.bpf.h (upstream vs vendored) ==="
-diff -u "$TMPDIR/compat.bpf.h" "$VENDORED_COMPAT" || true
+echo "=== Diff: compat.bpf.h (upstream @ ${COMPAT_REF:0:12} vs vendored) ==="
+diff -u --label "upstream/compat.bpf.h" --label "vendored/compat.bpf.h" \
+    "$TMPDIR/compat.bpf.h" "$VENDORED_COMPAT" || true
 echo ""
 
-echo "=== Diff: core_fixes.bpf.h (upstream vs vendored) ==="
-diff -u "$TMPDIR/core_fixes.bpf.h" "$VENDORED_CORE" || true
+echo "=== Diff: core_fixes.bpf.h (upstream @ ${CORE_REF:0:12} vs vendored) ==="
+diff -u --label "upstream/core_fixes.bpf.h" --label "vendored/core_fixes.bpf.h" \
+    "$TMPDIR/core_fixes.bpf.h" "$VENDORED_CORE" || true
 echo ""
 
 echo "Review the diffs above and manually apply any upstream fixes to:"
 echo "  $VENDORED_COMPAT"
 echo "  $VENDORED_CORE"
 echo ""
-echo "Then update the 'Upstream commit' lines in the file headers."
+echo "To check against latest upstream: $0 --ref master"
+echo "Then update the 'Upstream commit' lines in the file headers and the"
+echo "pinned SHAs in this script (COMPAT_PIN / CORE_PIN)."

--- a/scripts/sync-libbpf-compat.sh
+++ b/scripts/sync-libbpf-compat.sh
@@ -13,6 +13,11 @@
 
 set -euo pipefail
 
+# Resolve paths before any cd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+VENDORED_FILE="$REPO_ROOT/src/bpf/compat.bpf.h"
+
 BCC_REPO="${1:-/workspace/kernel/bcc}"
 UPSTREAM_FILE="$BCC_REPO/libbpf-tools/compat.bpf.h"
 
@@ -31,11 +36,6 @@ echo ""
 CURRENT_COMMIT=$(git log --format='%H' -1 -- libbpf-tools/compat.bpf.h)
 echo "Latest upstream commit: $CURRENT_COMMIT"
 echo ""
-
-# Show diff between upstream and our vendored version
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-VENDORED_FILE="$REPO_ROOT/src/bpf/compat.bpf.h"
 
 echo "=== Diff: upstream vs vendored ==="
 diff -u "$UPSTREAM_FILE" "$VENDORED_FILE" || true

--- a/scripts/sync-libbpf-compat.sh
+++ b/scripts/sync-libbpf-compat.sh
@@ -5,55 +5,76 @@
 #   - src/bpf/compat.bpf.h  (reserve_buf/submit_buf transport abstraction)
 #   - src/bpf/core_fixes.bpf.h (CO-RE field rename fixes, e.g. state/__state)
 #
+# Fetches directly from iovisor/bcc GitHub repo (no local clone needed).
 # Vendored files are NOT verbatim copies — they are adapted for wPerf.
 # When updating, diff the upstream changes and manually apply relevant fixes.
 #
-# Usage: ./scripts/sync-libbpf-compat.sh [bcc-repo-path]
+# Usage: ./scripts/sync-libbpf-compat.sh [--apply]
+#   Without --apply: shows diffs only (dry run)
+#   With --apply: downloads upstream files to a temp dir for manual diffing
 
 set -euo pipefail
 
-# Resolve paths before any cd
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+GITHUB_RAW="https://raw.githubusercontent.com/iovisor/bcc/master/libbpf-tools"
+GITHUB_LOG="https://api.github.com/repos/iovisor/bcc/commits"
+
 VENDORED_COMPAT="$REPO_ROOT/src/bpf/compat.bpf.h"
-
-BCC_REPO="${1:-/workspace/kernel/bcc}"
-UPSTREAM_FILE="$BCC_REPO/libbpf-tools/compat.bpf.h"
-
-if [[ ! -f "$UPSTREAM_FILE" ]]; then
-    echo "Error: $UPSTREAM_FILE not found"
-    echo "Usage: $0 [path-to-bcc-repo]"
-    exit 1
-fi
-
-# Show upstream provenance
-echo "=== Upstream provenance ==="
-cd "$BCC_REPO"
-git log --oneline -3 -- libbpf-tools/compat.bpf.h
-echo ""
-
-CURRENT_COMMIT=$(git log --format='%H' -1 -- libbpf-tools/compat.bpf.h)
-echo "Latest upstream commit: $CURRENT_COMMIT"
-echo ""
-
-echo "=== Diff: compat.bpf.h (upstream vs vendored) ==="
-diff -u "$UPSTREAM_FILE" "$VENDORED_COMPAT" || true
-echo ""
-
-# core_fixes.bpf.h
-UPSTREAM_CORE="$BCC_REPO/libbpf-tools/core_fixes.bpf.h"
 VENDORED_CORE="$REPO_ROOT/src/bpf/core_fixes.bpf.h"
 
-if [[ -f "$UPSTREAM_CORE" ]]; then
-    echo "=== core_fixes.bpf.h provenance ==="
-    git log --oneline -3 -- libbpf-tools/core_fixes.bpf.h
-    CORE_COMMIT=$(git log --format='%H' -1 -- libbpf-tools/core_fixes.bpf.h)
-    echo "Latest upstream commit: $CORE_COMMIT"
-    echo ""
-    echo "=== Diff: core_fixes.bpf.h (upstream vs vendored) ==="
-    diff -u "$UPSTREAM_CORE" "$VENDORED_CORE" || true
-    echo ""
-fi
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fetch upstream files
+echo "=== Fetching upstream files from iovisor/bcc ==="
+
+curl -sfL "$GITHUB_RAW/compat.bpf.h" -o "$TMPDIR/compat.bpf.h" || {
+    echo "Error: failed to fetch compat.bpf.h from GitHub"
+    exit 1
+}
+echo "  Downloaded compat.bpf.h"
+
+curl -sfL "$GITHUB_RAW/core_fixes.bpf.h" -o "$TMPDIR/core_fixes.bpf.h" || {
+    echo "Error: failed to fetch core_fixes.bpf.h from GitHub"
+    exit 1
+}
+echo "  Downloaded core_fixes.bpf.h"
+echo ""
+
+# Show upstream provenance via GitHub API
+echo "=== Upstream provenance ==="
+echo "compat.bpf.h:"
+curl -sf "$GITHUB_LOG?path=libbpf-tools/compat.bpf.h&per_page=3" | \
+    python3 -c "
+import sys, json
+for c in json.load(sys.stdin):
+    sha = c['sha'][:12]
+    msg = c['commit']['message'].split('\n')[0][:72]
+    print(f'  {sha} {msg}')
+" 2>/dev/null || echo "  (could not fetch commit history — check network/rate limit)"
+echo ""
+
+echo "core_fixes.bpf.h:"
+curl -sf "$GITHUB_LOG?path=libbpf-tools/core_fixes.bpf.h&per_page=3" | \
+    python3 -c "
+import sys, json
+for c in json.load(sys.stdin):
+    sha = c['sha'][:12]
+    msg = c['commit']['message'].split('\n')[0][:72]
+    print(f'  {sha} {msg}')
+" 2>/dev/null || echo "  (could not fetch commit history — check network/rate limit)"
+echo ""
+
+# Show diffs
+echo "=== Diff: compat.bpf.h (upstream vs vendored) ==="
+diff -u "$TMPDIR/compat.bpf.h" "$VENDORED_COMPAT" || true
+echo ""
+
+echo "=== Diff: core_fixes.bpf.h (upstream vs vendored) ==="
+diff -u "$TMPDIR/core_fixes.bpf.h" "$VENDORED_CORE" || true
+echo ""
 
 echo "Review the diffs above and manually apply any upstream fixes to:"
 echo "  $VENDORED_COMPAT"

--- a/src/bpf/compat.bpf.h
+++ b/src/bpf/compat.bpf.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2022 Hengqi Chen */
+/*
+ * Vendored from bcc/libbpf-tools/compat.bpf.h
+ * Upstream commit: 7f394c6d6775b9df68cac30b8147f9ab8a611ba7
+ *                  "libbpf-tools: Add support for bpf_ringbuf"
+ * Source: https://github.com/iovisor/bcc/blob/master/libbpf-tools/compat.bpf.h
+ *
+ * Adapted for wPerf (ADR-004 / ADR-002-supplement):
+ *   - Map declarations moved to wperf.bpf.c (wperf-specific value type
+ *     and buffer sizing; upstream uses generic MAX_EVENT_SIZE/RINGBUF_SIZE)
+ *   - reserve_buf() and submit_buf() are kept verbatim from upstream,
+ *     referencing the same map names ("events", "heap")
+ *   - Drop counter added (not in upstream) — incremented on ringbuf
+ *     reserve failure for user-space observability
+ *
+ * To update, run: scripts/sync-libbpf-compat.sh
+ */
+
+#ifndef __COMPAT_BPF_H
+#define __COMPAT_BPF_H
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+/* Drop counter for ringbuf reserve failures (wperf extension).
+ * Read by user-space at end of recording. */
+extern __u64 drop_counter;
+
+/*
+ * reserve_buf() / submit_buf() — verbatim from upstream compat.bpf.h,
+ * with wperf drop_counter instrumentation on the ringbuf path.
+ *
+ * Uses bpf_core_type_exists(struct bpf_ringbuf) as a CO-RE load-time
+ * check to select ringbuf vs perfarray path. No runtime branching.
+ */
+static __always_inline void *reserve_buf(__u64 size)
+{
+	static const int zero = 0;
+
+	if (bpf_core_type_exists(struct bpf_ringbuf)) {
+		void *buf = bpf_ringbuf_reserve(&events, size, 0);
+
+		if (!buf)
+			__sync_fetch_and_add(&drop_counter, 1);
+		return buf;
+	}
+
+	return bpf_map_lookup_elem(&heap, &zero);
+}
+
+static __always_inline long submit_buf(void *ctx, void *buf, __u64 size)
+{
+	if (bpf_core_type_exists(struct bpf_ringbuf)) {
+		bpf_ringbuf_submit(buf, 0);
+		return 0;
+	}
+
+	return bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
+				     buf, size);
+}
+
+#endif /* __COMPAT_BPF_H */

--- a/src/bpf/core_fixes.bpf.h
+++ b/src/bpf/core_fixes.bpf.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2021 Hengqi Chen */
+/*
+ * Vendored from bcc/libbpf-tools/core_fixes.bpf.h
+ * Upstream commit: 82ad428c40cb270fda6c0de5a9914705c94dd4c7
+ * Source: https://github.com/iovisor/bcc/blob/master/libbpf-tools/core_fixes.bpf.h
+ *
+ * Only the task_struct state/\__state rename fix is included here.
+ * Other CO-RE fixes from upstream are not needed by wPerf.
+ *
+ * To update, run: scripts/sync-libbpf-compat.sh
+ */
+
+#ifndef __CORE_FIXES_BPF_H
+#define __CORE_FIXES_BPF_H
+
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+
+/**
+ * commit 2f064a59a1 ("sched: Change task_struct::state") changes
+ * the name of task_struct::state to task_struct::__state
+ * see:
+ *     https://github.com/torvalds/linux/commit/2f064a59a1
+ */
+struct task_struct___o {
+	volatile long int state;
+} __attribute__((preserve_access_index));
+
+struct task_struct___x {
+	unsigned int __state;
+} __attribute__((preserve_access_index));
+
+static __always_inline __s64 get_task_state(void *task)
+{
+	struct task_struct___x *t = task;
+
+	if (bpf_core_field_exists(t->__state))
+		return BPF_CORE_READ(t, __state);
+	return BPF_CORE_READ((struct task_struct___o *)task, state);
+}
+
+#endif /* __CORE_FIXES_BPF_H */

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
+/*
+ * wperf.bpf.c — Scheduler tracepoint probes for wPerf.
+ *
+ * Implements ADR-013: dual-variant sched_switch + sched_wakeup probes.
+ *   - Primary: tp_btf/sched_switch + tp_btf/sched_wakeup (kernel 5.5+)
+ *     Direct task_struct * access, no BPF_CORE_READ overhead on hot path.
+ *   - Fallback: raw_tp/sched_switch + raw_tp/sched_wakeup (kernel 4.17+)
+ *     Uses BPF_CORE_READ for field access.
+ *
+ * Transport: ADR-004 dual-mode ringbuf/perfarray via reserve_buf/submit_buf
+ * abstraction. Map reconfiguration happens in user-space between open()/load().
+ *
+ * This file is compiled to wperf.bpf.o by libbpf-cargo's SkeletonBuilder.
+ * It is NOT compiled as part of the normal cargo build — it requires
+ * clang with BPF target and vmlinux.h.
+ */
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#include "wperf.h"
+
+/* --------------------------------------------------------------------------
+ * Maps
+ * --------------------------------------------------------------------------
+ * Both ringbuf and perfarray maps are declared. User-space reconfigures
+ * between open() and load() based on probe_ringbuf() result:
+ *   - RingBuf mode: events is RINGBUF, heap is suppressed (set_autocreate=false)
+ *   - PerfArray mode: events is reconfigured to PERF_EVENT_ARRAY, heap is active
+ */
+
+/* Primary event output map. Declared as RINGBUF; user-space may reconfigure
+ * to PERF_EVENT_ARRAY before load(). */
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 16 * 1024 * 1024); /* 16 MiB default, overridable */
+} events SEC(".maps");
+
+/* Per-CPU staging area for perfarray path. Suppressed in ringbuf mode
+ * via set_autocreate(false). */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct wperf_event);
+} heap SEC(".maps");
+
+/* BSS: drop counter for ringbuf path. Incremented when bpf_ringbuf_reserve
+ * returns NULL. Read by user-space at end of recording. */
+__u64 drop_counter = 0;
+
+/* --------------------------------------------------------------------------
+ * Buffer abstraction: reserve_buf / submit_buf
+ * --------------------------------------------------------------------------
+ * Uses CO-RE bpf_core_type_exists to select ringbuf vs perfarray path
+ * at BPF load time. This avoids runtime branching on the hot path.
+ *
+ * Note: bpf_core_type_exists(struct bpf_ringbuf) resolves at load time
+ * via CO-RE relocations — if the kernel has ringbuf support, the ringbuf
+ * path is taken; otherwise the perfarray path.
+ */
+
+static __always_inline struct wperf_event *reserve_buf(void)
+{
+	if (bpf_core_type_exists(struct bpf_ringbuf)) {
+		struct wperf_event *e;
+
+		e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
+		if (!e)
+			__sync_fetch_and_add(&drop_counter, 1);
+		return e;
+	} else {
+		__u32 zero = 0;
+
+		return bpf_map_lookup_elem(&heap, &zero);
+	}
+}
+
+static __always_inline void submit_buf(void *ctx, struct wperf_event *e)
+{
+	if (bpf_core_type_exists(struct bpf_ringbuf)) {
+		bpf_ringbuf_submit(e, 0);
+	} else {
+		bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
+				      e, sizeof(*e));
+	}
+}
+
+/* --------------------------------------------------------------------------
+ * Helper: fill common event fields
+ * -------------------------------------------------------------------------- */
+
+static __always_inline void fill_timestamp_and_cpu(struct wperf_event *e)
+{
+	e->timestamp_ns = bpf_ktime_get_boot_ns();
+	e->cpu = (__u16)bpf_get_smp_processor_id();
+	e->flags = 0;
+}
+
+/* --------------------------------------------------------------------------
+ * tp_btf variants (kernel 5.5+)
+ *
+ * Direct task_struct * access — no BPF_CORE_READ needed for most fields.
+ * Controlled by set_autoload(): disabled on kernels without tp_btf support.
+ * -------------------------------------------------------------------------- */
+
+SEC("tp_btf/sched_switch")
+int BPF_PROG(handle_sched_switch_btf,
+	     bool preempt,
+	     struct task_struct *prev,
+	     struct task_struct *next)
+{
+	struct wperf_event *e;
+
+	e = reserve_buf();
+	if (!e)
+		return 0;
+
+	fill_timestamp_and_cpu(e);
+	e->event_type = WPERF_EVENT_SWITCH;
+	e->prev_state = (__u8)BPF_CORE_READ(prev, __state);
+
+	/* tp_btf gives direct task_struct pointers. */
+	e->prev_tid = BPF_CORE_READ(prev, pid);
+	e->prev_pid = BPF_CORE_READ(prev, tgid);
+	e->next_tid = BPF_CORE_READ(next, pid);
+	e->next_pid = BPF_CORE_READ(next, tgid);
+
+	/* pid/tid from the BPF context (current task at switch time = prev). */
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	e->pid = (__u32)(pid_tgid >> 32);
+	e->tid = (__u32)pid_tgid;
+
+	submit_buf(ctx, e);
+	return 0;
+}
+
+SEC("tp_btf/sched_wakeup")
+int BPF_PROG(handle_sched_wakeup_btf,
+	     struct task_struct *p)
+{
+	struct wperf_event *e;
+
+	e = reserve_buf();
+	if (!e)
+		return 0;
+
+	fill_timestamp_and_cpu(e);
+	e->event_type = WPERF_EVENT_WAKEUP;
+	e->prev_state = 0;
+
+	/* Woken thread. */
+	e->next_tid = BPF_CORE_READ(p, pid);
+	e->next_pid = BPF_CORE_READ(p, tgid);
+
+	/* Waker = current task. */
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	e->pid = (__u32)(pid_tgid >> 32);
+	e->tid = (__u32)pid_tgid;
+
+	/* prev_tid/prev_pid not meaningful for wakeup; zero them. */
+	e->prev_tid = 0;
+	e->prev_pid = 0;
+
+	submit_buf(ctx, e);
+	return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * raw_tp variants (kernel 4.17+)
+ *
+ * Fallback path using BPF_CORE_READ for all task_struct field access.
+ * Enabled when tp_btf is not available (set_autoload on tp_btf = false).
+ * -------------------------------------------------------------------------- */
+
+SEC("raw_tp/sched_switch")
+int BPF_PROG(handle_sched_switch_raw,
+	     bool preempt,
+	     struct task_struct *prev,
+	     struct task_struct *next)
+{
+	struct wperf_event *e;
+
+	e = reserve_buf();
+	if (!e)
+		return 0;
+
+	fill_timestamp_and_cpu(e);
+	e->event_type = WPERF_EVENT_SWITCH;
+	e->prev_state = (__u8)BPF_CORE_READ(prev, __state);
+
+	/* raw_tp: task_struct pointers require BPF_CORE_READ. */
+	e->prev_tid = BPF_CORE_READ(prev, pid);
+	e->prev_pid = BPF_CORE_READ(prev, tgid);
+	e->next_tid = BPF_CORE_READ(next, pid);
+	e->next_pid = BPF_CORE_READ(next, tgid);
+
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	e->pid = (__u32)(pid_tgid >> 32);
+	e->tid = (__u32)pid_tgid;
+
+	submit_buf(ctx, e);
+	return 0;
+}
+
+SEC("raw_tp/sched_wakeup")
+int BPF_PROG(handle_sched_wakeup_raw,
+	     struct task_struct *p)
+{
+	struct wperf_event *e;
+
+	e = reserve_buf();
+	if (!e)
+		return 0;
+
+	fill_timestamp_and_cpu(e);
+	e->event_type = WPERF_EVENT_WAKEUP;
+	e->prev_state = 0;
+
+	e->next_tid = BPF_CORE_READ(p, pid);
+	e->next_pid = BPF_CORE_READ(p, tgid);
+
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	e->pid = (__u32)(pid_tgid >> 32);
+	e->tid = (__u32)pid_tgid;
+
+	e->prev_tid = 0;
+	e->prev_pid = 0;
+
+	submit_buf(ctx, e);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -8,8 +8,9 @@
  *   - Fallback: raw_tp/sched_switch + raw_tp/sched_wakeup (kernel 4.17+)
  *     Uses BPF_CORE_READ for all task_struct field access.
  *
- * Transport: ADR-004 dual-mode ringbuf/perfarray via reserve_buf/submit_buf
- * abstraction. Map reconfiguration happens in user-space between open()/load().
+ * Transport: ADR-004 dual-mode ringbuf/perfarray via compat.bpf.h
+ * reserve_buf/submit_buf abstraction (vendored from libbpf-tools).
+ * Map reconfiguration happens in user-space between open()/load().
  *
  * This file is compiled to wperf.bpf.o by libbpf-cargo's SkeletonBuilder.
  * It is NOT compiled as part of the normal cargo build — it requires
@@ -30,6 +31,10 @@
  * between open() and load() based on probe_ringbuf() result:
  *   - RingBuf mode: events is RINGBUF, heap is suppressed (set_autocreate=false)
  *   - PerfArray mode: events is reconfigured to PERF_EVENT_ARRAY, heap is active
+ *
+ * Map declarations are wperf-specific (typed value, sized buffers).
+ * The upstream compat.bpf.h uses generic MAX_EVENT_SIZE/RINGBUF_SIZE;
+ * we declare maps here and let compat.bpf.h reference them by name.
  */
 
 /* Primary event output map. Declared as RINGBUF; user-space may reconfigure
@@ -48,46 +53,19 @@ struct {
 	__type(value, struct wperf_event);
 } heap SEC(".maps");
 
-/* BSS: drop counter for ringbuf path. Incremented when bpf_ringbuf_reserve
- * returns NULL. Read by user-space at end of recording. */
+/* BSS: drop counter for ringbuf path. Incremented by compat.bpf.h's
+ * reserve_buf() when bpf_ringbuf_reserve returns NULL.
+ * Read by user-space at end of recording. */
 __u64 drop_counter = 0;
 
 /* --------------------------------------------------------------------------
- * Buffer abstraction: reserve_buf / submit_buf
+ * Buffer abstraction: vendored from libbpf-tools compat.bpf.h
  * --------------------------------------------------------------------------
- * Uses CO-RE bpf_core_type_exists to select ringbuf vs perfarray path
- * at BPF load time. This avoids runtime branching on the hot path.
- *
- * Note: bpf_core_type_exists(struct bpf_ringbuf) resolves at load time
- * via CO-RE relocations — if the kernel has ringbuf support, the ringbuf
- * path is taken; otherwise the perfarray path.
+ * reserve_buf() / submit_buf() use CO-RE bpf_core_type_exists to select
+ * ringbuf vs perfarray path at BPF load time. See compat.bpf.h for
+ * implementation and provenance details.
  */
-
-static __always_inline struct wperf_event *reserve_buf(void)
-{
-	if (bpf_core_type_exists(struct bpf_ringbuf)) {
-		struct wperf_event *e;
-
-		e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
-		if (!e)
-			__sync_fetch_and_add(&drop_counter, 1);
-		return e;
-	} else {
-		__u32 zero = 0;
-
-		return bpf_map_lookup_elem(&heap, &zero);
-	}
-}
-
-static __always_inline void submit_buf(void *ctx, struct wperf_event *e)
-{
-	if (bpf_core_type_exists(struct bpf_ringbuf)) {
-		bpf_ringbuf_submit(e, 0);
-	} else {
-		bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
-				      e, sizeof(*e));
-	}
-}
+#include "compat.bpf.h"
 
 /* --------------------------------------------------------------------------
  * Helper: fill common event fields
@@ -117,7 +95,7 @@ int BPF_PROG(handle_sched_switch_btf,
 {
 	struct wperf_event *e;
 
-	e = reserve_buf();
+	e = reserve_buf(sizeof(*e));
 	if (!e)
 		return 0;
 
@@ -138,7 +116,7 @@ int BPF_PROG(handle_sched_switch_btf,
 	e->pid = (__u32)(pid_tgid >> 32);
 	e->tid = (__u32)pid_tgid;
 
-	submit_buf(ctx, e);
+	submit_buf(ctx, e, sizeof(*e));
 	return 0;
 }
 
@@ -148,7 +126,7 @@ int BPF_PROG(handle_sched_wakeup_btf,
 {
 	struct wperf_event *e;
 
-	e = reserve_buf();
+	e = reserve_buf(sizeof(*e));
 	if (!e)
 		return 0;
 
@@ -168,7 +146,7 @@ int BPF_PROG(handle_sched_wakeup_btf,
 	e->prev_tid = e->tid;
 	e->prev_pid = e->pid;
 
-	submit_buf(ctx, e);
+	submit_buf(ctx, e, sizeof(*e));
 	return 0;
 }
 
@@ -187,7 +165,7 @@ int BPF_PROG(handle_sched_switch_raw,
 {
 	struct wperf_event *e;
 
-	e = reserve_buf();
+	e = reserve_buf(sizeof(*e));
 	if (!e)
 		return 0;
 
@@ -205,7 +183,7 @@ int BPF_PROG(handle_sched_switch_raw,
 	e->pid = (__u32)(pid_tgid >> 32);
 	e->tid = (__u32)pid_tgid;
 
-	submit_buf(ctx, e);
+	submit_buf(ctx, e, sizeof(*e));
 	return 0;
 }
 
@@ -215,7 +193,7 @@ int BPF_PROG(handle_sched_wakeup_raw,
 {
 	struct wperf_event *e;
 
-	e = reserve_buf();
+	e = reserve_buf(sizeof(*e));
 	if (!e)
 		return 0;
 
@@ -234,7 +212,7 @@ int BPF_PROG(handle_sched_wakeup_raw,
 	e->prev_tid = e->tid;
 	e->prev_pid = e->pid;
 
-	submit_buf(ctx, e);
+	submit_buf(ctx, e, sizeof(*e));
 	return 0;
 }
 

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -66,6 +66,7 @@ __u64 drop_counter = 0;
  * implementation and provenance details.
  */
 #include "compat.bpf.h"
+#include "core_fixes.bpf.h"
 
 /* --------------------------------------------------------------------------
  * Helper: fill common event fields
@@ -104,7 +105,7 @@ int BPF_PROG(handle_sched_switch_btf,
 	/* __state needs BPF_CORE_READ for CO-RE relocation (field name
 	 * changed across kernel versions). pid/tgid are stable — direct
 	 * access is safe with tp_btf's BTF-typed pointers. */
-	e->prev_state = (__u8)BPF_CORE_READ(prev, __state);
+	e->prev_state = (__u8)get_task_state(prev);
 
 	e->prev_tid = prev->pid;
 	e->prev_pid = prev->tgid;
@@ -171,7 +172,7 @@ int BPF_PROG(handle_sched_switch_raw,
 
 	fill_timestamp_and_cpu(e);
 	e->event_type = WPERF_EVENT_SWITCH;
-	e->prev_state = (__u8)BPF_CORE_READ(prev, __state);
+	e->prev_state = (__u8)get_task_state(prev);
 
 	/* raw_tp: task_struct pointers require BPF_CORE_READ. */
 	e->prev_tid = BPF_CORE_READ(prev, pid);

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -95,7 +95,7 @@ static __always_inline void submit_buf(void *ctx, struct wperf_event *e)
 
 static __always_inline void fill_timestamp_and_cpu(struct wperf_event *e)
 {
-	e->timestamp_ns = bpf_ktime_get_boot_ns();
+	e->timestamp_ns = bpf_ktime_get_ns();
 	e->cpu = (__u16)bpf_get_smp_processor_id();
 	e->flags = 0;
 }

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -4,9 +4,9 @@
  *
  * Implements ADR-013: dual-variant sched_switch + sched_wakeup probes.
  *   - Primary: tp_btf/sched_switch + tp_btf/sched_wakeup (kernel 5.5+)
- *     Direct task_struct * access, no BPF_CORE_READ overhead on hot path.
+ *     BTF-typed pointers: direct field access for stable fields (pid, tgid).
  *   - Fallback: raw_tp/sched_switch + raw_tp/sched_wakeup (kernel 4.17+)
- *     Uses BPF_CORE_READ for field access.
+ *     Uses BPF_CORE_READ for all task_struct field access.
  *
  * Transport: ADR-004 dual-mode ringbuf/perfarray via reserve_buf/submit_buf
  * abstraction. Map reconfiguration happens in user-space between open()/load().
@@ -103,7 +103,9 @@ static __always_inline void fill_timestamp_and_cpu(struct wperf_event *e)
 /* --------------------------------------------------------------------------
  * tp_btf variants (kernel 5.5+)
  *
- * Direct task_struct * access — no BPF_CORE_READ needed for most fields.
+ * BTF-typed task_struct pointers allow direct field access for stable
+ * fields (pid, tgid). BPF_CORE_READ still used for __state (CO-RE
+ * relocation needed — field name changed across kernel versions).
  * Controlled by set_autoload(): disabled on kernels without tp_btf support.
  * -------------------------------------------------------------------------- */
 
@@ -121,13 +123,15 @@ int BPF_PROG(handle_sched_switch_btf,
 
 	fill_timestamp_and_cpu(e);
 	e->event_type = WPERF_EVENT_SWITCH;
+	/* __state needs BPF_CORE_READ for CO-RE relocation (field name
+	 * changed across kernel versions). pid/tgid are stable — direct
+	 * access is safe with tp_btf's BTF-typed pointers. */
 	e->prev_state = (__u8)BPF_CORE_READ(prev, __state);
 
-	/* tp_btf gives direct task_struct pointers. */
-	e->prev_tid = BPF_CORE_READ(prev, pid);
-	e->prev_pid = BPF_CORE_READ(prev, tgid);
-	e->next_tid = BPF_CORE_READ(next, pid);
-	e->next_pid = BPF_CORE_READ(next, tgid);
+	e->prev_tid = prev->pid;
+	e->prev_pid = prev->tgid;
+	e->next_tid = next->pid;
+	e->next_pid = next->tgid;
 
 	/* pid/tid from the BPF context (current task at switch time = prev). */
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -152,9 +156,9 @@ int BPF_PROG(handle_sched_wakeup_btf,
 	e->event_type = WPERF_EVENT_WAKEUP;
 	e->prev_state = 0;
 
-	/* Woken thread. */
-	e->next_tid = BPF_CORE_READ(p, pid);
-	e->next_pid = BPF_CORE_READ(p, tgid);
+	/* Woken thread — direct access via tp_btf BTF-typed pointer. */
+	e->next_tid = p->pid;
+	e->next_pid = p->tgid;
 
 	/* Waker = current task. */
 	__u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -156,18 +156,17 @@ int BPF_PROG(handle_sched_wakeup_btf,
 	e->event_type = WPERF_EVENT_WAKEUP;
 	e->prev_state = 0;
 
-	/* Woken thread — direct access via tp_btf BTF-typed pointer. */
+	/* Wakee — direct access via tp_btf BTF-typed pointer. */
 	e->next_tid = p->pid;
 	e->next_pid = p->tgid;
 
-	/* Waker = current task. */
+	/* Waker = current task. prev_tid/prev_pid encode waker identity
+	 * per the event contract in src/format/event.rs. */
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	e->pid = (__u32)(pid_tgid >> 32);
 	e->tid = (__u32)pid_tgid;
-
-	/* prev_tid/prev_pid not meaningful for wakeup; zero them. */
-	e->prev_tid = 0;
-	e->prev_pid = 0;
+	e->prev_tid = e->tid;
+	e->prev_pid = e->pid;
 
 	submit_buf(ctx, e);
 	return 0;
@@ -227,12 +226,13 @@ int BPF_PROG(handle_sched_wakeup_raw,
 	e->next_tid = BPF_CORE_READ(p, pid);
 	e->next_pid = BPF_CORE_READ(p, tgid);
 
+	/* Waker = current task. prev_tid/prev_pid encode waker identity
+	 * per the event contract in src/format/event.rs. */
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	e->pid = (__u32)(pid_tgid >> 32);
 	e->tid = (__u32)pid_tgid;
-
-	e->prev_tid = 0;
-	e->prev_pid = 0;
+	e->prev_tid = e->tid;
+	e->prev_pid = e->pid;
 
 	submit_buf(ctx, e);
 	return 0;

--- a/src/bpf/wperf.h
+++ b/src/bpf/wperf.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * wperf.h — Shared definitions between BPF programs and user-space.
+ *
+ * This header defines the event structure and enums that must match
+ * the Rust-side definitions in src/format/event.rs exactly.
+ *
+ * Layout: 40 bytes, naturally aligned (no __attribute__((packed))).
+ * See ADR-004 and docs/design/final-design.md §2.4.
+ */
+
+#ifndef __WPERF_H
+#define __WPERF_H
+
+/* When included outside BPF context (e.g., standalone clang check),
+ * pull in fixed-width types. In BPF programs, vmlinux.h provides these. */
+#ifndef __VMLINUX_H__
+#include <linux/types.h>
+#endif
+
+/* Event type discriminants — must match Rust EventType repr(u8). */
+enum wperf_event_type {
+	WPERF_EVENT_SWITCH     = 1,
+	WPERF_EVENT_WAKEUP     = 2,
+	WPERF_EVENT_WAKEUP_NEW = 3,
+	WPERF_EVENT_EXIT       = 4,
+};
+
+/*
+ * 40-byte event structure — Rust mirror: src/format/event.rs WperfEvent.
+ *
+ * Fields are ordered for natural alignment:
+ *   u64 first, then u32s, then u16, then u8s, then u32 (flags fills padding).
+ *
+ * Must NOT use __attribute__((packed)) — BPF verifier rejects unaligned
+ * access on kernels < 5.8.
+ */
+struct wperf_event {
+	__u64 timestamp_ns;   /* offset  0: ktime_get_boot_ns() */
+	__u32 pid;            /* offset  8: tgid (userspace PID) */
+	__u32 tid;            /* offset 12: kernel tid (task->pid) */
+	__u32 prev_tid;       /* offset 16: previous thread tid (sched_switch) */
+	__u32 next_tid;       /* offset 20: next thread tid (sched_switch) */
+	__u32 prev_pid;       /* offset 24: previous thread tgid */
+	__u32 next_pid;       /* offset 28: next thread tgid */
+	__u16 cpu;            /* offset 32: CPU core number */
+	__u8  event_type;     /* offset 34: enum wperf_event_type */
+	__u8  prev_state;     /* offset 35: TASK_* state before switch */
+	__u32 flags;          /* offset 36: reserved (0 in Phase 1) */
+};                            /* total: 40 bytes */
+
+/* Compile-time size check (BPF programs should verify this). */
+_Static_assert(sizeof(struct wperf_event) == 40,
+	       "wperf_event must be exactly 40 bytes");
+
+#endif /* __WPERF_H */


### PR DESCRIPTION
## Summary

- Add dual-variant BPF tracepoint probes for `sched_switch` and `sched_wakeup` (ADR-013)
  - **tp_btf** (kernel 5.5+): direct `task_struct *` access, no `BPF_CORE_READ` overhead on hot path
  - **raw_tp** (kernel 4.17+): fallback using `BPF_CORE_READ` for all field access
- Add shared C header (`wperf.h`) defining `struct wperf_event` (40 bytes, naturally aligned) and `enum wperf_event_type` — matches Rust-side `WperfEvent` in `src/format/event.rs`
- Dual-mode ringbuf/perfarray transport via `reserve_buf()`/`submit_buf()` CO-RE abstraction (`bpf_core_type_exists`)
- BSS `drop_counter` for ringbuf reserve failures

## Design decisions

- **Source-only**: these files require `clang -target bpf` + `vmlinux.h` to compile. Actual compilation is blocked on skeleton build pipeline (Task #5 / W1 #9). No changes to `cargo build`.
- **4 SEC programs**: `tp_btf/sched_switch`, `tp_btf/sched_wakeup`, `raw_tp/sched_switch`, `raw_tp/sched_wakeup`. User-space selects via `set_autoload()` based on feature probing.
- **CO-RE transport selection**: `bpf_core_type_exists(struct bpf_ringbuf)` resolves at load time — no runtime branching on the hot path.
- **No `__attribute__((packed))`**: BPF verifier rejects unaligned access on kernels < 5.8.

## Files

| File | Purpose |
|------|---------|
| `src/bpf/wperf.h` | Shared event struct + enum (C header) |
| `src/bpf/wperf.bpf.c` | BPF programs (4 tracepoint probes) |

## Test plan

- [ ] `clang -target bpf` compilation (requires vmlinux.h — deferred to Task #5)
- [ ] BPF verifier acceptance on 5.15+ and 6.x kernels
- [ ] Event field correctness vs Rust `WperfEvent` layout (`_Static_assert` in header)
- [ ] Ringbuf and perfarray paths exercised on respective kernel versions

Implements W1 #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)