### PR TITLE
feat: JSON report output snapshot tests (W3 #21)

### DIFF
--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -1,7 +1,10 @@
-//! Snapshot tests for `.wperf` parser output using `insta`.
+//! Snapshot tests for `.wperf` parser output and JSON report output.
 //!
-//! Covers reader round-trip parsing: events, metadata, headers, and error
-//! display strings. JSON/report snapshots are deferred to W3 #21.
+//! Parser snapshots (W2 #14): reader round-trip parsing of events, metadata,
+//! headers, and error display strings.
+//!
+//! Report snapshots (W3 #21): JSON report output from `build_report()` pure
+//! seam, covering schema shape and health metrics contract.
 
 use std::io::Cursor;
 
@@ -9,6 +12,7 @@ use wperf::format::event::{EventType, WperfEvent};
 use wperf::format::header::HEADER_SIZE;
 use wperf::format::reader::{ReaderError, WperfReader};
 use wperf::format::writer::WperfWriter;
+use wperf::report;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -208,4 +212,56 @@ fn snapshot_error_unexpected_payload_size() {
 fn snapshot_error_unknown_record_type() {
     let err = ReaderError::UnknownRecordType(255);
     insta::assert_snapshot!("error_unknown_record_type", format!("{err}"));
+}
+
+// ---------------------------------------------------------------------------
+// JSON report output snapshots (W3 #21)
+// ---------------------------------------------------------------------------
+
+/// Helper: write events → open reader → `build_report()`.
+fn build_test_report(events: &[WperfEvent], drop_count: u64) -> report::ReportOutput {
+    let mut reader = write_and_open(events, drop_count);
+    report::build_report(&mut reader).unwrap()
+}
+
+#[test]
+fn snapshot_empty_trace_report() {
+    let report = build_test_report(&[], 0);
+    let json = serde_json::to_value(&report).unwrap();
+    insta::assert_yaml_snapshot!(json);
+}
+
+#[test]
+fn snapshot_single_edge_report() {
+    // 1 matched wait edge: T101 goes off-CPU, T201 wakes T101, T101 back on.
+    let events = vec![
+        switch_event(1_000_000, 101, 202),
+        wakeup_event(2_000_000, 201, 101),
+        switch_event(3_000_000, 202, 101),
+    ];
+    let report = build_test_report(&events, 5);
+    let json = serde_json::to_value(&report).unwrap();
+    insta::assert_yaml_snapshot!(json);
+}
+
+#[test]
+fn snapshot_unmatched_wakeup_report() {
+    // Wakeup with no matching off-CPU switch → unmatched_wakeup_count > 0.
+    let events = vec![wakeup_event(1_000_000, 201, 101)];
+    let report = build_test_report(&events, 0);
+    let json = serde_json::to_value(&report).unwrap();
+    insta::assert_yaml_snapshot!(json);
+}
+
+#[test]
+fn snapshot_health_metrics_schema() {
+    // Verifies all 6 health fields: 3 actual + 3 null (unavailable in Phase 1).
+    let events = vec![
+        switch_event(1_000_000, 101, 202),
+        wakeup_event(2_000_000, 201, 101),
+        switch_event(3_000_000, 202, 101),
+    ];
+    let report = build_test_report(&events, 7);
+    let health_json = serde_json::to_value(&report.health).unwrap();
+    insta::assert_yaml_snapshot!(health_json);
 }

--- a/tests/snapshots/snapshot_tests__snapshot_empty_trace_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_empty_trace_report.snap
@@ -1,0 +1,29 @@
+---
+source: tests/snapshot_tests.rs
+expression: json
+---
+cascade:
+  edges: []
+  graph_metrics:
+    edge_count: 0
+    invariants_ok: true
+    node_count: 0
+    total_attributed_delay_ms: 0
+    total_raw_wait_ms: 0
+critical_path: ~
+health:
+  cascade_depth_truncation_count: ~
+  drop_count: 0
+  false_wakeup_filtered_count: ~
+  invariants_ok: true
+  partial_stack_count: ~
+  unmatched_wakeup_count: 0
+knots: []
+stats:
+  correlation:
+    edges_created: 0
+    events_processed: 0
+    switch_in_without_waker_count: 0
+    unmatched_switch_in_count: 0
+    unmatched_wakeup_count: 0
+  events_read: 0

--- a/tests/snapshots/snapshot_tests__snapshot_health_metrics_schema.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_health_metrics_schema.snap
@@ -1,0 +1,10 @@
+---
+source: tests/snapshot_tests.rs
+expression: health_json
+---
+cascade_depth_truncation_count: ~
+drop_count: 7
+false_wakeup_filtered_count: ~
+invariants_ok: true
+partial_stack_count: ~
+unmatched_wakeup_count: 0

--- a/tests/snapshots/snapshot_tests__snapshot_single_edge_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_single_edge_report.snap
@@ -1,0 +1,41 @@
+---
+source: tests/snapshot_tests.rs
+expression: json
+---
+cascade:
+  edges:
+    - attributed_delay_ms: 2
+      dst: 201
+      raw_wait_ms: 2
+      src: 101
+  graph_metrics:
+    edge_count: 1
+    invariants_ok: true
+    node_count: 2
+    total_attributed_delay_ms: 2
+    total_raw_wait_ms: 2
+critical_path:
+  chain:
+    - members:
+        - 101
+      weight: 2
+    - members:
+        - 201
+      weight: 2
+  total_weight: 6
+health:
+  cascade_depth_truncation_count: ~
+  drop_count: 5
+  false_wakeup_filtered_count: ~
+  invariants_ok: true
+  partial_stack_count: ~
+  unmatched_wakeup_count: 0
+knots: []
+stats:
+  correlation:
+    edges_created: 1
+    events_processed: 3
+    switch_in_without_waker_count: 0
+    unmatched_switch_in_count: 1
+    unmatched_wakeup_count: 0
+  events_read: 3

--- a/tests/snapshots/snapshot_tests__snapshot_unmatched_wakeup_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_unmatched_wakeup_report.snap
@@ -1,0 +1,29 @@
+---
+source: tests/snapshot_tests.rs
+expression: json
+---
+cascade:
+  edges: []
+  graph_metrics:
+    edge_count: 0
+    invariants_ok: true
+    node_count: 0
+    total_attributed_delay_ms: 0
+    total_raw_wait_ms: 0
+critical_path: ~
+health:
+  cascade_depth_truncation_count: ~
+  drop_count: 0
+  false_wakeup_filtered_count: ~
+  invariants_ok: true
+  partial_stack_count: ~
+  unmatched_wakeup_count: 1
+knots: []
+stats:
+  correlation:
+    edges_created: 0
+    events_processed: 1
+    switch_in_without_waker_count: 0
+    unmatched_switch_in_count: 0
+    unmatched_wakeup_count: 1
+  events_read: 1


### PR DESCRIPTION
## Summary
- Add 4 insta YAML snapshot tests for `ReportOutput` JSON schema via `build_report()` pure seam
- Tests: `empty_trace_report`, `single_edge_report`, `unmatched_wakeup_report`, `health_metrics_schema`
- Completes JSON + `.wperf` snapshot coverage portion of Phase 1 exit criteria

## Authoritative Inputs
- `final-design.md:450` — snapshot/golden tests: "JSON output, `.wperf` format, CLI text"
- `final-design.md` Phase 1 exit criteria: "snapshot/golden tests cover JSON + `.wperf` output"
- PR #95: `insta` snapshot infra (`.wperf` parser snapshots)
- PR #94: `ReportOutput` JSON schema + `build_report()` testability seam
- PR #96: `HealthMetrics` 6-field contract (3 actual + 3 null)

## Deviations
- CLI text snapshots deferred (per PR #95 scope decision)
- dot/SVG snapshots belong to W3 #19

## Review Checklist
- [x] **Design conformance**: snapshot tests match approved v2 plan (4 test cases, `build_report()` seam)
- [x] **Deviations declared**: CLI text and dot/SVG snapshots explicitly deferred
- [x] **Code correctness**: deterministic inputs, no shell-out, no `.snap.new` residuals
- [x] **Tests pass**: 15/15 snapshot tests, `cargo test --quiet` all pass
- [x] **Clippy clean**: `cargo clippy --all-targets -- -D warnings` pass
- [x] **Fmt clean**: `cargo fmt --check` pass
- [ ] **CI**: mutation testing ≥90% kill rate (pending)

## Test plan
- [x] `cargo test` — all 15 snapshot tests pass (11 existing + 4 new)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] CI mutation testing ≥90% kill rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)