### PR TITLE
feat: SVG generation via Graphviz dot (Phase 1 gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # 34e11487
 
-      - name: Install BPF build dependencies
-        run: sudo apt-get update && sudo apt-get install -y libelf-dev zlib1g-dev
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libelf-dev zlib1g-dev graphviz
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,7 @@ pub struct ReportArgs {
 pub enum ReportFormat {
     Json,
     Dot,
+    Svg,
 }
 
 /// Parse a positive duration value (rejects zero and negative).

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -97,16 +97,21 @@ fn render_svg_with_command(
             }
         })?;
 
-    // Write DOT to stdin, then close it so `dot` can process.
-    {
+    // Write DOT to stdin in a separate thread to avoid deadlock: if dot's
+    // stdout/stderr buffers fill before we finish writing, both processes block.
+    let mut stdin = child.stdin.take().expect("stdin was piped");
+    let writer_thread = std::thread::spawn(move || {
         use std::io::Write;
-        let stdin = child.stdin.as_mut().expect("stdin was piped");
-        stdin
-            .write_all(dot_input.as_bytes())
-            .map_err(ReportError::Io)?;
-    }
+        stdin.write_all(dot_input.as_bytes())
+    });
 
     let output = child.wait_with_output().map_err(ReportError::Io)?;
+
+    // Propagate any stdin write error.
+    writer_thread
+        .join()
+        .expect("stdin writer thread panicked")
+        .map_err(ReportError::Io)?;
 
     if !output.status.success() {
         return Err(ReportError::GraphvizFailed {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,13 +1,14 @@
-//! Graphviz DOT backend for cascade results.
+//! Graphviz DOT and SVG backends for cascade results.
 //!
-//! Converts a `CascadeResult` into DOT format for visualization via
-//! `dot -Tsvg`. This is the W3 #19 DOT text backend; actual SVG
-//! generation is deferred to a follow-up task.
+//! Converts a `CascadeResult` into DOT format for visualization, and
+//! optionally renders SVG by invoking external Graphviz `dot -Tsvg`.
 
 use std::fmt::Write;
+use std::process::Command;
 
 use crate::graph::types::ThreadId;
 use crate::output::{CascadeResult, EdgeOutput};
+use crate::report::ReportError;
 
 /// Render a `CascadeResult` as a Graphviz DOT digraph.
 ///
@@ -67,11 +68,63 @@ fn dot_id(tid: i64) -> String {
     }
 }
 
+/// Render a `CascadeResult` as SVG by piping DOT through Graphviz `dot -Tsvg`.
+///
+/// Returns `ReportError::GraphvizNotFound` if `dot` is not in PATH, or
+/// `ReportError::GraphvizFailed` if the process exits non-zero.
+pub fn render_svg(cascade: &CascadeResult) -> Result<Vec<u8>, ReportError> {
+    render_svg_with_command(cascade, "dot")
+}
+
+/// Internal testable seam: same as `render_svg` but accepts a custom command path.
+fn render_svg_with_command(
+    cascade: &CascadeResult,
+    dot_command: &str,
+) -> Result<Vec<u8>, ReportError> {
+    let dot_input = render_dot(cascade);
+
+    let mut child = Command::new(dot_command)
+        .args(["-Tsvg"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                ReportError::GraphvizNotFound
+            } else {
+                ReportError::Io(e)
+            }
+        })?;
+
+    // Write DOT to stdin, then close it so `dot` can process.
+    {
+        use std::io::Write;
+        let stdin = child.stdin.as_mut().expect("stdin was piped");
+        stdin
+            .write_all(dot_input.as_bytes())
+            .map_err(ReportError::Io)?;
+    }
+
+    let output = child.wait_with_output().map_err(ReportError::Io)?;
+
+    if !output.status.success() {
+        return Err(ReportError::GraphvizFailed {
+            exit_code: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+
+    Ok(output.stdout)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::graph::types::ThreadId;
     use crate::output::{CascadeResult, EdgeOutput, GraphMetrics};
+    use crate::report::ReportError;
+    use std::process::Command;
 
     fn make_cascade(edges: Vec<EdgeOutput>) -> CascadeResult {
         let edge_count = edges.len();
@@ -186,5 +239,68 @@ mod tests {
         let pos_3ms = dot.find("label=\"3ms (raw 5ms)\"").unwrap();
         let pos_8ms = dot.find("label=\"8ms (raw 10ms)\"").unwrap();
         assert!(pos_3ms < pos_8ms);
+    }
+
+    // --- SVG rendering tests ---
+
+    #[test]
+    fn svg_missing_command_returns_not_found() {
+        let cascade = make_cascade(vec![]);
+        let err = render_svg_with_command(&cascade, "nonexistent-dot-binary-xyz")
+            .expect_err("should fail with missing command");
+        assert!(
+            matches!(err, ReportError::GraphvizNotFound),
+            "expected GraphvizNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn svg_bad_command_returns_failed() {
+        // Use `false` as the command — it exits with code 1.
+        let cascade = make_cascade(vec![]);
+        let err =
+            render_svg_with_command(&cascade, "false").expect_err("should fail with non-zero exit");
+        assert!(
+            matches!(err, ReportError::GraphvizFailed { .. }),
+            "expected GraphvizFailed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn svg_single_edge_produces_valid_svg() {
+        // Skip if `dot` is not installed (developer convenience).
+        if Command::new("dot").arg("-V").output().is_err() {
+            eprintln!("skipping svg test: dot not found");
+            return;
+        }
+        let cascade = make_cascade(vec![EdgeOutput {
+            src: ThreadId(100),
+            dst: ThreadId(200),
+            raw_wait_ms: 5,
+            attributed_delay_ms: 3,
+        }]);
+        let svg = render_svg_with_command(&cascade, "dot").unwrap();
+        let svg_str = String::from_utf8(svg).expect("SVG should be valid UTF-8");
+        assert!(
+            svg_str.contains("<svg"),
+            "output should contain <svg element"
+        );
+        assert!(
+            svg_str.contains("</svg>"),
+            "output should contain closing </svg>"
+        );
+    }
+
+    #[test]
+    fn svg_empty_graph_produces_valid_svg() {
+        if Command::new("dot").arg("-V").output().is_err() {
+            eprintln!("skipping svg test: dot not found");
+            return;
+        }
+        let cascade = make_cascade(vec![]);
+        let svg = render_svg_with_command(&cascade, "dot").unwrap();
+        let svg_str = String::from_utf8(svg).expect("SVG should be valid UTF-8");
+        assert!(svg_str.contains("<svg"));
+        assert!(svg_str.contains("</svg>"));
     }
 }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -106,19 +106,19 @@ fn render_svg_with_command(
     });
 
     let output = child.wait_with_output().map_err(ReportError::Io)?;
+    let writer_result = writer_thread.join().expect("stdin writer thread panicked");
 
-    // Propagate any stdin write error.
-    writer_thread
-        .join()
-        .expect("stdin writer thread panicked")
-        .map_err(ReportError::Io)?;
-
+    // Prioritize Graphviz's own error if it failed — a stdin BrokenPipe is
+    // usually a symptom of dot rejecting the input, not the root cause.
     if !output.status.success() {
         return Err(ReportError::GraphvizFailed {
             exit_code: output.status.code(),
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         });
     }
+
+    // Otherwise propagate any stdin write error.
+    writer_result.map_err(ReportError::Io)?;
 
     Ok(output.stdout)
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -29,6 +29,13 @@ pub enum ReportError {
     Io(std::io::Error),
     Pipeline(PipelineError),
     Cascade(InvariantError),
+    /// Graphviz `dot` executable not found in PATH.
+    GraphvizNotFound,
+    /// Graphviz `dot` exited with a non-zero status.
+    GraphvizFailed {
+        exit_code: Option<i32>,
+        stderr: String,
+    },
 }
 
 impl std::fmt::Display for ReportError {
@@ -37,6 +44,23 @@ impl std::fmt::Display for ReportError {
             Self::Io(e) => write!(f, "I/O error: {e}"),
             Self::Pipeline(e) => write!(f, "pipeline error: {e}"),
             Self::Cascade(e) => write!(f, "cascade invariant error: {e}"),
+            Self::GraphvizNotFound => write!(
+                f,
+                "Graphviz 'dot' not found in PATH; \
+                 install graphviz (https://graphviz.org) or use --format dot"
+            ),
+            Self::GraphvizFailed { exit_code, stderr } => {
+                write!(f, "Graphviz 'dot' failed")?;
+                if let Some(code) = exit_code {
+                    write!(f, " (exit code {code})")?;
+                }
+                if !stderr.is_empty() {
+                    // Bound stderr to avoid dumping unbounded process output.
+                    let truncated: String = stderr.chars().take(1024).collect();
+                    write!(f, ": {truncated}")?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -47,6 +71,7 @@ impl std::error::Error for ReportError {
             Self::Io(e) => Some(e),
             Self::Pipeline(e) => Some(e),
             Self::Cascade(e) => Some(e),
+            Self::GraphvizNotFound | Self::GraphvizFailed { .. } => None,
         }
     }
 }
@@ -123,6 +148,13 @@ pub fn run(args: &ReportArgs) -> Result<(), ReportError> {
             let mut writer = BufWriter::new(stdout);
             let dot_output = dot::render_dot(&report.cascade);
             writer.write_all(dot_output.as_bytes())?;
+            writer.flush()?;
+        }
+        ReportFormat::Svg => {
+            let svg = dot::render_svg(&report.cascade)?;
+            let stdout = std::io::stdout().lock();
+            let mut writer = BufWriter::new(stdout);
+            writer.write_all(&svg)?;
             writer.flush()?;
         }
     }
@@ -365,11 +397,40 @@ mod tests {
             std::io::Error::other("test"),
         )));
         assert!(format!("{err}").contains("pipeline error"));
+
+        let err = ReportError::GraphvizNotFound;
+        let msg = format!("{err}");
+        assert!(msg.contains("not found in PATH"));
+        assert!(msg.contains("--format dot"));
+
+        let err = ReportError::GraphvizFailed {
+            exit_code: Some(1),
+            stderr: "syntax error".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("exit code 1"));
+        assert!(msg.contains("syntax error"));
+
+        let err = ReportError::GraphvizFailed {
+            exit_code: None,
+            stderr: String::new(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("failed"));
     }
 
     #[test]
     fn error_source() {
         let err = ReportError::Io(std::io::Error::other("test"));
         assert!(std::error::Error::source(&err).is_some());
+
+        let err = ReportError::GraphvizNotFound;
+        assert!(std::error::Error::source(&err).is_none());
+
+        let err = ReportError::GraphvizFailed {
+            exit_code: Some(1),
+            stderr: "test".into(),
+        };
+        assert!(std::error::Error::source(&err).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `wperf report --format svg` by piping DOT output through external `dot -Tsvg`
- Closes Phase 1 "minimal SVG readable" exit gate (task #27)
- Introduces external runtime dependency on Graphviz `dot` for `--format svg` only; `--format json` and `--format dot` remain dependency-free

## Authoritative Inputs
- `final-design.md:578` — Phase 1 exit gate: "minimal SVG readable"
- PR #98: `render_dot()` DOT text backend (source-of-truth for graph→text conversion)
- Task #27 revised plan: Graphviz-backed SVG path with explicit error contract and CI validation

## Changes
- `ReportFormat::Svg` CLI variant in `cli.rs`
- `render_svg()` / `render_svg_with_command()` in `dot.rs` — thin adapter over `render_dot()`
- `ReportError::GraphvizNotFound` — clear error when `dot` not in PATH
- `ReportError::GraphvizFailed` — surfaces exit code + bounded stderr (≤1024 chars)
- SVG writes to stdout, consistent with JSON and DOT formats
- CI workflow installs `graphviz` for SVG smoke tests
- 4 new unit tests: missing command, failed command, valid SVG (empty + single edge)

## Error contract
- Missing `dot`: `GraphvizNotFound` with actionable message pointing to `--format dot` fallback
- Non-zero exit: `GraphvizFailed` with exit code and stderr (truncated to 1024 chars)
- Pipe/IO failure: existing `ReportError::Io`
- No silent degradation: `--format svg` never falls back to DOT output

## Deviations
- External process invocation (Graphviz) is not typical for this codebase — justified by avoiding embedding a full graph layout engine for Phase 1
- Phase 3 may replace with embedded renderer if Graphviz dependency is undesirable long-term

## Test plan
- [x] `svg_missing_command_returns_not_found` — verifies `GraphvizNotFound` error
- [x] `svg_bad_command_returns_failed` — verifies `GraphvizFailed` error
- [x] `svg_single_edge_produces_valid_svg` — asserts `<svg` and `</svg>` in output
- [x] `svg_empty_graph_produces_valid_svg` — same for empty graph
- [x] Error Display tests for new variants
- [x] All existing tests pass (clippy clean, fmt clean)
- [ ] CI mutation testing ≥90% kill rate

## Review Checklist
- [x] Design conformance: implementation matches task #27 revised plan
- [x] Deviations declared and justified
- [x] Code correctness: `render_svg` is thin adapter over `render_dot`, no forked logic
- [x] Error contract: `GraphvizNotFound` / `GraphvizFailed` / no silent degradation
- [x] Tests: 4 SVG tests + error display coverage
- [x] Clippy clean, fmt clean
- [ ] CI green (including mutation testing ≥90%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)