### PR TITLE
feat: wire actual health metrics into HealthMetrics (W3 #18)

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -80,15 +80,23 @@ pub struct ReportOutput {
 
 /// Coverage and health metrics (§5.5).
 ///
-/// Fields that lack plumbing in Phase 1 are `None` (serialized as `null`).
+/// Actual metrics are wired from the pipeline; fields that lack plumbing
+/// in Phase 1 are `None` (serialized as `null`, meaning "not yet measured").
 #[derive(Debug, Serialize)]
 pub struct HealthMetrics {
+    /// Structural postcondition guard (I-2 ∧ I-7). `false` means cascade
+    /// engine violation — results should not be trusted.
+    pub invariants_ok: bool,
+    /// BPF-side event drops (ringbuf reserve failures / perfarray overflows).
     pub drop_count: Option<u64>,
-    /// Deferred: no stack capture in Phase 1.
+    /// Wakeup events with no matching off-CPU switch — measures correlation
+    /// completeness.
+    pub unmatched_wakeup_count: u64,
+    /// Unavailable: no stack capture in Phase 1.
     pub partial_stack_count: Option<u64>,
-    /// Deferred: cascade engine does not yet track depth truncations.
+    /// Unavailable: cascade engine depth limit exists but is not instrumented.
     pub cascade_depth_truncation_count: Option<u64>,
-    /// Deferred: no false-wakeup filter in Phase 1.
+    /// Unavailable: no false-wakeup filter in Phase 1.
     pub false_wakeup_filtered_count: Option<u64>,
 }
 
@@ -140,13 +148,18 @@ pub fn build_report<R: Read + Seek>(
     // Knot detection
     let knots = knot::detect_knots(&cdag, &cascaded);
 
+    let invariants_ok = cascade.graph_metrics.invariants_ok;
+    let unmatched_wakeup_count = stats.correlation.unmatched_wakeup_count;
+
     Ok(ReportOutput {
         cascade,
         critical_path,
         knots,
         stats,
         health: HealthMetrics {
+            invariants_ok,
             drop_count,
+            unmatched_wakeup_count,
             partial_stack_count: None,
             cascade_depth_truncation_count: None,
             false_wakeup_filtered_count: None,
@@ -248,10 +261,37 @@ mod tests {
     }
 
     #[test]
-    fn deferred_health_fields_are_null() {
+    fn health_metrics_actual_values() {
+        let events = vec![
+            switch_event(1_000_000, 100, 200, 1),
+            wakeup_event(2_000_000, 200, 100),
+            switch_event(3_000_000, 200, 100, 0),
+        ];
+        let mut reader = write_and_read(&events, 7);
+        let report = build_report(&mut reader).unwrap();
+
+        // Actual metrics — wired from pipeline
+        assert!(report.health.invariants_ok);
+        assert_eq!(report.health.drop_count, Some(7));
+        assert_eq!(report.health.unmatched_wakeup_count, 0);
+    }
+
+    #[test]
+    fn health_metrics_unmatched_wakeup() {
+        // Wakeup with no matching off-CPU switch → unmatched
+        let events = vec![wakeup_event(1_000_000, 200, 100)];
+        let mut reader = write_and_read(&events, 0);
+        let report = build_report(&mut reader).unwrap();
+
+        assert_eq!(report.health.unmatched_wakeup_count, 1);
+    }
+
+    #[test]
+    fn health_metrics_unavailable_are_null() {
         let mut reader = write_and_read(&[], 0);
         let report = build_report(&mut reader).unwrap();
 
+        // Unavailable metrics — not yet measured, serialized as null
         assert!(report.health.partial_stack_count.is_none());
         assert!(report.health.cascade_depth_truncation_count.is_none());
         assert!(report.health.false_wakeup_filtered_count.is_none());
@@ -272,8 +312,16 @@ mod tests {
         assert!(json["cascade"]["graph_metrics"]["invariants_ok"].is_boolean());
         assert!(json["critical_path"].is_object() || json["critical_path"].is_null());
         assert!(json["stats"]["events_read"].is_number());
+
+        // Actual health metrics in JSON
+        assert_eq!(json["health"]["invariants_ok"], true);
         assert_eq!(json["health"]["drop_count"], 5);
+        assert_eq!(json["health"]["unmatched_wakeup_count"], 0);
+
+        // Unavailable metrics are null in JSON
         assert!(json["health"]["partial_stack_count"].is_null());
+        assert!(json["health"]["cascade_depth_truncation_count"].is_null());
+        assert!(json["health"]["false_wakeup_filtered_count"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Authoritative Inputs

- `final-design.md §5.5`: Coverage & Health Dashboard — `invariants_ok`, `drop_count`, `unmatched_wakeup_count`, `partial_stack_count`, `cascade_depth_truncation_count`, `false_wakeup_filtered_count`
- `final-design.md` Phase 1 exit criteria: "all 5 coverage metrics exported in JSON"
- PR #94 `report.rs`: `HealthMetrics` struct (schema established)

## Summary

- **HealthMetrics schema completion + currently-available metrics wiring** (not "5 coverage metrics fully implemented")
- Promotes `invariants_ok: bool` from `cascade.graph_metrics` to top-level `HealthMetrics`
- Promotes `unmatched_wakeup_count: u64` from `stats.correlation` to top-level `HealthMetrics`
- 3 deferred metrics remain `Option<T>` → `null`

## Metrics Contract

| Field | Status | Source |
|-------|--------|--------|
| `invariants_ok` | **actual** | `cascade.graph_metrics.invariants_ok` |
| `drop_count` | **actual** (when footer exists) | `reader.read_metadata()` |
| `unmatched_wakeup_count` | **actual** | `stats.correlation.unmatched_wakeup_count` |
| `partial_stack_count` | **unavailable** (`null`) | No stack capture in Phase 1 |
| `cascade_depth_truncation_count` | **unavailable** (`null`) | Cascade engine depth limit exists but not instrumented |
| `false_wakeup_filtered_count` | **unavailable** (`null`) | No false-wakeup filter in Phase 1 |

`null` means **not yet measured**, not "metric satisfied". These 3 deferred metrics require follow-up plumbing before Phase 1 exit can claim full coverage.

## Follow-up tracking

- `cascade_depth_truncation_count`: cascade engine `max_depth` already exists, needs instrumentation counter
- `partial_stack_count`: requires stack capture infrastructure (Phase 2+)
- `false_wakeup_filtered_count`: requires false-wakeup filter (Phase 2a)

## Deviations

This PR delivers schema + 3 actual metrics. 3 deferred metrics remain `null` pending follow-up plumbing.

## Test plan

- [x] `health_metrics_actual_values` — verifies `invariants_ok`, `drop_count`, `unmatched_wakeup_count`
- [x] `health_metrics_unmatched_wakeup` — verifies unmatched wakeup with no prior off-CPU switch
- [x] `health_metrics_unavailable_are_null` — verifies deferred fields are null
- [x] `report_json_roundtrip` — asserts all 6 health fields in JSON (actual values + null for unavailable)
- [x] All 226 tests pass (`cargo test`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Review Checklist
- [ ] Metrics contract correctness — actual vs unavailable matches plan v2
- [ ] JSON schema — all 6 fields present in `health` object
- [ ] Test coverage — both actual values and null semantics tested
- [ ] Mutation testing ≥90% kill rate (CI)

Signed-off-by: Maestro