### PR TITLE
feat: insta snapshot tests for .wperf parser output (W2 #14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "criterion"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +317,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -462,6 +479,19 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -950,6 +980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1304,7 @@ dependencies = [
  "clap",
  "criterion",
  "iai-callgrind",
+ "insta",
  "libbpf-rs",
  "libbpf-sys",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ signal-hook = "0.4"
 [dev-dependencies]
 criterion = { version = "0.6", features = ["html_reports"] }
 iai-callgrind = "0.16"
+insta = { version = "1", features = ["yaml"] }
 proptest = "1.11"
 
 [[bench]]

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -1,0 +1,211 @@
+//! Snapshot tests for `.wperf` parser output using `insta`.
+//!
+//! Covers reader round-trip parsing: events, metadata, headers, and error
+//! display strings. JSON/report snapshots are deferred to W3 #21.
+
+use std::io::Cursor;
+
+use wperf::format::event::{EventType, WperfEvent};
+use wperf::format::header::HEADER_SIZE;
+use wperf::format::reader::{ReaderError, WperfReader};
+use wperf::format::writer::WperfWriter;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write events into an in-memory `.wperf` file, return raw bytes.
+fn write_trace(events: &[WperfEvent], drop_count: u64) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let mut w = WperfWriter::new(buf).unwrap();
+    for ev in events {
+        w.write_event(ev).unwrap();
+    }
+    let buf = w.finish(drop_count).unwrap();
+    buf.into_inner()
+}
+
+/// Write events, then open a reader on the result.
+fn write_and_open(events: &[WperfEvent], drop_count: u64) -> WperfReader<Cursor<Vec<u8>>> {
+    let data = write_trace(events, drop_count);
+    WperfReader::open(Cursor::new(data)).unwrap()
+}
+
+fn switch_event(ts: u64, prev_tid: u32, next_tid: u32) -> WperfEvent {
+    WperfEvent {
+        timestamp_ns: ts,
+        pid: 100,
+        tid: 101,
+        prev_tid,
+        next_tid,
+        prev_pid: 100,
+        next_pid: 200,
+        cpu: 0,
+        event_type: EventType::Switch as u8,
+        prev_state: 1,
+        flags: 0,
+    }
+}
+
+fn wakeup_event(ts: u64, source: u32, target: u32) -> WperfEvent {
+    WperfEvent {
+        timestamp_ns: ts,
+        pid: 200,
+        tid: 201,
+        prev_tid: source,
+        next_tid: target,
+        prev_pid: 200,
+        next_pid: 100,
+        cpu: 2,
+        event_type: EventType::Wakeup as u8,
+        prev_state: 0,
+        flags: 0,
+    }
+}
+
+fn exit_event(ts: u64, tid: u32) -> WperfEvent {
+    WperfEvent {
+        timestamp_ns: ts,
+        pid: 100,
+        tid,
+        prev_tid: tid,
+        next_tid: 0,
+        prev_pid: 100,
+        next_pid: 0,
+        cpu: 0,
+        event_type: EventType::Exit as u8,
+        prev_state: 0,
+        flags: 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event parse round-trip snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_single_switch_event() {
+    let events = vec![switch_event(1_000_000, 101, 202)];
+    let mut reader = write_and_open(&events, 0);
+    let parsed = reader.read_all_events().unwrap();
+    insta::assert_debug_snapshot!(parsed);
+}
+
+#[test]
+fn snapshot_single_wakeup_event() {
+    let events = vec![wakeup_event(2_000_000, 201, 101)];
+    let mut reader = write_and_open(&events, 0);
+    let parsed = reader.read_all_events().unwrap();
+    insta::assert_debug_snapshot!(parsed);
+}
+
+#[test]
+fn snapshot_mixed_event_trace() {
+    let events = vec![
+        switch_event(1_000_000, 101, 202),
+        wakeup_event(2_000_000, 201, 101),
+        switch_event(3_000_000, 202, 101),
+        exit_event(4_000_000, 202),
+    ];
+    let mut reader = write_and_open(&events, 0);
+    let parsed = reader.read_all_events().unwrap();
+    insta::assert_debug_snapshot!(parsed);
+}
+
+// ---------------------------------------------------------------------------
+// Metadata round-trip snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_metadata_with_counts() {
+    let events = vec![
+        switch_event(1_000_000, 101, 202),
+        wakeup_event(2_000_000, 201, 101),
+        switch_event(3_000_000, 202, 101),
+    ];
+    let mut reader = write_and_open(&events, 42);
+    // Consume events first so reader position is past data section
+    let _ = reader.read_all_events().unwrap();
+    let metadata = reader.read_metadata().unwrap();
+    insta::assert_debug_snapshot!(metadata);
+}
+
+// ---------------------------------------------------------------------------
+// Empty trace snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_empty_finished_trace() {
+    // Normal empty trace: writer.finish(0) produces a valid file with footer
+    let mut reader = write_and_open(&[], 0);
+    let events = reader.read_all_events().unwrap();
+    let metadata = reader.read_metadata().unwrap();
+    insta::assert_debug_snapshot!("empty_finished_events", events);
+    insta::assert_debug_snapshot!("empty_finished_metadata", metadata);
+}
+
+#[test]
+fn snapshot_crash_recovery_no_footer() {
+    // Crash recovery: section_table_offset == 0, no footer written.
+    // Simulate by writing a valid header + some event data, but with
+    // section_table_offset left at 0 (as if the writer crashed before finish).
+    let events = vec![switch_event(1_000_000, 101, 202)];
+    let data = write_trace(&events, 0);
+
+    // Corrupt: zero out section_table_offset (bytes 16..24 in header)
+    let mut corrupted = data;
+    corrupted[16..24].copy_from_slice(&0u64.to_le_bytes());
+
+    let mut reader = WperfReader::open(Cursor::new(corrupted)).unwrap();
+    let parsed_events = reader.read_all_events().unwrap();
+    let metadata = reader.read_metadata().unwrap();
+    insta::assert_debug_snapshot!("crash_recovery_events", parsed_events);
+    insta::assert_debug_snapshot!("crash_recovery_metadata", metadata);
+}
+
+// ---------------------------------------------------------------------------
+// Reader error Display snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_error_bad_magic() {
+    let mut data = vec![0u8; HEADER_SIZE];
+    data[0..4].copy_from_slice(b"NOPE");
+    let err = WperfReader::open(Cursor::new(data)).unwrap_err();
+    insta::assert_snapshot!("error_bad_magic", format!("{err}"));
+}
+
+#[test]
+fn snapshot_error_unsupported_version() {
+    // Write a valid header, then corrupt the version byte
+    let data = write_trace(&[], 0);
+    let mut corrupted = data;
+    corrupted[4] = 99; // version byte at offset 4
+    let err = WperfReader::open(Cursor::new(corrupted)).unwrap_err();
+    insta::assert_snapshot!("error_unsupported_version", format!("{err}"));
+}
+
+#[test]
+fn snapshot_error_payload_too_large() {
+    let err = ReaderError::PayloadTooLarge {
+        rec_type: 1,
+        length: 20_000_000,
+    };
+    insta::assert_snapshot!("error_payload_too_large", format!("{err}"));
+}
+
+#[test]
+fn snapshot_error_unexpected_payload_size() {
+    let err = ReaderError::UnexpectedPayloadSize {
+        rec_type: 1,
+        expected: 40,
+        actual: 30,
+    };
+    insta::assert_snapshot!("error_unexpected_payload_size", format!("{err}"));
+}
+
+#[test]
+fn snapshot_error_unknown_record_type() {
+    let err = ReaderError::UnknownRecordType(255);
+    insta::assert_snapshot!("error_unknown_record_type", format!("{err}"));
+}

--- a/tests/snapshots/snapshot_tests__crash_recovery_events.snap
+++ b/tests/snapshots/snapshot_tests__crash_recovery_events.snap
@@ -1,0 +1,19 @@
+---
+source: tests/snapshot_tests.rs
+expression: parsed_events
+---
+[
+    WperfEvent {
+        timestamp_ns: 1000000,
+        pid: 100,
+        tid: 101,
+        prev_tid: 101,
+        next_tid: 202,
+        prev_pid: 100,
+        next_pid: 200,
+        cpu: 0,
+        event_type: 1,
+        prev_state: 1,
+        flags: 0,
+    },
+]

--- a/tests/snapshots/snapshot_tests__crash_recovery_metadata.snap
+++ b/tests/snapshots/snapshot_tests__crash_recovery_metadata.snap
@@ -1,0 +1,8 @@
+---
+source: tests/snapshot_tests.rs
+expression: metadata
+---
+Metadata {
+    event_count: None,
+    drop_count: None,
+}

--- a/tests/snapshots/snapshot_tests__empty_finished_events.snap
+++ b/tests/snapshots/snapshot_tests__empty_finished_events.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot_tests.rs
+expression: events
+---
+[]

--- a/tests/snapshots/snapshot_tests__empty_finished_metadata.snap
+++ b/tests/snapshots/snapshot_tests__empty_finished_metadata.snap
@@ -1,0 +1,12 @@
+---
+source: tests/snapshot_tests.rs
+expression: metadata
+---
+Metadata {
+    event_count: Some(
+        0,
+    ),
+    drop_count: Some(
+        0,
+    ),
+}

--- a/tests/snapshots/snapshot_tests__error_bad_magic.snap
+++ b/tests/snapshots/snapshot_tests__error_bad_magic.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot_tests.rs
+expression: "format!(\"{err}\")"
+---
+header error: invalid wPRF magic bytes

--- a/tests/snapshots/snapshot_tests__error_payload_too_large.snap
+++ b/tests/snapshots/snapshot_tests__error_payload_too_large.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot_tests.rs
+expression: "format!(\"{err}\")"
+---
+TLV payload too large: type=1, length=20000000

--- a/tests/snapshots/snapshot_tests__error_unexpected_payload_size.snap
+++ b/tests/snapshots/snapshot_tests__error_unexpected_payload_size.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot_tests.rs
+expression: "format!(\"{err}\")"
+---
+unexpected payload size for type 1: expected 40, got 30

--- a/tests/snapshots/snapshot_tests__error_unknown_record_type.snap
+++ b/tests/snapshots/snapshot_tests__error_unknown_record_type.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot_tests.rs
+expression: "format!(\"{err}\")"
+---
+unknown TLV record type: 255

--- a/tests/snapshots/snapshot_tests__error_unsupported_version.snap
+++ b/tests/snapshots/snapshot_tests__error_unsupported_version.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot_tests.rs
+expression: "format!(\"{err}\")"
+---
+header error: unsupported wPRF version: 99

--- a/tests/snapshots/snapshot_tests__snapshot_metadata_with_counts.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_metadata_with_counts.snap
@@ -1,0 +1,12 @@
+---
+source: tests/snapshot_tests.rs
+expression: metadata
+---
+Metadata {
+    event_count: Some(
+        3,
+    ),
+    drop_count: Some(
+        42,
+    ),
+}

--- a/tests/snapshots/snapshot_tests__snapshot_mixed_event_trace.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_mixed_event_trace.snap
@@ -1,0 +1,58 @@
+---
+source: tests/snapshot_tests.rs
+expression: parsed
+---
+[
+    WperfEvent {
+        timestamp_ns: 1000000,
+        pid: 100,
+        tid: 101,
+        prev_tid: 101,
+        next_tid: 202,
+        prev_pid: 100,
+        next_pid: 200,
+        cpu: 0,
+        event_type: 1,
+        prev_state: 1,
+        flags: 0,
+    },
+    WperfEvent {
+        timestamp_ns: 2000000,
+        pid: 200,
+        tid: 201,
+        prev_tid: 201,
+        next_tid: 101,
+        prev_pid: 200,
+        next_pid: 100,
+        cpu: 2,
+        event_type: 2,
+        prev_state: 0,
+        flags: 0,
+    },
+    WperfEvent {
+        timestamp_ns: 3000000,
+        pid: 100,
+        tid: 101,
+        prev_tid: 202,
+        next_tid: 101,
+        prev_pid: 100,
+        next_pid: 200,
+        cpu: 0,
+        event_type: 1,
+        prev_state: 1,
+        flags: 0,
+    },
+    WperfEvent {
+        timestamp_ns: 4000000,
+        pid: 100,
+        tid: 202,
+        prev_tid: 202,
+        next_tid: 0,
+        prev_pid: 100,
+        next_pid: 0,
+        cpu: 0,
+        event_type: 4,
+        prev_state: 0,
+        flags: 0,
+    },
+]

--- a/tests/snapshots/snapshot_tests__snapshot_single_switch_event.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_single_switch_event.snap
@@ -1,0 +1,19 @@
+---
+source: tests/snapshot_tests.rs
+expression: parsed
+---
+[
+    WperfEvent {
+        timestamp_ns: 1000000,
+        pid: 100,
+        tid: 101,
+        prev_tid: 101,
+        next_tid: 202,
+        prev_pid: 100,
+        next_pid: 200,
+        cpu: 0,
+        event_type: 1,
+        prev_state: 1,
+        flags: 0,
+    },
+]

--- a/tests/snapshots/snapshot_tests__snapshot_single_wakeup_event.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_single_wakeup_event.snap
@@ -1,0 +1,19 @@
+---
+source: tests/snapshot_tests.rs
+expression: parsed
+---
+[
+    WperfEvent {
+        timestamp_ns: 2000000,
+        pid: 200,
+        tid: 201,
+        prev_tid: 201,
+        next_tid: 101,
+        prev_pid: 200,
+        next_pid: 100,
+        cpu: 2,
+        event_type: 2,
+        prev_state: 0,
+        flags: 0,
+    },
+]


### PR DESCRIPTION
## Authoritative Inputs

- `final-design.md:450` — snapshot/golden tests with `insta`: "Highest priority — cheapest defense against semantic drift"
- `final-design.md` Phase 1 exit criteria: "snapshot/golden tests cover JSON + `.wperf` output"
- Task #10 scope: "W2 #14 验证：snapshot tests for `.wperf` 解析输出"

## Summary

- Adds `insta` (v1, yaml feature) to dev-dependencies — snapshot test infrastructure
- 11 snapshot tests covering `.wperf` reader round-trip parsing:
  - Single Switch event parse round-trip
  - Single Wakeup event parse round-trip
  - Mixed multi-event trace (Switch + Wakeup + Switch + Exit)
  - Metadata round-trip (event_count=3, drop_count=42)
  - Empty finished trace (with footer, 0 events)
  - Crash-recovery trace (no footer, section_table_offset=0)
  - 5 reader error Display string snapshots (bad magic, unsupported version, payload too large, unexpected payload size, unknown record type)
- 13 snapshot files in `tests/snapshots/`

## Dependency Checklist

- **New dep**: `insta` v1 (dev-dependency only, yaml feature)
- **Justification**: `final-design.md:450` explicitly lists `insta` or `expect-test` as the recommended snapshot/golden test tool
- **Baseline**: `docs/lessons/REGISTRY.md` has no existing snapshot-test crate baseline — this is the initial selection, not a deviation from an existing baseline
- **Scope**: test-only dev-dependency; not compiled into release binary
- **No new Cargo features** added to the crate itself — feature-on CI item N/A

## Deviations from spec

- **Scope**: This PR covers `.wperf` parser snapshots only — per task #10 boundary
- **Deferred**: `ReportOutput` / JSON report snapshots → #17 / W3 #21; CLI text snapshots → CLI/report follow-up; `CascadeResult` JSON → W3 scope

## Test plan

- [x] 11 snapshot tests pass
- [x] All 227 tests pass (`cargo test`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] All snapshots are deterministic (no HashMap/unordered output)
- [x] Crash-recovery no-footer trace constructed with `section_table_offset=0`, separate from empty finished trace

## Review Checklist
- [ ] Snapshot content correctness — event fields match input construction
- [ ] Crash-recovery vs empty finished trace properly separated
- [ ] Error Display strings match reader error contract
- [ ] Test coverage — mutation testing ≥90% kill rate (CI)

Signed-off-by: Maestro