### PR TITLE
process: add design-conformance sections to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,33 @@
 ## Summary
 <!-- 1-3 bullet points describing the change -->
 
+## Authoritative Inputs
+<!-- Which ADRs, design docs, or spec sections govern this PR?
+     List each by name/number. Example:
+       - ADR-002-supplement §3 (compat.bpf.h vendor pattern)
+       - final-design.md §4.1 (wPRF header layout)
+     If none apply, write: N/A (no governing spec) -->
+
+## Deviations
+<!-- Does this PR deviate from any accepted design or ADR?
+     Only two valid states:
+       - None
+       - Deviation: <description> — doc update: <PR or commit ref>
+     A deviation WITHOUT a prior or concurrent spec amendment is a process violation. -->
+
 ## Dependency Checklist
 <!-- Required when adding or modifying direct dependencies -->
 - [ ] New/modified dependency versions are aligned with baseline in `docs/lessons/REGISTRY.md`
 - [ ] If deviating from baseline, rationale is documented in this PR description
 - [ ] If introducing a new Cargo feature, CI validates both default and feature-on builds
+
+## Review Checklist
+<!-- For reviewers — check these IN ORDER before evaluating code correctness -->
+- [ ] **Design conformance**: implementation matches the ADRs/specs listed in Authoritative Inputs
+- [ ] **Deviations declared**: any spec drift is explicitly listed above with a doc update reference
+- [ ] **Code correctness**: logic, error handling, edge cases
+- [ ] **Tests**: new/changed code has adequate test coverage
+- [ ] **CI green**: all required checks pass
 
 ## Test Plan
 <!-- How was this tested? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,11 @@
      List each by name/number. Example:
        - ADR-002-supplement §3 (compat.bpf.h vendor pattern)
        - final-design.md §4.1 (wPRF header layout)
-     If none apply, write: N/A (no governing spec) -->
+     If none apply, write: None (no governing spec) -->
 
 ## Deviations
 <!-- Does this PR deviate from any accepted design or ADR?
-     Only two valid states:
+     Valid entries:
        - None
        - Deviation: <description> — doc update: <PR or commit ref>
      A deviation WITHOUT a prior or concurrent spec amendment is a process violation. -->
@@ -22,7 +22,7 @@
 - [ ] If introducing a new Cargo feature, CI validates both default and feature-on builds
 
 ## Review Checklist
-<!-- For reviewers — check these IN ORDER before evaluating code correctness -->
+<!-- For reviewers — check these items in order, prioritizing design conformance -->
 - [ ] **Design conformance**: implementation matches the ADRs/specs listed in Authoritative Inputs
 - [ ] **Deviations declared**: any spec drift is explicitly listed above with a doc update reference
 - [ ] **Code correctness**: logic, error handling, edge cases


### PR DESCRIPTION
## Summary
- Adds **Authoritative Inputs** section: PR author must declare which ADRs/specs govern the PR
- Adds **Deviations** section: explicit declaration of any spec drift (with doc update ref required)
- Adds **Review Checklist**: reviewers check design conformance BEFORE code correctness

## Authoritative Inputs
- Oracle Directives 2-3 (issued 2026-04-06 in #all channel)
- Root cause analysis of spec drift in PR #72 (40B struct without prior spec amendment) and PR #87 (compat.bpf.h hand-rolled, __state direct access)

## Deviations
None

## Test Plan
- Template renders correctly on new PRs (GitHub markdown preview)
- Existing open PRs are unaffected (template only applies to new PRs)