### PR TITLE
feat: DOT text backend for cascade visualization (W3 #19 partial)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,7 @@ pub struct ReportArgs {
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum ReportFormat {
     Json,
+    Dot,
 }
 
 /// Parse a positive duration value (rejects zero and negative).

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -20,16 +20,13 @@ pub fn render_dot(cascade: &CascadeResult) -> String {
     writeln!(out, "    node [shape=box];").unwrap();
 
     // Collect and sort unique node ids for deterministic output.
-    let mut nodes: Vec<i64> = Vec::new();
-    for edge in &cascade.edges {
-        if !nodes.contains(&edge.src.0) {
-            nodes.push(edge.src.0);
-        }
-        if !nodes.contains(&edge.dst.0) {
-            nodes.push(edge.dst.0);
-        }
-    }
+    let mut nodes: Vec<i64> = cascade
+        .edges
+        .iter()
+        .flat_map(|e| [e.src.0, e.dst.0])
+        .collect();
     nodes.sort_unstable();
+    nodes.dedup();
 
     // Emit nodes. Labels use ThreadId::Display for human-readable names
     // (e.g. "NIC", "Disk" for pseudo-threads, "T101" for regular threads).
@@ -78,15 +75,9 @@ mod tests {
 
     fn make_cascade(edges: Vec<EdgeOutput>) -> CascadeResult {
         let edge_count = edges.len();
-        let mut node_ids: Vec<i64> = Vec::new();
-        for e in &edges {
-            if !node_ids.contains(&e.src.0) {
-                node_ids.push(e.src.0);
-            }
-            if !node_ids.contains(&e.dst.0) {
-                node_ids.push(e.dst.0);
-            }
-        }
+        let mut node_ids: Vec<i64> = edges.iter().flat_map(|e| [e.src.0, e.dst.0]).collect();
+        node_ids.sort_unstable();
+        node_ids.dedup();
         CascadeResult {
             edges,
             graph_metrics: GraphMetrics {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Write;
 
+use crate::graph::types::ThreadId;
 use crate::output::{CascadeResult, EdgeOutput};
 
 /// Render a `CascadeResult` as a Graphviz DOT digraph.
@@ -30,15 +31,10 @@ pub fn render_dot(cascade: &CascadeResult) -> String {
     }
     nodes.sort_unstable();
 
-    // Emit nodes.
+    // Emit nodes. Labels use ThreadId::Display for human-readable names
+    // (e.g. "NIC", "Disk" for pseudo-threads, "T101" for regular threads).
     for tid in &nodes {
-        writeln!(
-            out,
-            "    {} [label=\"T{}\"];",
-            dot_id(*tid),
-            dot_escape_label(*tid)
-        )
-        .unwrap();
+        writeln!(out, "    {} [label=\"{}\"];", dot_id(*tid), ThreadId(*tid)).unwrap();
     }
 
     // Emit edges sorted by full key for determinism — includes label fields
@@ -72,11 +68,6 @@ fn dot_id(tid: i64) -> String {
     } else {
         format!("t{tid}")
     }
-}
-
-/// Produce a DOT-safe label string for a thread id.
-fn dot_escape_label(tid: i64) -> String {
-    format!("{tid}")
 }
 
 #[cfg(test)]
@@ -142,7 +133,7 @@ mod tests {
             attributed_delay_ms: 8,
         }]);
         let dot = render_dot(&cascade);
-        assert!(dot.contains("neg_4 [label=\"T-4\"]"));
+        assert!(dot.contains("neg_4 [label=\"NIC\"]"));
         assert!(dot.contains("neg_4 -> t100"));
     }
 

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,0 +1,181 @@
+//! Graphviz DOT backend for cascade results.
+//!
+//! Converts a `CascadeResult` into DOT format for visualization via
+//! `dot -Tsvg`. This is the W3 #19 DOT text backend; actual SVG
+//! generation is deferred to a follow-up task.
+
+use std::fmt::Write;
+
+use crate::output::{CascadeResult, EdgeOutput};
+
+/// Render a `CascadeResult` as a Graphviz DOT digraph.
+///
+/// Output is deterministic: nodes sorted by `ThreadId`, edges sorted by
+/// (src, dst). All identifiers are escaped for DOT safety.
+pub fn render_dot(cascade: &CascadeResult) -> String {
+    let mut out = String::new();
+    writeln!(out, "digraph wperf {{").unwrap();
+    writeln!(out, "    rankdir=LR;").unwrap();
+    writeln!(out, "    node [shape=box];").unwrap();
+
+    // Collect and sort unique node ids for deterministic output.
+    let mut nodes: Vec<i64> = Vec::new();
+    for edge in &cascade.edges {
+        if !nodes.contains(&edge.src.0) {
+            nodes.push(edge.src.0);
+        }
+        if !nodes.contains(&edge.dst.0) {
+            nodes.push(edge.dst.0);
+        }
+    }
+    nodes.sort_unstable();
+
+    // Emit nodes.
+    for tid in &nodes {
+        writeln!(
+            out,
+            "    {} [label=\"T{}\"];",
+            dot_id(*tid),
+            dot_escape_label(*tid)
+        )
+        .unwrap();
+    }
+
+    // Emit edges sorted by (src, dst) for determinism.
+    let mut edges: Vec<&EdgeOutput> = cascade.edges.iter().collect();
+    edges.sort_unstable_by_key(|e| (e.src, e.dst));
+
+    for edge in edges {
+        writeln!(
+            out,
+            "    {} -> {} [label=\"{}ms (raw {}ms)\"];",
+            dot_id(edge.src.0),
+            dot_id(edge.dst.0),
+            edge.attributed_delay_ms,
+            edge.raw_wait_ms,
+        )
+        .unwrap();
+    }
+
+    writeln!(out, "}}").unwrap();
+    out
+}
+
+/// Produce a DOT-safe node identifier from a thread id.
+///
+/// Negative ids (pseudo-threads) get a `neg_` prefix to avoid DOT syntax
+/// issues with leading `-`.
+fn dot_id(tid: i64) -> String {
+    if tid < 0 {
+        format!("neg_{}", tid.unsigned_abs())
+    } else {
+        format!("t{tid}")
+    }
+}
+
+/// Produce a DOT-safe label string for a thread id.
+fn dot_escape_label(tid: i64) -> String {
+    format!("{tid}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::types::ThreadId;
+    use crate::output::{CascadeResult, EdgeOutput, GraphMetrics};
+
+    fn make_cascade(edges: Vec<EdgeOutput>) -> CascadeResult {
+        let edge_count = edges.len();
+        let mut node_ids: Vec<i64> = Vec::new();
+        for e in &edges {
+            if !node_ids.contains(&e.src.0) {
+                node_ids.push(e.src.0);
+            }
+            if !node_ids.contains(&e.dst.0) {
+                node_ids.push(e.dst.0);
+            }
+        }
+        CascadeResult {
+            edges,
+            graph_metrics: GraphMetrics {
+                total_raw_wait_ms: 0,
+                total_attributed_delay_ms: 0,
+                invariants_ok: true,
+                edge_count,
+                node_count: node_ids.len(),
+            },
+        }
+    }
+
+    #[test]
+    fn empty_graph() {
+        let cascade = make_cascade(vec![]);
+        let dot = render_dot(&cascade);
+        assert!(dot.contains("digraph wperf {"));
+        assert!(dot.contains('}'));
+        // No nodes or edges
+        assert!(!dot.contains("->"));
+        assert!(!dot.contains("[label=\"T"));
+    }
+
+    #[test]
+    fn single_edge() {
+        let cascade = make_cascade(vec![EdgeOutput {
+            src: ThreadId(100),
+            dst: ThreadId(200),
+            raw_wait_ms: 5,
+            attributed_delay_ms: 3,
+        }]);
+        let dot = render_dot(&cascade);
+        assert!(dot.contains("t100 [label=\"T100\"]"));
+        assert!(dot.contains("t200 [label=\"T200\"]"));
+        assert!(dot.contains("t100 -> t200 [label=\"3ms (raw 5ms)\"]"));
+    }
+
+    #[test]
+    fn negative_tid_escaping() {
+        let cascade = make_cascade(vec![EdgeOutput {
+            src: ThreadId(-4),
+            dst: ThreadId(100),
+            raw_wait_ms: 10,
+            attributed_delay_ms: 8,
+        }]);
+        let dot = render_dot(&cascade);
+        assert!(dot.contains("neg_4 [label=\"T-4\"]"));
+        assert!(dot.contains("neg_4 -> t100"));
+    }
+
+    #[test]
+    fn deterministic_output() {
+        // Create edges in non-sorted order, verify output is sorted.
+        let cascade = make_cascade(vec![
+            EdgeOutput {
+                src: ThreadId(300),
+                dst: ThreadId(100),
+                raw_wait_ms: 2,
+                attributed_delay_ms: 1,
+            },
+            EdgeOutput {
+                src: ThreadId(100),
+                dst: ThreadId(200),
+                raw_wait_ms: 5,
+                attributed_delay_ms: 3,
+            },
+        ]);
+        let dot1 = render_dot(&cascade);
+        let dot2 = render_dot(&cascade);
+        assert_eq!(dot1, dot2);
+
+        // Nodes should appear in sorted order: 100, 200, 300
+        let pos_100 = dot1.find("t100 [label").unwrap();
+        let pos_200 = dot1.find("t200 [label").unwrap();
+        let pos_300 = dot1.find("t300 [label").unwrap();
+        assert!(pos_100 < pos_200);
+        assert!(pos_200 < pos_300);
+
+        // Edges should appear sorted by (src, dst): 100→200 before 300→100
+        let edge_100_200 = dot1.find("t100 -> t200").unwrap();
+        let edge_300_100 = dot1.find("t300 -> t100").unwrap();
+        assert!(edge_100_200 < edge_300_100);
+    }
+}

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -41,10 +41,10 @@ pub fn render_dot(cascade: &CascadeResult) -> String {
         .unwrap();
     }
 
-    // Emit edges sorted by (src, dst) for determinism. Stable sort preserves
-    // upstream `CascadeResult` ordering for edges with the same (src, dst).
+    // Emit edges sorted by full key for determinism — includes label fields
+    // so output is self-contained and doesn't depend on upstream edge order.
     let mut edges: Vec<&EdgeOutput> = cascade.edges.iter().collect();
-    edges.sort_by_key(|e| (e.src, e.dst));
+    edges.sort_unstable_by_key(|e| (e.src, e.dst, e.attributed_delay_ms, e.raw_wait_ms));
 
     for edge in edges {
         writeln!(
@@ -178,5 +178,31 @@ mod tests {
         let edge_100_200 = dot1.find("t100 -> t200").unwrap();
         let edge_300_100 = dot1.find("t300 -> t100").unwrap();
         assert!(edge_100_200 < edge_300_100);
+    }
+
+    #[test]
+    fn duplicate_src_dst_deterministic() {
+        // Two edges with same (src, dst) but different weights must have
+        // deterministic ordering based on label fields.
+        let cascade = make_cascade(vec![
+            EdgeOutput {
+                src: ThreadId(100),
+                dst: ThreadId(200),
+                raw_wait_ms: 10,
+                attributed_delay_ms: 8,
+            },
+            EdgeOutput {
+                src: ThreadId(100),
+                dst: ThreadId(200),
+                raw_wait_ms: 5,
+                attributed_delay_ms: 3,
+            },
+        ]);
+        let dot = render_dot(&cascade);
+
+        // Smaller attributed_delay_ms (3) must appear before larger (8).
+        let pos_3ms = dot.find("label=\"3ms (raw 5ms)\"").unwrap();
+        let pos_8ms = dot.find("label=\"8ms (raw 10ms)\"").unwrap();
+        assert!(pos_3ms < pos_8ms);
     }
 }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -41,9 +41,10 @@ pub fn render_dot(cascade: &CascadeResult) -> String {
         .unwrap();
     }
 
-    // Emit edges sorted by (src, dst) for determinism.
+    // Emit edges sorted by (src, dst) for determinism. Stable sort preserves
+    // upstream `CascadeResult` ordering for edges with the same (src, dst).
     let mut edges: Vec<&EdgeOutput> = cascade.edges.iter().collect();
-    edges.sort_unstable_by_key(|e| (e.src, e.dst));
+    edges.sort_by_key(|e| (e.src, e.dst));
 
     for edge in edges {
         writeln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cascade;
 pub mod cli;
 pub mod correlate;
 pub mod critical_path;
+pub mod dot;
 pub mod format;
 pub mod graph;
 pub mod output;

--- a/src/report.rs
+++ b/src/report.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 use crate::cascade::engine::{self, InvariantError};
 use crate::cli::{ReportArgs, ReportFormat};
 use crate::critical_path::{self, CriticalPath};
+use crate::dot;
 use crate::format::reader::{ReaderError, WperfReader};
 use crate::output::CascadeResult;
 use crate::pipeline::{self, PipelineError, PipelineStats};
@@ -115,6 +116,13 @@ pub fn run(args: &ReportArgs) -> Result<(), ReportError> {
             let mut writer = BufWriter::new(stdout);
             serde_json::to_writer_pretty(&mut writer, &report)
                 .map_err(|e| ReportError::Io(e.into()))?;
+            writer.flush()?;
+        }
+        ReportFormat::Dot => {
+            let stdout = std::io::stdout().lock();
+            let mut writer = BufWriter::new(stdout);
+            let dot_output = dot::render_dot(&report.cascade);
+            writer.write_all(dot_output.as_bytes())?;
             writer.flush()?;
         }
     }

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -1,13 +1,16 @@
-//! Snapshot tests for `.wperf` parser output and JSON report output.
+//! Snapshot tests for `.wperf` parser output, JSON report output, and DOT output.
 //!
 //! Parser snapshots (W2 #14): reader round-trip parsing of events, metadata,
 //! headers, and error display strings.
 //!
 //! Report snapshots (W3 #21): JSON report output from `build_report()` pure
 //! seam, covering schema shape and health metrics contract.
+//!
+//! DOT snapshots (W3 #19): Graphviz DOT text output from `render_dot()`.
 
 use std::io::Cursor;
 
+use wperf::dot;
 use wperf::format::event::{EventType, WperfEvent};
 use wperf::format::header::HEADER_SIZE;
 use wperf::format::reader::{ReaderError, WperfReader};
@@ -264,4 +267,43 @@ fn snapshot_health_metrics_schema() {
     let report = build_test_report(&events, 7);
     let health_json = serde_json::to_value(&report.health).unwrap();
     insta::assert_yaml_snapshot!(health_json);
+}
+
+// ---------------------------------------------------------------------------
+// DOT output snapshots (W3 #19)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_dot_empty_graph() {
+    let report = build_test_report(&[], 0);
+    let dot_output = dot::render_dot(&report.cascade);
+    insta::assert_snapshot!(dot_output);
+}
+
+#[test]
+fn snapshot_dot_single_edge() {
+    let events = vec![
+        switch_event(1_000_000, 101, 202),
+        wakeup_event(2_000_000, 201, 101),
+        switch_event(3_000_000, 202, 101),
+    ];
+    let report = build_test_report(&events, 0);
+    let dot_output = dot::render_dot(&report.cascade);
+    insta::assert_snapshot!(dot_output);
+}
+
+#[test]
+fn snapshot_dot_multi_edge() {
+    // T101 waits on T201, T201 waits on T301 — two edges.
+    let events = vec![
+        switch_event(1_000_000, 101, 202),
+        switch_event(1_500_000, 201, 302),
+        wakeup_event(2_000_000, 301, 201),
+        switch_event(2_500_000, 302, 201),
+        wakeup_event(3_000_000, 201, 101),
+        switch_event(3_500_000, 202, 101),
+    ];
+    let report = build_test_report(&events, 0);
+    let dot_output = dot::render_dot(&report.cascade);
+    insta::assert_snapshot!(dot_output);
 }

--- a/tests/snapshots/snapshot_tests__snapshot_dot_empty_graph.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_dot_empty_graph.snap
@@ -1,0 +1,8 @@
+---
+source: tests/snapshot_tests.rs
+expression: dot_output
+---
+digraph wperf {
+    rankdir=LR;
+    node [shape=box];
+}

--- a/tests/snapshots/snapshot_tests__snapshot_dot_multi_edge.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_dot_multi_edge.snap
@@ -1,0 +1,13 @@
+---
+source: tests/snapshot_tests.rs
+expression: dot_output
+---
+digraph wperf {
+    rankdir=LR;
+    node [shape=box];
+    t101 [label="T101"];
+    t201 [label="T201"];
+    t301 [label="T301"];
+    t101 -> t201 [label="1ms (raw 2ms)"];
+    t201 -> t301 [label="1ms (raw 1ms)"];
+}

--- a/tests/snapshots/snapshot_tests__snapshot_dot_single_edge.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_dot_single_edge.snap
@@ -1,0 +1,11 @@
+---
+source: tests/snapshot_tests.rs
+expression: dot_output
+---
+digraph wperf {
+    rankdir=LR;
+    node [shape=box];
+    t101 [label="T101"];
+    t201 [label="T201"];
+    t101 -> t201 [label="2ms (raw 2ms)"];
+}


### PR DESCRIPTION
## Summary
- Add `dot` module: `CascadeResult` → Graphviz DOT format with deterministic node/edge ordering and proper ID escaping
- Wire `--format dot` into `wperf report` CLI
- Unit tests (empty graph, single edge, negative TID escaping, determinism) + 3 DOT snapshot tests

## Authoritative Inputs
- `final-design.md:552` — W3 core: "Pipeline integration + JSON output + minimal visualization (dot SVG)"
- `final-design.md:578` — Phase 1 exit gate: "minimal SVG readable"
- PR #94: `CascadeResult` with edges + graph_metrics

## Deviations
- **DOT text backend only** — does NOT satisfy Phase 1 exit gate "minimal SVG readable"
- SVG generation path (shell out to `dot -Tsvg` or embedded renderer) is a separate follow-up task
- Task #15 is partial after this PR; SVG follow-up must be tracked separately

## Review Checklist
- [x] **Design conformance**: DOT backend matches approved v2 plan scope
- [x] **Deviations declared**: DOT-only, SVG deferred
- [x] **Code correctness**: deterministic output, proper DOT ID escaping for negative TIDs
- [x] **Tests pass**: all tests pass including 4 unit tests + 3 snapshot tests
- [x] **Clippy clean**: `cargo clippy --all-targets -- -D warnings` pass
- [x] **Fmt clean**: `cargo fmt --check` pass
- [ ] **CI**: mutation testing ≥90% kill rate (pending)

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] CI mutation testing ≥90% kill rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)