### PR TITLE
feat: wperf report JSON backend (W3 #17)

### DIFF
--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -26,6 +26,8 @@
 
 use std::collections::HashMap;
 
+use serde::Serialize;
+
 use crate::format::event::{EventType, WperfEvent};
 use crate::graph::types::{NodeKind, ThreadId, TimeWindow};
 use crate::graph::wfg::WaitForGraph;
@@ -51,7 +53,7 @@ struct OffCpuRecord {
 ///   `final-design.md §3.2 / §3.8`. It measures correlation completeness.
 /// - All other counters are **internal diagnostic stats** for debugging and
 ///   are not part of the exported observability contract.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct CorrelationStats {
     /// Total events processed.
     pub events_processed: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ pub mod output;
 pub mod pipeline;
 pub mod probe;
 pub mod record;
+pub mod report;
 pub mod scc;
 pub mod transport;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,9 @@ use wperf::cli::{Cli, Command};
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let result = match cli.command {
-        Command::Record(args) => wperf::record::run(&args),
-        Command::Report(_args) => {
-            eprintln!("wperf report: not yet implemented (planned for W3 #17)");
-            return ExitCode::FAILURE;
-        }
+    let result: Result<(), Box<dyn std::error::Error>> = match cli.command {
+        Command::Record(args) => wperf::record::run(&args).map_err(Into::into),
+        Command::Report(args) => wperf::report::run(&args).map_err(Into::into),
         Command::Version => {
             println!("wperf {}", env!("CARGO_PKG_VERSION"));
             return ExitCode::SUCCESS;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -58,7 +58,7 @@ impl From<ReaderError> for PipelineError {
 }
 
 /// Aggregate statistics from the pipeline.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct PipelineStats {
     /// Total events read from the `.wperf` file.
     pub events_read: u64,

--- a/src/report.rs
+++ b/src/report.rs
@@ -13,7 +13,7 @@ use std::io::{BufWriter, Read, Seek};
 use serde::Serialize;
 
 use crate::cascade::engine::{self, InvariantError};
-use crate::cli::ReportArgs;
+use crate::cli::{ReportArgs, ReportFormat};
 use crate::critical_path::{self, CriticalPath};
 use crate::format::reader::{ReaderError, WperfReader};
 use crate::output::CascadeResult;
@@ -92,7 +92,7 @@ pub struct HealthMetrics {
     pub false_wakeup_filtered_count: Option<u64>,
 }
 
-/// CLI entry point: opens the file, runs the pipeline, writes JSON to stdout.
+/// CLI entry point: opens the file, runs the pipeline, writes output to stdout.
 pub fn run(args: &ReportArgs) -> Result<(), ReportError> {
     let file = File::open(&args.input)?;
     let mut reader = WperfReader::open(file).map_err(|e| match e {
@@ -100,9 +100,14 @@ pub fn run(args: &ReportArgs) -> Result<(), ReportError> {
         other => ReportError::Pipeline(PipelineError::Reader(other)),
     })?;
     let report = build_report(&mut reader)?;
-    let stdout = std::io::stdout().lock();
-    let writer = BufWriter::new(stdout);
-    serde_json::to_writer_pretty(writer, &report).map_err(|e| ReportError::Io(e.into()))?;
+
+    match args.format {
+        ReportFormat::Json => {
+            let stdout = std::io::stdout().lock();
+            let writer = BufWriter::new(stdout);
+            serde_json::to_writer_pretty(writer, &report).map_err(|e| ReportError::Io(e.into()))?;
+        }
+    }
     Ok(())
 }
 
@@ -113,9 +118,11 @@ pub fn build_report<R: Read + Seek>(
     // Step 1-3: parse + sort + correlate
     let (wfg, stats) = pipeline::build_wait_for_graph(reader)?;
 
-    // Read footer metadata for drop_count
-    let metadata = reader.read_metadata().ok();
-    let drop_count = metadata.and_then(|m| m.drop_count);
+    // Read footer metadata for drop_count — propagate real errors (malformed
+    // footer, oversized payload, I/O). Crash-recovery (no footer) is already
+    // expressed as Ok(Metadata { drop_count: None, .. }) by the reader.
+    let metadata = reader.read_metadata().map_err(PipelineError::Reader)?;
+    let drop_count = metadata.drop_count;
 
     // Step 4: cascade redistribution
     let cascaded = engine::cascade_engine(&wfg, None)?;
@@ -265,6 +272,30 @@ mod tests {
         assert!(json["stats"]["events_read"].is_number());
         assert_eq!(json["health"]["drop_count"], 5);
         assert!(json["health"]["partial_stack_count"].is_null());
+    }
+
+    #[test]
+    fn corrupted_metadata_propagates_error() {
+        // Write a valid trace, then corrupt the section table so the metadata
+        // size exceeds MAX_PAYLOAD_SIZE — build_report must return an error,
+        // not silently produce drop_count: null.
+        let mut cursor = Cursor::new(Vec::new());
+        let writer = WperfWriter::new(&mut cursor).unwrap();
+        writer.finish(0).unwrap();
+        let mut buf = cursor.into_inner();
+
+        // The section table entry is at header.section_table_offset.
+        // Entry layout: section_id(4) + offset(8) + size(8) = 20 bytes.
+        // Corrupt the size field (bytes 12..20 of the entry) to exceed MAX_PAYLOAD_SIZE.
+        #[allow(clippy::cast_possible_truncation)] // test-only, file is tiny
+        let st_offset = u64::from_le_bytes(buf[16..24].try_into().unwrap()) as usize;
+        let size_field_offset = st_offset + 12; // skip section_id(4) + offset(8)
+        let bad_size: u64 = (16 * 1024 * 1024) + 1; // MAX_PAYLOAD_SIZE + 1
+        buf[size_field_offset..size_field_offset + 8].copy_from_slice(&bad_size.to_le_bytes());
+
+        let mut reader = WperfReader::open(Cursor::new(buf)).unwrap();
+        let result = build_report(&mut reader);
+        assert!(result.is_err(), "corrupted metadata must propagate error");
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -8,7 +8,7 @@
 //! See plan v2 for the explicit JSON field inventory and deferred fields.
 
 use std::fs::File;
-use std::io::{BufWriter, Read, Seek};
+use std::io::{BufWriter, Read, Seek, Write};
 
 use serde::Serialize;
 
@@ -104,8 +104,10 @@ pub fn run(args: &ReportArgs) -> Result<(), ReportError> {
     match args.format {
         ReportFormat::Json => {
             let stdout = std::io::stdout().lock();
-            let writer = BufWriter::new(stdout);
-            serde_json::to_writer_pretty(writer, &report).map_err(|e| ReportError::Io(e.into()))?;
+            let mut writer = BufWriter::new(stdout);
+            serde_json::to_writer_pretty(&mut writer, &report)
+                .map_err(|e| ReportError::Io(e.into()))?;
+            writer.flush()?;
         }
     }
     Ok(())

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,286 @@
+//! `wperf report` — Phase 1 / W3 partial report backend.
+//!
+//! Orchestrates the full offline analysis pipeline:
+//! parse + sort + correlate + cascade + SCC + heuristic + critical path + knots,
+//! then serializes a JSON report to stdout.
+//!
+//! This is NOT the final §1.2 / §5.1 self-contained HTML report (Phase 3).
+//! See plan v2 for the explicit JSON field inventory and deferred fields.
+
+use std::fs::File;
+use std::io::{BufWriter, Read, Seek};
+
+use serde::Serialize;
+
+use crate::cascade::engine::{self, InvariantError};
+use crate::cli::ReportArgs;
+use crate::critical_path::{self, CriticalPath};
+use crate::format::reader::{ReaderError, WperfReader};
+use crate::output::CascadeResult;
+use crate::pipeline::{self, PipelineError, PipelineStats};
+use crate::scc::heuristic::apply_max_heuristic;
+use crate::scc::knot::{self, Knot};
+use crate::scc::tarjan::build_condensation;
+
+/// Report-level error.
+#[derive(Debug)]
+pub enum ReportError {
+    Io(std::io::Error),
+    Pipeline(PipelineError),
+    Cascade(InvariantError),
+}
+
+impl std::fmt::Display for ReportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Pipeline(e) => write!(f, "pipeline error: {e}"),
+            Self::Cascade(e) => write!(f, "cascade invariant error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ReportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Pipeline(e) => Some(e),
+            Self::Cascade(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for ReportError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<PipelineError> for ReportError {
+    fn from(e: PipelineError) -> Self {
+        Self::Pipeline(e)
+    }
+}
+
+impl From<InvariantError> for ReportError {
+    fn from(e: InvariantError) -> Self {
+        Self::Cascade(e)
+    }
+}
+
+/// Top-level JSON report output.
+#[derive(Debug, Serialize)]
+pub struct ReportOutput {
+    pub cascade: CascadeResult,
+    pub critical_path: Option<CriticalPath>,
+    pub knots: Vec<Knot>,
+    pub stats: PipelineStats,
+    pub health: HealthMetrics,
+}
+
+/// Coverage and health metrics (§5.5).
+///
+/// Fields that lack plumbing in Phase 1 are `None` (serialized as `null`).
+#[derive(Debug, Serialize)]
+pub struct HealthMetrics {
+    pub drop_count: Option<u64>,
+    /// Deferred: no stack capture in Phase 1.
+    pub partial_stack_count: Option<u64>,
+    /// Deferred: cascade engine does not yet track depth truncations.
+    pub cascade_depth_truncation_count: Option<u64>,
+    /// Deferred: no false-wakeup filter in Phase 1.
+    pub false_wakeup_filtered_count: Option<u64>,
+}
+
+/// CLI entry point: opens the file, runs the pipeline, writes JSON to stdout.
+pub fn run(args: &ReportArgs) -> Result<(), ReportError> {
+    let file = File::open(&args.input)?;
+    let mut reader = WperfReader::open(file).map_err(|e| match e {
+        ReaderError::Io(io) => ReportError::Io(io),
+        other => ReportError::Pipeline(PipelineError::Reader(other)),
+    })?;
+    let report = build_report(&mut reader)?;
+    let stdout = std::io::stdout().lock();
+    let writer = BufWriter::new(stdout);
+    serde_json::to_writer_pretty(writer, &report).map_err(|e| ReportError::Io(e.into()))?;
+    Ok(())
+}
+
+/// Pure, testable report builder: runs the full analysis pipeline on a reader.
+pub fn build_report<R: Read + Seek>(
+    reader: &mut WperfReader<R>,
+) -> Result<ReportOutput, ReportError> {
+    // Step 1-3: parse + sort + correlate
+    let (wfg, stats) = pipeline::build_wait_for_graph(reader)?;
+
+    // Read footer metadata for drop_count
+    let metadata = reader.read_metadata().ok();
+    let drop_count = metadata.and_then(|m| m.drop_count);
+
+    // Step 4: cascade redistribution
+    let cascaded = engine::cascade_engine(&wfg, None)?;
+    let cascade = CascadeResult::from_graph(&wfg, &cascaded);
+
+    // Step 5-6: SCC condensation + MAX heuristic
+    let mut cdag = build_condensation(&cascaded);
+    apply_max_heuristic(&mut cdag, &cascaded);
+
+    // Step 7: critical path DP
+    let critical_path = critical_path::critical_path_dp(&cdag);
+
+    // Knot detection
+    let knots = knot::detect_knots(&cdag, &cascaded);
+
+    Ok(ReportOutput {
+        cascade,
+        critical_path,
+        knots,
+        stats,
+        health: HealthMetrics {
+            drop_count,
+            partial_stack_count: None,
+            cascade_depth_truncation_count: None,
+            false_wakeup_filtered_count: None,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::event::{EventType, WperfEvent};
+    use crate::format::writer::WperfWriter;
+    use crate::graph::types::ThreadId;
+    use std::io::Cursor;
+
+    fn write_and_read(events: &[WperfEvent], drop_count: u64) -> WperfReader<Cursor<Vec<u8>>> {
+        let mut cursor = Cursor::new(Vec::new());
+        let mut writer = WperfWriter::new(&mut cursor).unwrap();
+        for ev in events {
+            writer.write_event(ev).unwrap();
+        }
+        writer.finish(drop_count).unwrap();
+        let buf = cursor.into_inner();
+        WperfReader::open(Cursor::new(buf)).unwrap()
+    }
+
+    fn switch_event(ts: u64, prev_tid: u32, next_tid: u32, prev_state: u8) -> WperfEvent {
+        WperfEvent {
+            timestamp_ns: ts,
+            pid: 0,
+            tid: 0,
+            prev_tid,
+            next_tid,
+            prev_pid: 0,
+            next_pid: 0,
+            cpu: 0,
+            event_type: EventType::Switch as u8,
+            prev_state,
+            flags: 0,
+        }
+    }
+
+    fn wakeup_event(ts: u64, source: u32, target: u32) -> WperfEvent {
+        WperfEvent {
+            timestamp_ns: ts,
+            pid: 0,
+            tid: 0,
+            prev_tid: source,
+            next_tid: target,
+            prev_pid: 0,
+            next_pid: 0,
+            cpu: 0,
+            event_type: EventType::Wakeup as u8,
+            prev_state: 0,
+            flags: 0,
+        }
+    }
+
+    #[test]
+    fn empty_trace_produces_valid_report() {
+        let mut reader = write_and_read(&[], 0);
+        let report = build_report(&mut reader).unwrap();
+
+        assert_eq!(report.cascade.edges.len(), 0);
+        assert!(report.critical_path.is_none());
+        assert!(report.knots.is_empty());
+        assert_eq!(report.stats.events_read, 0);
+    }
+
+    #[test]
+    fn figure4_report() {
+        // T1 waits on T2, T2 waits on T3 — linear chain
+        let events = vec![
+            switch_event(1_000_000, 100, 200, 1), // T100 off-CPU
+            wakeup_event(2_000_000, 200, 100),    // T200 wakes T100
+            switch_event(3_000_000, 200, 100, 0), // T100 back on-CPU
+        ];
+        let mut reader = write_and_read(&events, 0);
+        let report = build_report(&mut reader).unwrap();
+
+        assert_eq!(report.stats.events_read, 3);
+        assert_eq!(report.stats.correlation.edges_created, 1);
+        assert_eq!(report.cascade.edges.len(), 1);
+        assert!(report.cascade.graph_metrics.invariants_ok);
+
+        // Edge: T100 → T200 (T100 waited on T200)
+        let edge = &report.cascade.edges[0];
+        assert_eq!(edge.src, ThreadId(100));
+        assert_eq!(edge.dst, ThreadId(200));
+        assert!(edge.raw_wait_ms > 0);
+    }
+
+    #[test]
+    fn report_includes_drop_count() {
+        let mut reader = write_and_read(&[], 42);
+        let report = build_report(&mut reader).unwrap();
+
+        assert_eq!(report.health.drop_count, Some(42));
+    }
+
+    #[test]
+    fn deferred_health_fields_are_null() {
+        let mut reader = write_and_read(&[], 0);
+        let report = build_report(&mut reader).unwrap();
+
+        assert!(report.health.partial_stack_count.is_none());
+        assert!(report.health.cascade_depth_truncation_count.is_none());
+        assert!(report.health.false_wakeup_filtered_count.is_none());
+    }
+
+    #[test]
+    fn report_json_roundtrip() {
+        let events = vec![
+            switch_event(1_000_000, 100, 200, 1),
+            wakeup_event(2_000_000, 200, 100),
+            switch_event(3_000_000, 200, 100, 0),
+        ];
+        let mut reader = write_and_read(&events, 5);
+        let report = build_report(&mut reader).unwrap();
+
+        let json = serde_json::to_value(&report).unwrap();
+        assert!(json["cascade"]["edges"].is_array());
+        assert!(json["cascade"]["graph_metrics"]["invariants_ok"].is_boolean());
+        assert!(json["critical_path"].is_object() || json["critical_path"].is_null());
+        assert!(json["stats"]["events_read"].is_number());
+        assert_eq!(json["health"]["drop_count"], 5);
+        assert!(json["health"]["partial_stack_count"].is_null());
+    }
+
+    #[test]
+    fn error_display() {
+        let err = ReportError::Io(std::io::Error::other("test"));
+        assert!(format!("{err}").contains("I/O error"));
+
+        let err = ReportError::Pipeline(PipelineError::Reader(ReaderError::Io(
+            std::io::Error::other("test"),
+        )));
+        assert!(format!("{err}").contains("pipeline error"));
+    }
+
+    #[test]
+    fn error_source() {
+        let err = ReportError::Io(std::io::Error::other("test"));
+        assert!(std::error::Error::source(&err).is_some());
+    }
+}

--- a/src/scc/knot.rs
+++ b/src/scc/knot.rs
@@ -5,14 +5,17 @@
 
 use petgraph::graph::NodeIndex;
 
+use serde::Serialize;
+
 use crate::graph::types::{NodeKind, ThreadId};
 use crate::graph::wfg::WaitForGraph;
 
 use super::tarjan::CondensationDag;
 
 /// A detected Knot — a sink SCC that passes business filters.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Knot {
+    #[serde(skip)]
     pub dag_index: NodeIndex,
     pub members: Vec<ThreadId>,
 }


### PR DESCRIPTION
## Authoritative Inputs

- `final-design.md` Phase 1 / W3 roadmap: Pipeline integration + JSON output + minimal visualization
- `final-design.md §3.2`: Offline pipeline path (parse → sort → correlate)
- `final-design.md §5.5`: Coverage & Health Dashboard (health metrics contract)
- `PR #93 / pipeline.rs`: `.wperf` → `WaitForGraph` pipeline contract (`build_wait_for_graph`)
- `cascade/engine.rs`: `cascade_engine()` redistribution contract
- `scc/tarjan.rs`: `build_condensation()` → `CondensationDag` contract
- `scc/heuristic.rs`: `apply_max_heuristic()` weight-filling contract
- `critical_path/mod.rs`: `critical_path_dp()` → `Option<CriticalPath>` contract
- `scc/knot.rs`: `detect_knots()` → `Vec<Knot>` contract
- `output.rs`: `CascadeResult::from_graph()` serializable output contract

## Summary

- Implements `wperf report` end-to-end JSON pipeline: parse → sort → correlate → cascade → SCC condensation → MAX heuristic → critical path DP → knot detection → JSON stdout
- Two-layer design: `run()` for CLI entry, `build_report()` pure function for unit testing with `Cursor<Vec<u8>>`
- Adds `Serialize` derives to `CorrelationStats`, `PipelineStats`, and `Knot` (with `#[serde(skip)]` on `dag_index`)
- `HealthMetrics` struct with available fields (`drop_count`) and deferred Phase 1 fields as `Option<T>` → `null`
- Explicit `match args.format` in `run()` for future format extensibility
- **Phase 1 / W3 partial backend only** — NOT the final §1.2 / §5.1 HTML report (Phase 3)

## Files changed

| File | Change |
|------|--------|
| `src/report.rs` | **NEW** — report orchestration + 8 unit tests |
| `src/correlate.rs` | Add `Serialize` to `CorrelationStats` |
| `src/pipeline.rs` | Add `Serialize` to `PipelineStats` |
| `src/scc/knot.rs` | Add `Serialize` to `Knot`, `#[serde(skip)]` on `dag_index` |
| `src/main.rs` | Wire `report::run`, unify match arms via `Box<dyn Error>` |
| `src/lib.rs` | Add `pub mod report` |

## Deviations from spec

- This is Phase 1 JSON backend, not the full §5.1 report. HTML output is Phase 3.
- `HealthMetrics` deferred fields (`partial_stack_count`, `cascade_depth_truncation_count`, `false_wakeup_filtered_count`) serialize as `null` — plumbing lands in later phases.

## Test plan

- [x] 8 unit tests covering: empty trace, figure-4 graph, drop_count, deferred health nulls, JSON roundtrip, corrupted metadata error propagation, error display/source
- [x] All 224 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Review Checklist
- [ ] Correctness — pipeline orchestration order matches §3.2
- [ ] Serialize contract — JSON field names stable for downstream consumers
- [ ] Error handling — metadata errors propagated (not silently swallowed), `ReportError` variants cover all failure modes
- [ ] Test coverage — mutation testing ≥90% kill rate (CI)

Signed-off-by: Maestro