### PR TITLE
feat: 2-thread mutex Knot E2E validation (W4 #22)

### DIFF
--- a/tests/workloads/mutex_knot.c
+++ b/tests/workloads/mutex_knot.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Synthetic 2-thread mutex contention workload for Knot E2E validation.
+//
+// Two pthreads alternate locking the same mutex with usleep() inside
+// the critical section to force voluntary context switches. This
+// produces bidirectional wait-for edges (A→B + B→A) in the WFG,
+// which the SCC/Knot detector should identify as a Knot.
+//
+// Usage: ./mutex_knot [duration_seconds]
+//   Default duration: 3 seconds
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
+static atomic_int stop_flag = 0;
+
+static void *worker(void *arg) {
+    long id = (long)arg;
+    unsigned long iterations = 0;
+
+    fprintf(stderr, "worker %ld: tid=%d\n", id, (int)gettid());
+
+    while (!atomic_load(&stop_flag)) {
+        pthread_mutex_lock(&mtx);
+        usleep(500);
+        pthread_mutex_unlock(&mtx);
+        usleep(100);
+        iterations++;
+    }
+
+    fprintf(stderr, "worker %ld: %lu iterations\n", id, iterations);
+    return NULL;
+}
+
+int main(int argc, char *argv[]) {
+    int duration = 3;
+    if (argc > 1)
+        duration = atoi(argv[1]);
+
+    fprintf(stderr, "mutex_knot: pid=%d, duration=%ds\n", getpid(), duration);
+
+    pthread_t t1, t2;
+    pthread_create(&t1, NULL, worker, (void *)0);
+    pthread_create(&t2, NULL, worker, (void *)1);
+
+    sleep(duration);
+    atomic_store(&stop_flag, 1);
+
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    fprintf(stderr, "mutex_knot: done\n");
+    return 0;
+}

--- a/tests/workloads/run_knot_e2e.sh
+++ b/tests/workloads/run_knot_e2e.sh
@@ -126,19 +126,10 @@ MATCHING_KNOTS=$(jq --argjson t1 "$TID1" --argjson t2 "$TID2" \
 echo "knots containing both TIDs ($TID1, $TID2): $MATCHING_KNOTS"
 
 if [ "$MATCHING_KNOTS" -lt 1 ]; then
-    echo "WARNING: no knot contains both workload TIDs — checking if either TID appears in any knot"
-    # Fallback: at least one TID in some knot (weaker but still meaningful)
-    ANY_TID_KNOTS=$(jq --argjson t1 "$TID1" --argjson t2 "$TID2" \
-        '[.knots[] | select((.members | index($t1)) or (.members | index($t2)))] | length' \
-        "$REPORT_FILE")
-    echo "knots containing either TID: $ANY_TID_KNOTS"
-    if [ "$ANY_TID_KNOTS" -lt 1 ]; then
-        echo "FAIL: workload TIDs not found in any knot" >&2
-        echo "--- all knots ---"
-        jq '.knots' "$REPORT_FILE"
-        exit 1
-    fi
-    echo "WARN: only partial TID match — workload threads may have been folded into a larger SCC"
+    echo "FAIL: no knot contains both workload TIDs ($TID1, $TID2)" >&2
+    echo "--- all knots ---"
+    jq '.knots' "$REPORT_FILE"
+    exit 1
 fi
 
 # Summary

--- a/tests/workloads/run_knot_e2e.sh
+++ b/tests/workloads/run_knot_e2e.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Knot E2E validation script (W4 #22).
+# Requires: root, BPF-enabled kernel, wperf built with --features bpf.
+#
+# Compiles the 2-thread mutex workload, records with wperf, and asserts
+# that the report contains a Knot with the workload's thread IDs.
+#
+# Evidence type: manual privileged smoke
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKLOAD_SRC="$SCRIPT_DIR/mutex_knot.c"
+WORKLOAD_BIN="$SCRIPT_DIR/mutex_knot"
+TRACE_FILE="$(mktemp /tmp/knot_e2e_XXXXXX.wperf)"
+REPORT_FILE="$(mktemp /tmp/knot_e2e_XXXXXX.json)"
+WPERF="$REPO_DIR/target/release/wperf"
+DURATION=3
+
+cleanup() {
+    rm -f "$TRACE_FILE" "$REPORT_FILE" "$WORKLOAD_BIN"
+}
+trap cleanup EXIT
+
+# --- Step 0: Prerequisites ---
+echo "=== Knot E2E: checking prerequisites ==="
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: must run as root" >&2
+    exit 1
+fi
+
+if [ ! -x "$WPERF" ]; then
+    echo "Building wperf with BPF support..."
+    (cd "$REPO_DIR" && cargo build --release --features bpf)
+fi
+
+# --- Step 1: Compile workload ---
+echo "=== Knot E2E: compiling mutex_knot ==="
+gcc -O2 -pthread -o "$WORKLOAD_BIN" "$WORKLOAD_SRC"
+
+# --- Step 2: Run workload + record ---
+echo "=== Knot E2E: recording (${DURATION}s) ==="
+
+# Start workload in background, capture stderr for TIDs
+WORKLOAD_LOG="$(mktemp /tmp/knot_e2e_log_XXXXXX.txt)"
+"$WORKLOAD_BIN" "$DURATION" 2>"$WORKLOAD_LOG" &
+WORKLOAD_PID=$!
+
+# Give workload time to start threads
+sleep 0.5
+
+# Record for duration + 1s margin
+"$WPERF" record -o "$TRACE_FILE" -d $((DURATION + 1)) 2>&1
+
+# Wait for workload to finish
+wait "$WORKLOAD_PID" || true
+
+echo "--- workload log ---"
+cat "$WORKLOAD_LOG"
+
+# Extract worker TIDs from workload stderr
+TIDS=$(grep -oP 'tid=\K[0-9]+' "$WORKLOAD_LOG" | sort -n)
+TID_COUNT=$(echo "$TIDS" | wc -l)
+echo "Detected $TID_COUNT worker TIDs: $(echo $TIDS | tr '\n' ' ')"
+
+if [ "$TID_COUNT" -lt 2 ]; then
+    echo "ERROR: expected at least 2 worker TIDs, got $TID_COUNT" >&2
+    exit 1
+fi
+
+TID_ARRAY=($TIDS)
+rm -f "$WORKLOAD_LOG"
+
+# --- Step 3: Generate report ---
+echo "=== Knot E2E: generating report ==="
+"$WPERF" report "$TRACE_FILE" > "$REPORT_FILE"
+
+# --- Step 4: Assertions ---
+echo "=== Knot E2E: validating assertions ==="
+
+# Guardrail C: pre-condition checks
+EVENTS_READ=$(jq '.stats.events_read' "$REPORT_FILE")
+EDGE_COUNT=$(jq '.cascade.graph_metrics.edge_count' "$REPORT_FILE")
+INVARIANTS_OK=$(jq '.health.invariants_ok' "$REPORT_FILE")
+
+echo "events_read=$EVENTS_READ, edge_count=$EDGE_COUNT, invariants_ok=$INVARIANTS_OK"
+
+if [ "$EVENTS_READ" -eq 0 ]; then
+    echo "FAIL: events_read == 0 — trace is empty (permission issue? probes not attached?)" >&2
+    exit 1
+fi
+
+if [ "$EDGE_COUNT" -eq 0 ]; then
+    echo "FAIL: edge_count == 0 — no wait-for edges correlated" >&2
+    exit 1
+fi
+
+if [ "$INVARIANTS_OK" != "true" ]; then
+    echo "FAIL: invariants_ok != true" >&2
+    exit 1
+fi
+
+# Core assertion: at least one Knot exists
+KNOT_COUNT=$(jq '.knots | length' "$REPORT_FILE")
+echo "knot_count=$KNOT_COUNT"
+
+if [ "$KNOT_COUNT" -lt 1 ]; then
+    echo "FAIL: no knots detected (expected >= 1)" >&2
+    echo "--- full knots output ---"
+    jq '.knots' "$REPORT_FILE"
+    exit 1
+fi
+
+# Guardrail A: verify workload TIDs appear in at least one knot
+# Check that at least one knot contains both worker TIDs
+TID1="${TID_ARRAY[0]}"
+TID2="${TID_ARRAY[1]}"
+MATCHING_KNOTS=$(jq --argjson t1 "$TID1" --argjson t2 "$TID2" \
+    '[.knots[] | select((.members | index($t1)) and (.members | index($t2)))] | length' \
+    "$REPORT_FILE")
+
+echo "knots containing both TIDs ($TID1, $TID2): $MATCHING_KNOTS"
+
+if [ "$MATCHING_KNOTS" -lt 1 ]; then
+    echo "WARNING: no knot contains both workload TIDs — checking if either TID appears in any knot"
+    # Fallback: at least one TID in some knot (weaker but still meaningful)
+    ANY_TID_KNOTS=$(jq --argjson t1 "$TID1" --argjson t2 "$TID2" \
+        '[.knots[] | select((.members | index($t1)) or (.members | index($t2)))] | length' \
+        "$REPORT_FILE")
+    echo "knots containing either TID: $ANY_TID_KNOTS"
+    if [ "$ANY_TID_KNOTS" -lt 1 ]; then
+        echo "FAIL: workload TIDs not found in any knot" >&2
+        echo "--- all knots ---"
+        jq '.knots' "$REPORT_FILE"
+        exit 1
+    fi
+    echo "WARN: only partial TID match — workload threads may have been folded into a larger SCC"
+fi
+
+# Summary
+echo ""
+echo "=== Knot E2E: ALL ASSERTIONS PASSED ==="
+echo "  events_read:    $EVENTS_READ"
+echo "  edge_count:     $EDGE_COUNT"
+echo "  invariants_ok:  $INVARIANTS_OK"
+echo "  knot_count:     $KNOT_COUNT"
+echo "  workload_knots: $MATCHING_KNOTS (both TIDs: $TID1, $TID2)"


### PR DESCRIPTION
## Summary

- Add synthetic 2-thread mutex contention workload (`tests/workloads/mutex_knot.c`) that creates deterministic bidirectional wait-for edges via mutex contention + `usleep()` inside the critical section
- Add E2E validation script (`tests/workloads/run_knot_e2e.sh`) that compiles, records, reports, and asserts Knot detection with TID filtering
- No code changes to the report pipeline — Knot detection is already fully wired

## Authoritative Inputs

- final-design.md §3.5 (Knot detection: sink SCC filtering)
- final-design.md §5 (Phase 1 exit gate: "is_conserved==true on real BPF data")
- ADR-013 (dual-variant probes)

## Deviations

- No automated CI — requires root + BPF. Validation is manual privileged evidence.
- Workload uses `usleep()` inside critical section to force voluntary switches, not pure busy-wait contention. This is by design: `usleep(500)` ensures the lock is held long enough for the other thread to actually block on `pthread_mutex_lock()`.

## Key Design Decisions

- **`atomic_int` clean shutdown** (Guardrail B): No `pthread_cancel` — threads check `stop_flag` each iteration for clean exit
- **TID filtering** (Guardrail A): Workload prints worker TIDs to stderr; script extracts them and verifies both appear in the same knot's `members` array. No partial-match fallback — both TIDs or FAIL.
- **Pre-condition assertions** (Guardrail C): Script checks `events_read > 0` and `edge_count > 0` before asserting knots, for diagnosable failures
- **Privileged evidence labeling** (Guardrail D): PR and script labeled as manual privileged smoke

## Guardrails Compliance

| # | Guardrail | Status |
|---|-----------|--------|
| A | TID filtering in assertions | ✅ Both TIDs must be in same knot or FAIL |
| B | Clean shutdown (no pthread_cancel) | ✅ atomic_int stop_flag |
| C | Pre-condition checks | ✅ events_read > 0, edges > 0 |
| D | Privileged evidence labeling | ✅ Script header + PR body |

## Test plan

- [x] `mutex_knot.c` compiles with `gcc -O2 -pthread`
- [x] `cargo check` passes (no Rust code changes)
- [ ] Manual privileged smoke: `sudo tests/workloads/run_knot_e2e.sh` → all assertions pass (requires root + BPF)

## Review Checklist

- [x] Authoritative Inputs section present and accurate
- [x] Deviations section present and all deviations justified
- [x] Workload design produces reliable bidirectional wait-for edges
- [x] Assertion script checks TIDs (not just "any knot exists")
- [x] Pre-condition checks for diagnosable failures
- [x] Script labeled as manual privileged evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)