### PR TITLE
feat: wire BPF record pipeline (Task A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +125,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +183,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -226,6 +278,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -464,6 +522,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,10 +617,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libbpf-cargo"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e63283df9689af55b85f91e99dc8b213ae89fc3e1d9bb29ab7f75eb8a8a783"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "clap",
+ "libbpf-rs",
+ "memmap2",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "libbpf-rs"
@@ -588,6 +694,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +712,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -637,6 +761,12 @@ dependencies = [
  "indexmap",
  "serde",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -909,6 +1039,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -951,6 +1085,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1016,6 +1159,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1195,38 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "chrono",
+ "nu-ansi-term",
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1195,10 +1399,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1305,6 +1562,7 @@ dependencies = [
  "criterion",
  "iai-callgrind",
  "insta",
+ "libbpf-cargo",
  "libbpf-rs",
  "libbpf-sys",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [features]
-bpf = ["libbpf-rs", "libbpf-sys", "libc"]
+bpf = ["libbpf-rs", "libbpf-sys", "libc", "libbpf-cargo"]
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
@@ -16,6 +16,9 @@ petgraph = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 signal-hook = "0.4"
+
+[build-dependencies]
+libbpf-cargo = { version = "0.26", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.6", features = ["html_reports"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// BPF skeleton generation via libbpf-cargo's SkeletonBuilder.
+// Only active when compiled with `--features bpf`.
+//
+// Generates vmlinux.h from the running kernel's BTF, then compiles
+// wperf.bpf.c into a skeleton with Rust bindings.
+//
+// Authoritative Inputs:
+// - ADR-013 (dual-variant sched_switch + sched_wakeup probes)
+// - ADR-004 (transport abstraction: ringbuf/perfarray)
+
+fn main() {
+    #[cfg(feature = "bpf")]
+    skeleton_build();
+}
+
+#[cfg(feature = "bpf")]
+fn skeleton_build() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    let out_dir = PathBuf::from(
+        std::env::var_os("OUT_DIR").expect("OUT_DIR not set"),
+    );
+
+    // Generate vmlinux.h from the running kernel's BTF.
+    let vmlinux_h = out_dir.join("vmlinux.h");
+    if !vmlinux_h.exists() {
+        let output = Command::new("bpftool")
+            .args(["btf", "dump", "file", "/sys/kernel/btf/vmlinux", "format", "c"])
+            .output()
+            .expect("failed to run bpftool — is the `bpf` package installed?");
+        assert!(
+            output.status.success(),
+            "bpftool btf dump failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        std::fs::write(&vmlinux_h, &output.stdout)
+            .expect("failed to write vmlinux.h");
+    }
+
+    let src = "src/bpf/wperf.bpf.c";
+    let skel_path = out_dir.join("wperf.skel.rs");
+
+    libbpf_cargo::SkeletonBuilder::new()
+        .source(src)
+        .clang_args([
+            "-I", "src/bpf",
+            "-I", out_dir.to_str().expect("OUT_DIR not UTF-8"),
+        ])
+        .build_and_generate(&skel_path)
+        .expect("failed to build and generate BPF skeleton");
+
+    println!("cargo::rerun-if-changed={src}");
+    println!("cargo::rerun-if-changed=src/bpf/wperf.h");
+    println!("cargo::rerun-if-changed=src/bpf/compat.bpf.h");
+    println!("cargo::rerun-if-changed=src/bpf/core_fixes.bpf.h");
+}

--- a/src/format/event.rs
+++ b/src/format/event.rs
@@ -216,8 +216,22 @@ mod tests {
 
     #[test]
     fn repr_c_layout() {
-        // Verify repr(C) layout: u64 alignment, 40B with flags field (no wasted padding)
         assert_eq!(std::mem::align_of::<WperfEvent>(), 8);
         assert_eq!(std::mem::size_of::<WperfEvent>(), 40);
+    }
+
+    #[test]
+    fn field_offsets_match_bpf_struct() {
+        assert_eq!(std::mem::offset_of!(WperfEvent, timestamp_ns), 0);
+        assert_eq!(std::mem::offset_of!(WperfEvent, pid), 8);
+        assert_eq!(std::mem::offset_of!(WperfEvent, tid), 12);
+        assert_eq!(std::mem::offset_of!(WperfEvent, prev_tid), 16);
+        assert_eq!(std::mem::offset_of!(WperfEvent, next_tid), 20);
+        assert_eq!(std::mem::offset_of!(WperfEvent, prev_pid), 24);
+        assert_eq!(std::mem::offset_of!(WperfEvent, next_pid), 28);
+        assert_eq!(std::mem::offset_of!(WperfEvent, cpu), 32);
+        assert_eq!(std::mem::offset_of!(WperfEvent, event_type), 34);
+        assert_eq!(std::mem::offset_of!(WperfEvent, prev_state), 35);
+        assert_eq!(std::mem::offset_of!(WperfEvent, flags), 36);
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -19,6 +19,12 @@ use std::sync::atomic::Ordering;
 
 use crate::cli::RecordArgs;
 
+#[cfg(feature = "bpf")]
+#[allow(unused_imports, clippy::all, clippy::pedantic)]
+mod skel {
+    include!(concat!(env!("OUT_DIR"), "/wperf.skel.rs"));
+}
+
 /// Errors from the record subcommand.
 #[derive(Debug)]
 pub enum RecordError {

--- a/src/record.rs
+++ b/src/record.rs
@@ -5,11 +5,7 @@
 //! - final-design.md §4.1-4.4 (wPRF format + crash recovery)
 //! - ADR-002 (feature probing)
 //! - ADR-004 (transport abstraction)
-//!
-//! Current status: CLI scaffold + signal handling + orchestration seam.
-//! The actual BPF load → transport → write pipeline is behind
-//! `#[cfg(feature = "bpf")]` and requires the skeleton build pipeline
-//! to be wired before it can function end-to-end.
+//! - ADR-013 (dual-variant `sched_switch` + `sched_wakeup` probes)
 
 use std::io;
 use std::sync::Arc;
@@ -30,8 +26,10 @@ mod skel {
 pub enum RecordError {
     /// BPF feature not compiled in.
     NoBpfSupport,
-    /// BPF skeleton / transport pipeline not yet wired.
-    NotYetWired,
+    /// Feature probing failed (e.g., no BTF).
+    Probe(String),
+    /// BPF skeleton operation failed (open/load/attach).
+    Bpf(String),
     /// Signal handler registration failed.
     SignalSetup(io::Error),
     /// I/O error (file creation, write, etc).
@@ -46,11 +44,8 @@ impl std::fmt::Display for RecordError {
                 "this build of wperf was compiled without BPF support; \
                  rebuild with `--features bpf`"
             ),
-            Self::NotYetWired => write!(
-                f,
-                "record pipeline not yet wired: BPF skeleton build pipeline is required \
-                 but not yet integrated"
-            ),
+            Self::Probe(msg) => write!(f, "feature probing failed: {msg}"),
+            Self::Bpf(msg) => write!(f, "BPF error: {msg}"),
             Self::SignalSetup(e) => write!(f, "failed to register signal handler: {e}"),
             Self::Io(e) => write!(f, "record I/O error: {e}"),
         }
@@ -61,7 +56,7 @@ impl std::error::Error for RecordError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::SignalSetup(e) | Self::Io(e) => Some(e),
-            Self::NoBpfSupport | Self::NotYetWired => None,
+            Self::NoBpfSupport | Self::Probe(_) | Self::Bpf(_) => None,
         }
     }
 }
@@ -74,22 +69,17 @@ impl From<io::Error> for RecordError {
 
 /// Run the `wperf record` subcommand.
 ///
-/// Orchestration flow (once BPF skeleton is wired):
-/// 1. Register SIGINT/SIGTERM handlers → `running` flag
+/// Orchestration flow:
+/// 1. Register SIGINT/SIGTERM handlers → `stop_requested` flag
 /// 2. `probe::probe_all()` → `FeatureMatrix`
-/// 3. Open BPF skeleton → configure transport → load → attach
+/// 3. Open BPF skeleton → disable unused variant → load → attach
 /// 4. Create `WperfWriter` for output file
-/// 5. Poll transport in loop while `running` is true
+/// 5. Poll transport in loop while `!stop_requested` (+ optional duration)
 /// 6. Drain remaining events → `writer.finish(drop_count)`
 /// 7. Print summary
 pub fn run(args: &RecordArgs) -> Result<(), RecordError> {
-    // Step 1: Register signal handlers for graceful shutdown.
-    // `signal_hook::flag::register` stores `true` into the AtomicBool on signal,
-    // so we start at `false` and poll `stop_requested.load()` to detect shutdown.
     let stop_requested = Arc::new(AtomicBool::new(false));
     register_signal_handlers(&stop_requested)?;
-
-    // Step 2-6: BPF pipeline (feature-gated).
     record_impl(args, &stop_requested)
 }
 
@@ -102,19 +92,252 @@ fn register_signal_handlers(stop_requested: &Arc<AtomicBool>) -> Result<(), Reco
     Ok(())
 }
 
-/// BPF-enabled record implementation.
-///
-/// Currently returns `NotYetWired` because the BPF skeleton build pipeline
-/// is not yet integrated. Once skeleton wiring lands, this function will:
-/// 1. `probe_all()` → `FeatureMatrix`
-/// 2. Open skeleton → configure transport (ringbuf/perfarray) → load → attach
-/// 3. Poll transport in loop while `!stop_requested`
-/// 4. Drain → `writer.finish(drop_count)`
 #[cfg(feature = "bpf")]
-fn record_impl(_args: &RecordArgs, _stop_requested: &Arc<AtomicBool>) -> Result<(), RecordError> {
-    // The BPF skeleton build pipeline is not yet wired.
-    // Returning an explicit error avoids producing a misleading empty trace.
-    Err(RecordError::NotYetWired)
+fn record_impl(args: &RecordArgs, stop_requested: &Arc<AtomicBool>) -> Result<(), RecordError> {
+    use std::fs::File;
+    use std::io::BufWriter;
+    use std::time::Instant;
+
+    use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
+
+    use crate::format::writer::WperfWriter;
+    use crate::probe::{self, ProbePaths, TracepointMode, TransportMode};
+    use crate::transport::TransportConfig;
+
+    // --- Step 1: Feature probing ---
+    let paths = ProbePaths::default();
+    let features = probe::probe_all(&paths)
+        .map_err(|e| RecordError::Probe(e.to_string()))?;
+    let transport_config = match args.buffer_size {
+        Some(size) => match features.transport {
+            TransportMode::RingBuf => TransportConfig::ringbuf(size),
+            TransportMode::PerfArray => {
+                let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
+                TransportConfig::perfarray(size / page_size)
+            }
+        },
+        None => TransportConfig::from_mode(features.transport),
+    };
+
+    eprintln!(
+        "wperf: transport={:?}, tracepoint={:?}",
+        features.transport, features.tracepoint,
+    );
+
+    // --- Step 2: Open → configure → load → attach ---
+    let mut open_obj = std::mem::MaybeUninit::uninit();
+    let mut open_skel = skel::WperfSkelBuilder::default()
+        .open(&mut open_obj)
+        .map_err(|e| RecordError::Bpf(format!("skeleton open: {e}")))?;
+
+    match features.tracepoint {
+        TracepointMode::TpBtf => {
+            open_skel.progs.handle_sched_switch_raw.set_autoload(false);
+            open_skel.progs.handle_sched_wakeup_raw.set_autoload(false);
+        }
+        TracepointMode::RawTp => {
+            open_skel.progs.handle_sched_switch_btf.set_autoload(false);
+            open_skel.progs.handle_sched_wakeup_btf.set_autoload(false);
+        }
+    }
+
+    if features.transport == TransportMode::RingBuf {
+        open_skel
+            .maps
+            .events
+            .set_max_entries(transport_config.ringbuf_size)
+            .map_err(|e| RecordError::Bpf(format!("set ringbuf size: {e}")))?;
+    }
+
+    let mut loaded_skel = open_skel
+        .load()
+        .map_err(|e| RecordError::Bpf(format!("skeleton load: {e}")))?;
+
+    loaded_skel
+        .attach()
+        .map_err(|e| RecordError::Bpf(format!("skeleton attach: {e}")))?;
+
+    eprintln!("wperf: probes attached, recording to {}", args.output.display());
+
+    // --- Step 3: Create writer ---
+    let file = File::create(&args.output)?;
+    let buf_writer = BufWriter::new(file);
+    let mut writer = WperfWriter::new(buf_writer)?;
+
+    // --- Step 4: Poll loop ---
+    let start = Instant::now();
+    let deadline = args.duration.map(|d| start + std::time::Duration::from_secs_f64(d));
+    let mut event_count: u64 = 0;
+    let mut transport_lost: u64 = 0;
+
+    match features.transport {
+        TransportMode::RingBuf => {
+            poll_ringbuf(
+                &loaded_skel,
+                &mut writer,
+                &mut event_count,
+                stop_requested,
+                deadline,
+            )?;
+        }
+        TransportMode::PerfArray => {
+            transport_lost = poll_perfarray(
+                &loaded_skel,
+                &mut writer,
+                &mut event_count,
+                stop_requested,
+                deadline,
+                &transport_config,
+            )?;
+        }
+    }
+
+    // --- Step 5: Finish ---
+    // BPF-side drops (ringbuf reserve failures) + transport-side drops (perfarray lost events).
+    let bpf_drops = loaded_skel
+        .maps
+        .bss_data
+        .as_ref()
+        .map_or(0, |bss| bss.drop_counter);
+    let drop_count = bpf_drops + transport_lost;
+
+    let inner = writer.finish(drop_count)?;
+    inner.into_inner().map_err(|e| RecordError::Io(e.into_error()))?;
+
+    let elapsed = start.elapsed();
+    eprintln!(
+        "wperf: recording complete — {event_count} events, {drop_count} drops, {:.1}s",
+        elapsed.as_secs_f64(),
+    );
+
+    Ok(())
+}
+
+/// Ringbuf poll loop: events arrive in global timestamp order.
+#[cfg(feature = "bpf")]
+fn poll_ringbuf<W: std::io::Write + std::io::Seek>(
+    skel: &skel::WperfSkel<'_>,
+    writer: &mut crate::format::writer::WperfWriter<W>,
+    event_count: &mut u64,
+    stop_requested: &Arc<AtomicBool>,
+    deadline: Option<std::time::Instant>,
+) -> Result<(), RecordError> {
+    use std::cell::RefCell;
+    use std::sync::atomic::Ordering;
+
+    use crate::format::event::{EVENT_SIZE, WperfEvent};
+
+    let writer = RefCell::new(writer);
+    let count = RefCell::new(event_count);
+    let write_err: RefCell<Option<io::Error>> = RefCell::new(None);
+
+    let mut builder = libbpf_rs::RingBufferBuilder::new();
+    builder
+        .add(&skel.maps.events, |data: &[u8]| {
+            if data.len() < EVENT_SIZE {
+                return 0;
+            }
+            let buf: &[u8; EVENT_SIZE] = data[..EVENT_SIZE].try_into().unwrap();
+            let event = WperfEvent::from_bytes(buf);
+            let mut w = writer.borrow_mut();
+            if let Err(e) = w.write_event(&event) {
+                *write_err.borrow_mut() = Some(e);
+                return -1;
+            }
+            **count.borrow_mut() += 1;
+            0
+        })
+        .map_err(|e| RecordError::Bpf(format!("ringbuf builder: {e}")))?;
+    let ringbuf = builder
+        .build()
+        .map_err(|e| RecordError::Bpf(format!("ringbuf build: {e}")))?;
+
+    loop {
+        if stop_requested.load(Ordering::Relaxed) {
+            break;
+        }
+        if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+            break;
+        }
+        let _ = ringbuf.poll(std::time::Duration::from_millis(100));
+        if let Some(e) = write_err.borrow_mut().take() {
+            return Err(RecordError::Io(e));
+        }
+    }
+
+    // Final drain.
+    let _ = ringbuf.consume();
+    if let Some(e) = write_err.borrow_mut().take() {
+        return Err(RecordError::Io(e));
+    }
+
+    Ok(())
+}
+
+/// Perfarray poll loop: events arrive per-CPU, reordered via `ReorderBuf`.
+///
+/// PerfBuffer callbacks collect events into a shared Vec, which the main loop
+/// drains through the reorder buffer into the writer.
+#[cfg(feature = "bpf")]
+fn poll_perfarray<W: std::io::Write + std::io::Seek>(
+    skel: &skel::WperfSkel<'_>,
+    writer: &mut crate::format::writer::WperfWriter<W>,
+    event_count: &mut u64,
+    stop_requested: &Arc<AtomicBool>,
+    deadline: Option<std::time::Instant>,
+    config: &crate::transport::TransportConfig,
+) -> Result<u64, RecordError> {
+    use std::cell::RefCell;
+    use std::sync::atomic::Ordering;
+
+    use crate::format::event::{EVENT_SIZE, WperfEvent};
+    use crate::transport::ReorderBuf;
+
+    let pending: RefCell<Vec<WperfEvent>> = RefCell::new(Vec::with_capacity(4096));
+    let lost_count: RefCell<u64> = RefCell::new(0);
+
+    let perf = libbpf_rs::PerfBufferBuilder::new(&skel.maps.events)
+        .pages(config.perf_pages as usize)
+        .sample_cb(|_cpu: i32, data: &[u8]| {
+            if data.len() < EVENT_SIZE {
+                return;
+            }
+            let buf: &[u8; EVENT_SIZE] = data[..EVENT_SIZE].try_into().unwrap();
+            let event = WperfEvent::from_bytes(buf);
+            pending.borrow_mut().push(event);
+        })
+        .lost_cb(|_cpu: i32, count: u64| {
+            *lost_count.borrow_mut() += count;
+        })
+        .build()
+        .map_err(|e| RecordError::Bpf(format!("perf buffer build: {e}")))?;
+
+    let mut reorder = ReorderBuf::new();
+
+    loop {
+        if stop_requested.load(Ordering::Relaxed) {
+            break;
+        }
+        if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+            break;
+        }
+        let _ = perf.poll(std::time::Duration::from_millis(100));
+
+        for event in pending.borrow_mut().drain(..) {
+            reorder.push(event, &mut |ev| {
+                let _ = writer.write_event(ev);
+                *event_count += 1;
+            });
+        }
+    }
+
+    // Final drain: flush reorder buffer.
+    reorder.drain(&mut |ev| {
+        let _ = writer.write_event(ev);
+        *event_count += 1;
+    });
+
+    Ok(*lost_count.borrow())
 }
 
 /// Non-BPF build: runtime error at invocation boundary.
@@ -132,7 +355,6 @@ mod tests {
     fn signal_handler_registration_succeeds() {
         let stop_requested = Arc::new(AtomicBool::new(false));
         register_signal_handlers(&stop_requested).unwrap();
-        // Flag should still be false (no signal sent).
         assert!(!stop_requested.load(Ordering::Relaxed));
     }
 
@@ -145,11 +367,18 @@ mod tests {
     }
 
     #[test]
-    fn record_error_display_not_yet_wired() {
-        let err = RecordError::NotYetWired;
+    fn record_error_display_probe() {
+        let err = RecordError::Probe("BTF not available".to_string());
         let msg = format!("{err}");
-        assert!(msg.contains("not yet wired"));
-        assert!(msg.contains("skeleton"));
+        assert!(msg.contains("feature probing failed"));
+        assert!(msg.contains("BTF"));
+    }
+
+    #[test]
+    fn record_error_display_bpf() {
+        let err = RecordError::Bpf("load failed".to_string());
+        let msg = format!("{err}");
+        assert!(msg.contains("BPF error"));
     }
 
     #[test]
@@ -173,7 +402,10 @@ mod tests {
         let err = RecordError::NoBpfSupport;
         assert!(std::error::Error::source(&err).is_none());
 
-        let err = RecordError::NotYetWired;
+        let err = RecordError::Probe("x".to_string());
+        assert!(std::error::Error::source(&err).is_none());
+
+        let err = RecordError::Bpf("x".to_string());
         assert!(std::error::Error::source(&err).is_none());
 
         let err = RecordError::SignalSetup(io::Error::other("x"));
@@ -195,19 +427,5 @@ mod tests {
         let result = record_impl(&args, &stop_requested);
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), RecordError::NoBpfSupport));
-    }
-
-    #[cfg(feature = "bpf")]
-    #[test]
-    fn record_bpf_returns_not_yet_wired() {
-        let args = RecordArgs {
-            output: PathBuf::from("/tmp/test.wperf"),
-            duration: None,
-            buffer_size: None,
-        };
-        let stop_requested = Arc::new(AtomicBool::new(false));
-        let result = record_impl(&args, &stop_requested);
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), RecordError::NotYetWired));
     }
 }


### PR DESCRIPTION
## Summary

- Replace `NotYetWired` stub with full `record_impl()` pipeline: `probe_all()` → skeleton open/configure/load/attach → dual-path poll loop → drain → finish
- Add `build.rs` with `SkeletonBuilder` for BPF skeleton generation (`bpftool btf dump` → `vmlinux.h` → `wperf.bpf.c` → `wperf.skel.rs`)
- Add `libbpf-cargo` build-dependency gated on `bpf` feature
- Add `offset_of!` assertions for all 11 `WperfEvent` fields (Guardrail B)

## Authoritative Inputs

- final-design.md §1.2 (CLI model), §4.1-4.4 (wPRF format + crash recovery)
- ADR-002 (feature probing)
- ADR-004 (transport abstraction: ringbuf/perfarray)
- ADR-013 (dual-variant sched_switch + sched_wakeup probes)

## Deviations

- `vmlinux.h` is generated from the build host's `/sys/kernel/btf/vmlinux` at build time. This is standard CO-RE practice but means builds require a BTF-enabled kernel. W4 #25 will evaluate vendored `vmlinux.h` for CI portability.
- Perfarray write errors in the `ReorderBuf` callback are silently dropped (`let _ = writer.write_event(ev)`) due to the `FnMut(&WperfEvent)` callback signature not supporting `Result`. This causes silent `event_count`/`drop_count` divergence under I/O pressure — tracked as high-priority follow-up debt.

## Key Design Decisions

- **Dual transport paths**: Both ringbuf (zero-copy, global timestamp order) and perfarray (per-CPU with `ReorderBuf` reordering) are fully wired
- **`set_autoload(false)`**: Standard libbpf pattern — disable probe programs not matching detected `TracepointMode`
- **drop_count = bpf_drops + transport_lost**: Combines BPF-side `bss.drop_counter` (ringbuf reserve failures) with perfarray `lost_cb` count for accurate coverage metrics
- **RefCell bridge**: Bridges libbpf's build-time callbacks with per-poll writer access without requiring `unsafe`

## Guardrails Compliance

| # | Guardrail | Status |
|---|-----------|--------|
| 1 | Task A tracked independently | ✅ Single-purpose branch |
| 2 | Success = record pipeline only | ✅ No Knot detection changes |
| 3 | Transport not narrowed | ✅ Both ringbuf + perfarray paths |
| 4 | Privileged evidence labeled "manual" | ✅ Smoke test was manual privileged |
| 5 | Skeleton API shape verified | ✅ open/load/attach/maps confirmed |
| 6 | Event struct field offset assertions | ✅ All 11 fields via offset_of! |

## Test plan

- [x] `cargo check` passes
- [x] `cargo check --features bpf` passes (0 warnings)
- [x] `cargo clippy --all-targets` passes (0 warnings)
- [x] `cargo test --quiet` — all pass
- [x] Manual privileged smoke: `sudo wperf record -o test.wperf -d 2` → 3.3M events, 0 drops; `wperf report test.wperf` → valid JSON with real WFG edges

## Review Checklist

- [x] Authoritative Inputs section present and accurate
- [x] Deviations section present and all deviations justified
- [x] Code matches spec (ADR-004 transport, ADR-013 dual-variant probes)
- [x] Error handling correct (no panics on BPF failures)
- [x] `NotYetWired` fully removed, no dead code
- [x] Field offset test covers all 11 fields
- [x] `build.rs` fails explicitly (not silently) on missing BTF

🤖 Generated with [Claude Code](https://claude.com/claude-code)