### PR TITLE
feat: E2E crash recovery integration tests (W4 #24)

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11,7 +11,7 @@
 use std::io::Cursor;
 
 use wperf::format::event::{EVENT_SIZE, EventType, WperfEvent};
-use wperf::format::header::HEADER_SIZE;
+use wperf::format::header::{HEADER_SIZE, WprfHeader};
 use wperf::format::reader::WperfReader;
 use wperf::format::writer::{TLV_HEADER_SIZE, WperfWriter};
 use wperf::graph::types::ThreadId;
@@ -286,20 +286,20 @@ fn fixture_drop_count_propagation() {
 // Crash recovery helpers
 // ---------------------------------------------------------------------------
 
-/// Header field byte offsets (from header.rs binary layout).
-const DATA_SECTION_END_OFFSET_POS: std::ops::Range<usize> = 8..16;
-const SECTION_TABLE_OFFSET_POS: std::ops::Range<usize> = 16..24;
-
 /// TLV record size derived from crate constants.
 const TLV_RECORD_SIZE: usize = TLV_HEADER_SIZE + EVENT_SIZE;
 
 /// Simulate a crash by patching the header to remove the footer and set
 /// `data_section_end_offset` to cover exactly `recoverable_events` events.
 fn simulate_crash(mut data: Vec<u8>, recoverable_events: usize) -> Vec<u8> {
-    let data_end = (HEADER_SIZE + recoverable_events * TLV_RECORD_SIZE) as u64;
-    data[DATA_SECTION_END_OFFSET_POS].copy_from_slice(&data_end.to_le_bytes());
-    // section_table_offset = 0 → no footer (crash scenario).
-    data[SECTION_TABLE_OFFSET_POS].copy_from_slice(&0u64.to_le_bytes());
+    let mut header =
+        WprfHeader::from_bytes(data[..HEADER_SIZE].try_into().expect("buffer too small"))
+            .expect("failed to parse header");
+
+    header.data_section_end_offset = (HEADER_SIZE + recoverable_events * TLV_RECORD_SIZE) as u64;
+    header.section_table_offset = 0;
+
+    data[..HEADER_SIZE].copy_from_slice(&header.to_bytes());
     data
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,9 +10,10 @@
 
 use std::io::Cursor;
 
-use wperf::format::event::{EventType, WperfEvent};
+use wperf::format::event::{EVENT_SIZE, EventType, WperfEvent};
+use wperf::format::header::HEADER_SIZE;
 use wperf::format::reader::WperfReader;
-use wperf::format::writer::WperfWriter;
+use wperf::format::writer::{TLV_HEADER_SIZE, WperfWriter};
 use wperf::graph::types::ThreadId;
 use wperf::report;
 
@@ -285,13 +286,12 @@ fn fixture_drop_count_propagation() {
 // Crash recovery helpers
 // ---------------------------------------------------------------------------
 
-/// Header field offsets (from header.rs binary layout).
-const HEADER_SIZE: usize = 64;
+/// Header field byte offsets (from header.rs binary layout).
 const DATA_SECTION_END_OFFSET_POS: std::ops::Range<usize> = 8..16;
 const SECTION_TABLE_OFFSET_POS: std::ops::Range<usize> = 16..24;
 
-/// TLV record size: 5 (type + length) + 40 (event payload).
-const TLV_RECORD_SIZE: usize = 45;
+/// TLV record size derived from crate constants.
+const TLV_RECORD_SIZE: usize = TLV_HEADER_SIZE + EVENT_SIZE;
 
 /// Simulate a crash by patching the header to remove the footer and set
 /// `data_section_end_offset` to cover exactly `recoverable_events` events.
@@ -400,14 +400,10 @@ fn fixture_crash_recovery_offset_past_eof() {
     let events = vec![switch(1_000_000, 10, 20), wakeup(2_000_000, 20, 10)];
     let data = write_trace(&events, 0);
 
-    // Physical file contains only header + 1 event, but header says 2.
+    // Physical file contains only header + 1 event, but header claims 2.
     let physical_len = HEADER_SIZE + TLV_RECORD_SIZE;
-    let mut truncated = data[..physical_len].to_vec();
-
-    // Patch: data_section_end_offset claims 2 events worth, no footer.
-    let fake_end = (HEADER_SIZE + 2 * TLV_RECORD_SIZE) as u64;
-    truncated[DATA_SECTION_END_OFFSET_POS].copy_from_slice(&fake_end.to_le_bytes());
-    truncated[SECTION_TABLE_OFFSET_POS].copy_from_slice(&0u64.to_le_bytes());
+    let truncated = data[..physical_len].to_vec();
+    let truncated = simulate_crash(truncated, 2);
 
     let report = build_report_from_raw(truncated);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -400,8 +400,8 @@ fn fixture_crash_recovery_offset_past_eof() {
     let events = vec![switch(1_000_000, 10, 20), wakeup(2_000_000, 20, 10)];
     let data = write_trace(&events, 0);
 
-    // Physical file contains only header + 1 event, but header claims 2.
-    let physical_len = HEADER_SIZE + TLV_RECORD_SIZE;
+    // Physical file contains header + 1 event + 3 bytes of 2nd, but header claims 2.
+    let physical_len = HEADER_SIZE + TLV_RECORD_SIZE + 3;
     let truncated = data[..physical_len].to_vec();
     let truncated = simulate_crash(truncated, 2);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -291,7 +291,7 @@ const TLV_RECORD_SIZE: usize = TLV_HEADER_SIZE + EVENT_SIZE;
 
 /// Simulate a crash by patching the header to remove the footer and set
 /// `data_section_end_offset` to cover exactly `recoverable_events` events.
-fn simulate_crash(mut data: Vec<u8>, recoverable_events: usize) -> Vec<u8> {
+fn simulate_crash(data: &mut [u8], recoverable_events: usize) {
     let mut header =
         WprfHeader::from_bytes(data[..HEADER_SIZE].try_into().expect("buffer too small"))
             .expect("failed to parse header");
@@ -300,7 +300,6 @@ fn simulate_crash(mut data: Vec<u8>, recoverable_events: usize) -> Vec<u8> {
     header.section_table_offset = 0;
 
     data[..HEADER_SIZE].copy_from_slice(&header.to_bytes());
-    data
 }
 
 fn build_report_from_raw(data: Vec<u8>) -> report::ReportOutput {
@@ -322,8 +321,8 @@ fn fixture_crash_recovery_record_boundary() {
         wakeup(2_000_000, 20, 10),
         switch(3_000_000, 20, 10),
     ];
-    let data = write_trace(&events, 99);
-    let data = simulate_crash(data, 3);
+    let mut data = write_trace(&events, 99);
+    simulate_crash(&mut data, 3);
 
     let report = build_report_from_raw(data);
 
@@ -359,7 +358,7 @@ fn fixture_crash_recovery_mid_record_truncation() {
     let mut truncated = data[..truncated_len].to_vec();
 
     // Patch header: data_section_end_offset covers 2 events, no footer.
-    truncated = simulate_crash(truncated, 2);
+    simulate_crash(&mut truncated, 2);
 
     let report = build_report_from_raw(truncated);
 
@@ -377,8 +376,8 @@ fn fixture_crash_recovery_mid_record_truncation() {
 #[test]
 fn fixture_crash_recovery_zero_events() {
     // Crash immediately after writing the header — no events at all.
-    let data = write_trace(&[], 0);
-    let data = simulate_crash(data, 0);
+    let mut data = write_trace(&[], 0);
+    simulate_crash(&mut data, 0);
 
     let report = build_report_from_raw(data);
 
@@ -402,8 +401,8 @@ fn fixture_crash_recovery_offset_past_eof() {
 
     // Physical file contains header + 1 event + 3 bytes of 2nd, but header claims 2.
     let physical_len = HEADER_SIZE + TLV_RECORD_SIZE + 3;
-    let truncated = data[..physical_len].to_vec();
-    let truncated = simulate_crash(truncated, 2);
+    let mut truncated = data[..physical_len].to_vec();
+    simulate_crash(&mut truncated, 2);
 
     let report = build_report_from_raw(truncated);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -280,3 +280,140 @@ fn fixture_drop_count_propagation() {
     let report = build_report_from(&[], 12345);
     assert_eq!(report.health.drop_count, Some(12345));
 }
+
+// ---------------------------------------------------------------------------
+// Crash recovery helpers
+// ---------------------------------------------------------------------------
+
+/// Header field offsets (from header.rs binary layout).
+const HEADER_SIZE: usize = 64;
+const DATA_SECTION_END_OFFSET_POS: std::ops::Range<usize> = 8..16;
+const SECTION_TABLE_OFFSET_POS: std::ops::Range<usize> = 16..24;
+
+/// TLV record size: 5 (type + length) + 40 (event payload).
+const TLV_RECORD_SIZE: usize = 45;
+
+/// Simulate a crash by patching the header to remove the footer and set
+/// `data_section_end_offset` to cover exactly `recoverable_events` events.
+fn simulate_crash(mut data: Vec<u8>, recoverable_events: usize) -> Vec<u8> {
+    let data_end = (HEADER_SIZE + recoverable_events * TLV_RECORD_SIZE) as u64;
+    data[DATA_SECTION_END_OFFSET_POS].copy_from_slice(&data_end.to_le_bytes());
+    // section_table_offset = 0 → no footer (crash scenario).
+    data[SECTION_TABLE_OFFSET_POS].copy_from_slice(&0u64.to_le_bytes());
+    data
+}
+
+fn build_report_from_raw(data: Vec<u8>) -> report::ReportOutput {
+    let mut reader = WperfReader::open(Cursor::new(data)).expect("failed to open raw trace");
+    report::build_report(&mut reader).expect("failed to build report from raw trace")
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: crash recovery — truncation at record boundary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixture_crash_recovery_record_boundary() {
+    // Write 3 events forming a matched pair (T10→T20) + an extra switch.
+    // Simulate crash: data_section_end_offset covers only 3 events, no footer.
+    // All 3 events are intact → full pipeline should recover them.
+    let events = vec![
+        switch(1_000_000, 10, 20),
+        wakeup(2_000_000, 20, 10),
+        switch(3_000_000, 20, 10),
+    ];
+    let data = write_trace(&events, 99);
+    let data = simulate_crash(data, 3);
+
+    let report = build_report_from_raw(data);
+
+    // Pipeline recovers the matched pair → one edge.
+    assert_eq!(report.cascade.edges.len(), 1);
+    assert_eq!(report.cascade.edges[0].src, ThreadId(10));
+    assert_eq!(report.cascade.edges[0].dst, ThreadId(20));
+    assert_eq!(report.stats.events_read, 3);
+
+    // No footer → drop_count is None (unknown).
+    assert_eq!(report.health.drop_count, None);
+    assert!(report.health.invariants_ok);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: crash recovery — mid-record truncation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixture_crash_recovery_mid_record_truncation() {
+    // Write 3 events, but physically truncate the file mid-way through
+    // the 3rd record. data_section_end_offset covers only 2 complete events.
+    // The reader should parse exactly 2 events.
+    let events = vec![
+        switch(1_000_000, 10, 20),
+        wakeup(2_000_000, 20, 10),
+        switch(3_000_000, 20, 10),
+    ];
+    let data = write_trace(&events, 0);
+
+    // Truncate: keep header + 2 full records + 3 bytes of 3rd record.
+    let truncated_len = HEADER_SIZE + 2 * TLV_RECORD_SIZE + 3;
+    let mut truncated = data[..truncated_len].to_vec();
+
+    // Patch header: data_section_end_offset covers 2 events, no footer.
+    truncated = simulate_crash(truncated, 2);
+
+    let report = build_report_from_raw(truncated);
+
+    // Only 2 events recovered — the wakeup lacks a matching back-on switch,
+    // so no complete edge is formed. But both events are processed.
+    assert_eq!(report.stats.events_read, 2);
+    assert_eq!(report.health.drop_count, None);
+    assert!(report.health.invariants_ok);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: crash recovery — zero events
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixture_crash_recovery_zero_events() {
+    // Crash immediately after writing the header — no events at all.
+    let data = write_trace(&[], 0);
+    let data = simulate_crash(data, 0);
+
+    let report = build_report_from_raw(data);
+
+    assert_eq!(report.stats.events_read, 0);
+    assert_eq!(report.cascade.edges.len(), 0);
+    assert_eq!(report.health.drop_count, None);
+    assert!(report.health.invariants_ok);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: crash recovery — data_section_end_offset past file length (clamp)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixture_crash_recovery_offset_past_eof() {
+    // Write 2 events. Truncate the file so it's shorter than the
+    // data_section_end_offset claims. The reader must clamp to file length
+    // and recover what's physically present.
+    let events = vec![switch(1_000_000, 10, 20), wakeup(2_000_000, 20, 10)];
+    let data = write_trace(&events, 0);
+
+    // Physical file contains only header + 1 event, but header says 2.
+    let physical_len = HEADER_SIZE + TLV_RECORD_SIZE;
+    let mut truncated = data[..physical_len].to_vec();
+
+    // Patch: data_section_end_offset claims 2 events worth, no footer.
+    let fake_end = (HEADER_SIZE + 2 * TLV_RECORD_SIZE) as u64;
+    truncated[DATA_SECTION_END_OFFSET_POS].copy_from_slice(&fake_end.to_le_bytes());
+    truncated[SECTION_TABLE_OFFSET_POS].copy_from_slice(&0u64.to_le_bytes());
+
+    let report = build_report_from_raw(truncated);
+
+    // Reader clamps to file length → only 1 event recovered.
+    assert_eq!(report.stats.events_read, 1);
+    assert_eq!(report.cascade.edges.len(), 0); // single event can't form edge
+    assert_eq!(report.health.drop_count, None);
+    assert!(report.health.invariants_ok);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -399,8 +399,10 @@ fn fixture_crash_recovery_offset_past_eof() {
     let events = vec![switch(1_000_000, 10, 20), wakeup(2_000_000, 20, 10)];
     let data = write_trace(&events, 0);
 
-    // Physical file contains header + 1 event + 3 bytes of 2nd, but header claims 2.
-    let physical_len = HEADER_SIZE + TLV_RECORD_SIZE + 3;
+    // Physical file contains header + 1 event + 10 bytes of 2nd, but header claims 2.
+    // 10 bytes > TLV_HEADER_SIZE (5), so the TLV header is readable but payload
+    // is incomplete — exercises truncated-payload branch, not just truncated-header.
+    let physical_len = HEADER_SIZE + TLV_RECORD_SIZE + 10;
     let mut truncated = data[..physical_len].to_vec();
     simulate_crash(&mut truncated, 2);
 


### PR DESCRIPTION
## Summary
- Add 4 crash recovery E2E integration tests exercising `build_report()` against corrupted/truncated `.wperf` traces
- **Record-boundary truncation**: 3 valid events, footer stripped → recovers matched pair edge
- **Mid-record truncation**: physical truncation mid-3rd-record, `data_section_end_offset` covers 2 → recovers 2 events
- **Zero-event crash**: header-only file with no footer → empty report, `drop_count: None`
- **Offset past EOF**: `data_section_end_offset` claims more data than physically present → reader clamps to file length, recovers 1 event
- All tests verify `health.drop_count == None` (no footer) and `health.invariants_ok == true`

## Authoritative Inputs
- final-design.md §4.1 (crash recovery via `data_section_end_offset`)
- Existing unit test `crash_recovery_truncated_file` in `reader.rs` (reference pattern)
- Plan approved by Critic and Challenger in `#p1-dev:948e5732`

## Deviations
- **Constructed truncated files instead of real SIGKILL/BPF capture**: Tests use real `WperfWriter` output + byte mutation to simulate crash scenarios, rather than actual process kills or live BPF recording. This is deliberate — E2E crash recovery validation requires deterministic byte-level control that live capture cannot guarantee.
- **CLI smoke test deferred**: This PR validates crash recovery through the `build_report()` testability seam, not through the `wperf report` CLI entry point. CLI-level crash recovery smoke testing is optional/deferred.

## Test plan
- [x] All 9 integration tests pass (`cargo test --test integration_tests`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Review Checklist
- [x] Tests use real `WperfWriter` output + byte mutation (no hand-crafted binaries)
- [x] `section_table_offset = 0` explicitly set in all crash scenarios
- [x] Mid-record truncation verifies partial record is not parsed
- [x] Clamp-to-file-length case covers `data_section_end_offset > file_len`
- [x] No snapshot coupling — all assertions are structural/semantic

🤖 Generated with [Claude Code](https://claude.com/claude-code)