### PR TITLE
feat(cli): wperf record/report CLI scaffold with signal handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,71 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +78,15 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -36,6 +110,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +142,170 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "criterion"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -129,6 +379,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +411,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iai-callgrind"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,10 +465,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -254,6 +585,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +615,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +658,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -384,10 +777,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -403,6 +848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +863,15 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -470,6 +930,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +1006,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vsprintf"
@@ -531,6 +1033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +1058,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -580,6 +1137,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -689,6 +1265,9 @@ dependencies = [
 name = "wperf"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "criterion",
+ "iai-callgrind",
  "libbpf-rs",
  "libbpf-sys",
  "libc",
@@ -696,6 +1275,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "signal-hook",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,14 @@ publish = false
 bpf = ["libbpf-rs", "libbpf-sys", "libc"]
 
 [dependencies]
+clap = { version = "4.6", features = ["derive"] }
 libbpf-rs = { version = "0.26", optional = true }
 libbpf-sys = { version = "1.7", optional = true }
 libc = { version = "0.2", optional = true }
 petgraph = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+signal-hook = "0.4"
 
 [dev-dependencies]
 criterion = { version = "0.6", features = ["html_reports"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,9 @@ pub enum Command {
 
     /// Analyze a .wperf file and produce a performance report.
     Report(ReportArgs),
+
+    /// Print version information.
+    Version,
 }
 
 /// Arguments for the `record` subcommand.
@@ -73,7 +76,7 @@ mod tests {
                 assert!(args.duration.is_none());
                 assert!(args.buffer_size.is_none());
             }
-            Command::Report(_) => panic!("expected Record"),
+            _ => panic!("expected Record"),
         }
     }
 
@@ -95,7 +98,7 @@ mod tests {
                 assert!((args.duration.unwrap() - 10.5).abs() < f64::EPSILON);
                 assert_eq!(args.buffer_size.unwrap(), 8_388_608);
             }
-            Command::Report(_) => panic!("expected Record"),
+            _ => panic!("expected Record"),
         }
     }
 
@@ -106,7 +109,7 @@ mod tests {
             Command::Report(args) => {
                 assert_eq!(args.input, PathBuf::from("trace.wperf"));
             }
-            Command::Record(_) => panic!("expected Report"),
+            _ => panic!("expected Report"),
         }
     }
 
@@ -115,8 +118,14 @@ mod tests {
         let cli = Cli::parse_from(["wperf", "record", "-o", "out.wperf"]);
         match cli.command {
             Command::Record(args) => assert_eq!(args.output, PathBuf::from("out.wperf")),
-            Command::Report(_) => panic!("expected Record"),
+            _ => panic!("expected Record"),
         }
+    }
+
+    #[test]
+    fn parse_version_subcommand() {
+        let cli = Cli::parse_from(["wperf", "version"]);
+        assert!(matches!(cli.command, Command::Version));
     }
 
     #[test]
@@ -126,7 +135,7 @@ mod tests {
             Command::Record(args) => {
                 assert!((args.duration.unwrap() - 5.0).abs() < f64::EPSILON);
             }
-            Command::Report(_) => panic!("expected Record"),
+            _ => panic!("expected Record"),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,8 +33,8 @@ pub struct RecordArgs {
     #[arg(short, long, default_value = "wperf.data")]
     pub output: PathBuf,
 
-    /// Recording duration in seconds. If omitted, records until Ctrl+C.
-    #[arg(short, long)]
+    /// Recording duration in seconds (must be positive). If omitted, records until Ctrl+C.
+    #[arg(short, long, value_parser = parse_positive_duration)]
     pub duration: Option<f64>,
 
     /// Transport buffer size in bytes.
@@ -61,6 +61,16 @@ pub struct ReportArgs {
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum ReportFormat {
     Json,
+}
+
+/// Parse a positive duration value (rejects zero and negative).
+fn parse_positive_duration(s: &str) -> Result<f64, String> {
+    let val: f64 = s.parse().map_err(|e| format!("{e}"))?;
+    if val > 0.0 {
+        Ok(val)
+    } else {
+        Err("duration must be positive".to_string())
+    }
 }
 
 #[cfg(test)]
@@ -126,6 +136,18 @@ mod tests {
     fn parse_version_subcommand() {
         let cli = Cli::parse_from(["wperf", "version"]);
         assert!(matches!(cli.command, Command::Version));
+    }
+
+    #[test]
+    fn record_rejects_zero_duration() {
+        let result = Cli::try_parse_from(["wperf", "record", "-d", "0"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn record_rejects_negative_duration() {
+        let result = Cli::try_parse_from(["wperf", "record", "-d", "-1"]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,132 @@
+//! CLI definition for wperf — clap derive-based subcommands.
+//!
+//! Authoritative Input: final-design.md §1.2 (unified offline CLI model).
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+/// wPerf — thread-level Wait-For-Graph performance analysis.
+#[derive(Parser, Debug)]
+#[command(name = "wperf", version, about)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Collect scheduling events via BPF probes into a .wperf file.
+    Record(RecordArgs),
+
+    /// Analyze a .wperf file and produce a performance report.
+    Report(ReportArgs),
+}
+
+/// Arguments for the `record` subcommand.
+#[derive(clap::Args, Debug)]
+pub struct RecordArgs {
+    /// Output file path (default: wperf.data).
+    #[arg(short, long, default_value = "wperf.data")]
+    pub output: PathBuf,
+
+    /// Recording duration in seconds. If omitted, records until Ctrl+C.
+    #[arg(short, long)]
+    pub duration: Option<f64>,
+
+    /// Transport buffer size in bytes.
+    ///
+    /// For ringbuf transport: sets `max_entries` (must be power of 2).
+    /// For perfarray transport: sets per-CPU buffer size.
+    /// Default: 16 MiB for ringbuf, 1 MiB/CPU for perfarray.
+    #[arg(long)]
+    pub buffer_size: Option<u32>,
+}
+
+/// Arguments for the `report` subcommand.
+#[derive(clap::Args, Debug)]
+pub struct ReportArgs {
+    /// Input .wperf file to analyze.
+    pub input: PathBuf,
+
+    /// Output format.
+    #[arg(short, long, default_value = "json")]
+    pub format: ReportFormat,
+}
+
+/// Output formats for `wperf report`.
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum ReportFormat {
+    Json,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_record_defaults() {
+        let cli = Cli::parse_from(["wperf", "record"]);
+        match cli.command {
+            Command::Record(args) => {
+                assert_eq!(args.output, PathBuf::from("wperf.data"));
+                assert!(args.duration.is_none());
+                assert!(args.buffer_size.is_none());
+            }
+            Command::Report(_) => panic!("expected Record"),
+        }
+    }
+
+    #[test]
+    fn parse_record_all_args() {
+        let cli = Cli::parse_from([
+            "wperf",
+            "record",
+            "-o",
+            "trace.wperf",
+            "--duration",
+            "10.5",
+            "--buffer-size",
+            "8388608",
+        ]);
+        match cli.command {
+            Command::Record(args) => {
+                assert_eq!(args.output, PathBuf::from("trace.wperf"));
+                assert!((args.duration.unwrap() - 10.5).abs() < f64::EPSILON);
+                assert_eq!(args.buffer_size.unwrap(), 8_388_608);
+            }
+            Command::Report(_) => panic!("expected Record"),
+        }
+    }
+
+    #[test]
+    fn parse_report() {
+        let cli = Cli::parse_from(["wperf", "report", "trace.wperf"]);
+        match cli.command {
+            Command::Report(args) => {
+                assert_eq!(args.input, PathBuf::from("trace.wperf"));
+            }
+            Command::Record(_) => panic!("expected Report"),
+        }
+    }
+
+    #[test]
+    fn record_short_output_flag() {
+        let cli = Cli::parse_from(["wperf", "record", "-o", "out.wperf"]);
+        match cli.command {
+            Command::Record(args) => assert_eq!(args.output, PathBuf::from("out.wperf")),
+            Command::Report(_) => panic!("expected Record"),
+        }
+    }
+
+    #[test]
+    fn record_short_duration_flag() {
+        let cli = Cli::parse_from(["wperf", "record", "-d", "5"]);
+        match cli.command {
+            Command::Record(args) => {
+                assert!((args.duration.unwrap() - 5.0).abs() < f64::EPSILON);
+            }
+            Command::Report(_) => panic!("expected Record"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod cascade;
+pub mod cli;
 pub mod critical_path;
 pub mod format;
 pub mod graph;
 pub mod output;
 pub mod probe;
+pub mod record;
 pub mod scc;
 pub mod transport;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,24 @@
-fn main() {
-    println!("Hello, world!");
+use std::process::ExitCode;
+
+use clap::Parser;
+use wperf::cli::{Cli, Command};
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Command::Record(args) => wperf::record::run(&args),
+        Command::Report(_args) => {
+            eprintln!("wperf report: not yet implemented (planned for W3 #17)");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("wperf: {e}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,10 @@ fn main() -> ExitCode {
             eprintln!("wperf report: not yet implemented (planned for W3 #17)");
             return ExitCode::FAILURE;
         }
+        Command::Version => {
+            println!("wperf {}", env!("CARGO_PKG_VERSION"));
+            return ExitCode::SUCCESS;
+        }
     };
 
     match result {

--- a/src/record.rs
+++ b/src/record.rs
@@ -14,7 +14,7 @@
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-#[cfg(any(feature = "bpf", test))]
+#[cfg(test)]
 use std::sync::atomic::Ordering;
 
 use crate::cli::RecordArgs;
@@ -24,6 +24,8 @@ use crate::cli::RecordArgs;
 pub enum RecordError {
     /// BPF feature not compiled in.
     NoBpfSupport,
+    /// BPF skeleton / transport pipeline not yet wired.
+    NotYetWired,
     /// Signal handler registration failed.
     SignalSetup(io::Error),
     /// I/O error (file creation, write, etc).
@@ -38,6 +40,11 @@ impl std::fmt::Display for RecordError {
                 "this build of wperf was compiled without BPF support; \
                  rebuild with `--features bpf`"
             ),
+            Self::NotYetWired => write!(
+                f,
+                "record pipeline not yet wired: BPF skeleton build pipeline is required \
+                 but not yet integrated"
+            ),
             Self::SignalSetup(e) => write!(f, "failed to register signal handler: {e}"),
             Self::Io(e) => write!(f, "record I/O error: {e}"),
         }
@@ -48,7 +55,7 @@ impl std::error::Error for RecordError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::SignalSetup(e) | Self::Io(e) => Some(e),
-            Self::NoBpfSupport => None,
+            Self::NoBpfSupport | Self::NotYetWired => None,
         }
     }
 }
@@ -71,83 +78,42 @@ impl From<io::Error> for RecordError {
 /// 7. Print summary
 pub fn run(args: &RecordArgs) -> Result<(), RecordError> {
     // Step 1: Register signal handlers for graceful shutdown.
-    let running = Arc::new(AtomicBool::new(true));
-    register_signal_handlers(&running)?;
+    // `signal_hook::flag::register` stores `true` into the AtomicBool on signal,
+    // so we start at `false` and poll `stop_requested.load()` to detect shutdown.
+    let stop_requested = Arc::new(AtomicBool::new(false));
+    register_signal_handlers(&stop_requested)?;
 
     // Step 2-6: BPF pipeline (feature-gated).
-    record_impl(args, &running)
+    record_impl(args, &stop_requested)
 }
 
-/// Register SIGINT and SIGTERM handlers that clear the `running` flag.
-fn register_signal_handlers(running: &Arc<AtomicBool>) -> Result<(), RecordError> {
+/// Register SIGINT and SIGTERM handlers that set `stop_requested` to true.
+fn register_signal_handlers(stop_requested: &Arc<AtomicBool>) -> Result<(), RecordError> {
     for sig in [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM] {
-        signal_hook::flag::register(sig, Arc::clone(running)).map_err(RecordError::SignalSetup)?;
+        signal_hook::flag::register(sig, Arc::clone(stop_requested))
+            .map_err(RecordError::SignalSetup)?;
     }
     Ok(())
 }
 
 /// BPF-enabled record implementation.
+///
+/// Currently returns `NotYetWired` because the BPF skeleton build pipeline
+/// is not yet integrated. Once skeleton wiring lands, this function will:
+/// 1. `probe_all()` → `FeatureMatrix`
+/// 2. Open skeleton → configure transport (ringbuf/perfarray) → load → attach
+/// 3. Poll transport in loop while `!stop_requested`
+/// 4. Drain → `writer.finish(drop_count)`
 #[cfg(feature = "bpf")]
-fn record_impl(args: &RecordArgs, running: &Arc<AtomicBool>) -> Result<(), RecordError> {
-    use std::fs::File;
-    use std::io::BufWriter;
-    use std::time::Instant;
-
-    use crate::format::writer::WperfWriter;
-
-    eprintln!("wperf: recording to {} ...", args.output.display());
-    if let Some(d) = args.duration {
-        eprintln!("wperf: duration limit: {d:.1}s");
-    }
-
-    // Create output file and writer.
-    let file = File::create(&args.output)?;
-    let mut writer = WperfWriter::new(BufWriter::new(file))?;
-
-    // TODO: probe_all() → FeatureMatrix → skeleton open → configure → load → attach
-    // This is blocked on the BPF skeleton build pipeline (#5 closeout).
-    //
-    // For now, the record loop structure is in place but there is no
-    // transport to poll. We write an empty trace with a valid footer.
-
-    let start = Instant::now();
-    let deadline = args
-        .duration
-        .map(|d| start + std::time::Duration::from_secs_f64(d));
-
-    // Event collection loop (placeholder — no transport yet).
-    while running.load(Ordering::Relaxed) {
-        if let Some(dl) = deadline {
-            if Instant::now() >= dl {
-                break;
-            }
-        }
-        // Once transport is wired:
-        //   transport.poll(100, &mut |event| { writer.write_event(event).unwrap(); });
-        //
-        // For now, just sleep briefly to avoid busy-looping.
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-
-    // Drain + finalize.
-    // Once transport is wired: transport.drain(...)
-    let drop_count = 0_u64; // Will come from transport.drop_count()
-    let event_count = writer.event_count();
-    writer.finish(drop_count)?;
-
-    let elapsed = start.elapsed();
-    eprintln!(
-        "wperf: recorded {event_count} events in {:.1}s ({drop_count} drops) → {}",
-        elapsed.as_secs_f64(),
-        args.output.display(),
-    );
-
-    Ok(())
+fn record_impl(_args: &RecordArgs, _stop_requested: &Arc<AtomicBool>) -> Result<(), RecordError> {
+    // The BPF skeleton build pipeline is not yet wired.
+    // Returning an explicit error avoids producing a misleading empty trace.
+    Err(RecordError::NotYetWired)
 }
 
 /// Non-BPF build: runtime error at invocation boundary.
 #[cfg(not(feature = "bpf"))]
-fn record_impl(_args: &RecordArgs, _running: &Arc<AtomicBool>) -> Result<(), RecordError> {
+fn record_impl(_args: &RecordArgs, _stop_requested: &Arc<AtomicBool>) -> Result<(), RecordError> {
     Err(RecordError::NoBpfSupport)
 }
 
@@ -158,10 +124,10 @@ mod tests {
 
     #[test]
     fn signal_handler_registration_succeeds() {
-        let running = Arc::new(AtomicBool::new(true));
-        // Should not panic or error on a normal system.
-        register_signal_handlers(&running).unwrap();
-        assert!(running.load(Ordering::Relaxed));
+        let stop_requested = Arc::new(AtomicBool::new(false));
+        register_signal_handlers(&stop_requested).unwrap();
+        // Flag should still be false (no signal sent).
+        assert!(!stop_requested.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -170,6 +136,14 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("without BPF support"));
         assert!(msg.contains("--features bpf"));
+    }
+
+    #[test]
+    fn record_error_display_not_yet_wired() {
+        let err = RecordError::NotYetWired;
+        let msg = format!("{err}");
+        assert!(msg.contains("not yet wired"));
+        assert!(msg.contains("skeleton"));
     }
 
     #[test]
@@ -193,6 +167,9 @@ mod tests {
         let err = RecordError::NoBpfSupport;
         assert!(std::error::Error::source(&err).is_none());
 
+        let err = RecordError::NotYetWired;
+        assert!(std::error::Error::source(&err).is_none());
+
         let err = RecordError::SignalSetup(io::Error::other("x"));
         assert!(std::error::Error::source(&err).is_some());
 
@@ -208,34 +185,23 @@ mod tests {
             duration: None,
             buffer_size: None,
         };
-        let running = Arc::new(AtomicBool::new(true));
-        let result = record_impl(&args, &running);
+        let stop_requested = Arc::new(AtomicBool::new(false));
+        let result = record_impl(&args, &stop_requested);
         assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, RecordError::NoBpfSupport));
+        assert!(matches!(result.unwrap_err(), RecordError::NoBpfSupport));
     }
 
     #[cfg(feature = "bpf")]
     #[test]
-    fn record_with_duration_produces_valid_file() {
-        let dir = std::env::temp_dir().join("wperf-test-record");
-        std::fs::create_dir_all(&dir).unwrap();
-        let output = dir.join("test-record.wperf");
-
+    fn record_bpf_returns_not_yet_wired() {
         let args = RecordArgs {
-            output: output.clone(),
-            duration: Some(0.2), // 200ms — just enough to exercise the loop
+            output: PathBuf::from("/tmp/test.wperf"),
+            duration: None,
             buffer_size: None,
         };
-        let running = Arc::new(AtomicBool::new(true));
-        record_impl(&args, &running).unwrap();
-
-        // Verify the file is a valid .wperf with header.
-        let data = std::fs::read(&output).unwrap();
-        assert!(data.len() >= 64); // At least header
-        assert_eq!(&data[0..4], b"wPRF");
-
-        // Cleanup.
-        let _ = std::fs::remove_dir_all(&dir);
+        let stop_requested = Arc::new(AtomicBool::new(false));
+        let result = record_impl(&args, &stop_requested);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), RecordError::NotYetWired));
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,0 +1,241 @@
+//! `wperf record` subcommand — collect scheduling events into a .wperf file.
+//!
+//! Authoritative Inputs:
+//! - final-design.md §1.2 (CLI model)
+//! - final-design.md §4.1-4.4 (wPRF format + crash recovery)
+//! - ADR-002 (feature probing)
+//! - ADR-004 (transport abstraction)
+//!
+//! Current status: CLI scaffold + signal handling + orchestration seam.
+//! The actual BPF load → transport → write pipeline is behind
+//! `#[cfg(feature = "bpf")]` and requires the skeleton build pipeline
+//! to be wired before it can function end-to-end.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+#[cfg(any(feature = "bpf", test))]
+use std::sync::atomic::Ordering;
+
+use crate::cli::RecordArgs;
+
+/// Errors from the record subcommand.
+#[derive(Debug)]
+pub enum RecordError {
+    /// BPF feature not compiled in.
+    NoBpfSupport,
+    /// Signal handler registration failed.
+    SignalSetup(io::Error),
+    /// I/O error (file creation, write, etc).
+    Io(io::Error),
+}
+
+impl std::fmt::Display for RecordError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoBpfSupport => write!(
+                f,
+                "this build of wperf was compiled without BPF support; \
+                 rebuild with `--features bpf`"
+            ),
+            Self::SignalSetup(e) => write!(f, "failed to register signal handler: {e}"),
+            Self::Io(e) => write!(f, "record I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for RecordError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::SignalSetup(e) | Self::Io(e) => Some(e),
+            Self::NoBpfSupport => None,
+        }
+    }
+}
+
+impl From<io::Error> for RecordError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Run the `wperf record` subcommand.
+///
+/// Orchestration flow (once BPF skeleton is wired):
+/// 1. Register SIGINT/SIGTERM handlers → `running` flag
+/// 2. `probe::probe_all()` → `FeatureMatrix`
+/// 3. Open BPF skeleton → configure transport → load → attach
+/// 4. Create `WperfWriter` for output file
+/// 5. Poll transport in loop while `running` is true
+/// 6. Drain remaining events → `writer.finish(drop_count)`
+/// 7. Print summary
+pub fn run(args: &RecordArgs) -> Result<(), RecordError> {
+    // Step 1: Register signal handlers for graceful shutdown.
+    let running = Arc::new(AtomicBool::new(true));
+    register_signal_handlers(&running)?;
+
+    // Step 2-6: BPF pipeline (feature-gated).
+    record_impl(args, &running)
+}
+
+/// Register SIGINT and SIGTERM handlers that clear the `running` flag.
+fn register_signal_handlers(running: &Arc<AtomicBool>) -> Result<(), RecordError> {
+    for sig in [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM] {
+        signal_hook::flag::register(sig, Arc::clone(running)).map_err(RecordError::SignalSetup)?;
+    }
+    Ok(())
+}
+
+/// BPF-enabled record implementation.
+#[cfg(feature = "bpf")]
+fn record_impl(args: &RecordArgs, running: &Arc<AtomicBool>) -> Result<(), RecordError> {
+    use std::fs::File;
+    use std::io::BufWriter;
+    use std::time::Instant;
+
+    use crate::format::writer::WperfWriter;
+
+    eprintln!("wperf: recording to {} ...", args.output.display());
+    if let Some(d) = args.duration {
+        eprintln!("wperf: duration limit: {d:.1}s");
+    }
+
+    // Create output file and writer.
+    let file = File::create(&args.output)?;
+    let mut writer = WperfWriter::new(BufWriter::new(file))?;
+
+    // TODO: probe_all() → FeatureMatrix → skeleton open → configure → load → attach
+    // This is blocked on the BPF skeleton build pipeline (#5 closeout).
+    //
+    // For now, the record loop structure is in place but there is no
+    // transport to poll. We write an empty trace with a valid footer.
+
+    let start = Instant::now();
+    let deadline = args
+        .duration
+        .map(|d| start + std::time::Duration::from_secs_f64(d));
+
+    // Event collection loop (placeholder — no transport yet).
+    while running.load(Ordering::Relaxed) {
+        if let Some(dl) = deadline {
+            if Instant::now() >= dl {
+                break;
+            }
+        }
+        // Once transport is wired:
+        //   transport.poll(100, &mut |event| { writer.write_event(event).unwrap(); });
+        //
+        // For now, just sleep briefly to avoid busy-looping.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    // Drain + finalize.
+    // Once transport is wired: transport.drain(...)
+    let drop_count = 0_u64; // Will come from transport.drop_count()
+    let event_count = writer.event_count();
+    writer.finish(drop_count)?;
+
+    let elapsed = start.elapsed();
+    eprintln!(
+        "wperf: recorded {event_count} events in {:.1}s ({drop_count} drops) → {}",
+        elapsed.as_secs_f64(),
+        args.output.display(),
+    );
+
+    Ok(())
+}
+
+/// Non-BPF build: runtime error at invocation boundary.
+#[cfg(not(feature = "bpf"))]
+fn record_impl(_args: &RecordArgs, _running: &Arc<AtomicBool>) -> Result<(), RecordError> {
+    Err(RecordError::NoBpfSupport)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn signal_handler_registration_succeeds() {
+        let running = Arc::new(AtomicBool::new(true));
+        // Should not panic or error on a normal system.
+        register_signal_handlers(&running).unwrap();
+        assert!(running.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn record_error_display_no_bpf() {
+        let err = RecordError::NoBpfSupport;
+        let msg = format!("{err}");
+        assert!(msg.contains("without BPF support"));
+        assert!(msg.contains("--features bpf"));
+    }
+
+    #[test]
+    fn record_error_display_signal() {
+        let err = RecordError::SignalSetup(io::Error::other("test"));
+        let msg = format!("{err}");
+        assert!(msg.contains("signal handler"));
+        assert!(msg.contains("test"));
+    }
+
+    #[test]
+    fn record_error_display_io() {
+        let err = RecordError::Io(io::Error::other("disk full"));
+        let msg = format!("{err}");
+        assert!(msg.contains("I/O error"));
+        assert!(msg.contains("disk full"));
+    }
+
+    #[test]
+    fn record_error_source() {
+        let err = RecordError::NoBpfSupport;
+        assert!(std::error::Error::source(&err).is_none());
+
+        let err = RecordError::SignalSetup(io::Error::other("x"));
+        assert!(std::error::Error::source(&err).is_some());
+
+        let err = RecordError::Io(io::Error::other("y"));
+        assert!(std::error::Error::source(&err).is_some());
+    }
+
+    #[cfg(not(feature = "bpf"))]
+    #[test]
+    fn record_without_bpf_returns_error() {
+        let args = RecordArgs {
+            output: PathBuf::from("/tmp/test.wperf"),
+            duration: None,
+            buffer_size: None,
+        };
+        let running = Arc::new(AtomicBool::new(true));
+        let result = record_impl(&args, &running);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, RecordError::NoBpfSupport));
+    }
+
+    #[cfg(feature = "bpf")]
+    #[test]
+    fn record_with_duration_produces_valid_file() {
+        let dir = std::env::temp_dir().join("wperf-test-record");
+        std::fs::create_dir_all(&dir).unwrap();
+        let output = dir.join("test-record.wperf");
+
+        let args = RecordArgs {
+            output: output.clone(),
+            duration: Some(0.2), // 200ms — just enough to exercise the loop
+            buffer_size: None,
+        };
+        let running = Arc::new(AtomicBool::new(true));
+        record_impl(&args, &running).unwrap();
+
+        // Verify the file is a valid .wperf with header.
+        let data = std::fs::read(&output).unwrap();
+        assert!(data.len() >= 64); // At least header
+        assert_eq!(&data[0..4], b"wPRF");
+
+        // Cleanup.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Summary
- Add clap-based CLI scaffold with `record`, `report`, and `version` subcommands
- Implement `record` subcommand: argument parsing (`-o`, `-d`, `--buffer-size`), SIGINT/SIGTERM graceful shutdown via `signal-hook` `AtomicBool`, and BPF pipeline orchestration seam behind `#[cfg(feature = "bpf")]`
- Runtime error (not compile error) when BPF feature is absent — default build remains compilable
- BPF-enabled build returns explicit `NotYetWired` error until skeleton pipeline is integrated
- Does **not** deliver end-to-end record pipeline (blocked on BPF skeleton build wiring)

## Authoritative Inputs
- final-design.md §1.2 (unified offline CLI model: `wperf record/report/version`)
- final-design.md §4.1-4.4 (wPRF format + crash recovery)
- ADR-002 (feature probing: `probe_all()` → `FeatureMatrix`)
- ADR-004 (transport abstraction: `EventTransport` trait)
- PR #86 (transport abstraction landed)
- PR #90 (Authoritative Inputs / Deviations process)

## Deviations
None

## Dependency Checklist
- [ ] `clap` 4.6 with `derive` feature — new dependency, not in baseline (CLI framework, standard choice)
- [ ] `signal-hook` 0.4 — new dependency, not in baseline (POSIX signal handling)
- [ ] No deviations from existing baseline deps

## Review Checklist
- [x] **Design conformance**: implementation matches the ADRs/specs listed in Authoritative Inputs — *Critic PASS, Challenger PASS*
- [x] **Deviations declared**: any spec drift is explicitly listed above with a doc update reference — *Critic PASS, Challenger PASS*
- [x] **Code correctness**: logic, error handling, edge cases — *Critic PASS (3 blockers fixed: signal flag, false-success, version subcommand)*
- [x] **Tests**: new/changed code has adequate test coverage — *15 new tests (CLI + record)*
- [x] **CI green**: all required checks pass ✅

## Test Plan
- [x] `cargo test --lib -- cli` — 8 CLI parsing tests pass (including duration validation)
- [x] `cargo test --lib -- record` — 7 record module tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Full `cargo test` — all pass