### PR TITLE
fix: propagate write errors in perfarray poll loop

### DIFF
--- a/src/record.rs
+++ b/src/record.rs
@@ -313,15 +313,15 @@ fn poll_perfarray<W: std::io::Write + std::io::Seek>(
         .map_err(|e| RecordError::Bpf(format!("perf buffer build: {e}")))?;
 
     let mut reorder = ReorderBuf::new();
-    let mut write_err: Option<io::Error> = None;
+    let write_err: RefCell<Option<io::Error>> = RefCell::new(None);
 
     let mut write_cb = |ev: &WperfEvent| {
-        if write_err.is_some() {
+        if write_err.borrow().is_some() {
             return;
         }
         match writer.write_event(ev) {
             Ok(()) => *event_count += 1,
-            Err(e) => write_err = Some(e),
+            Err(e) => *write_err.borrow_mut() = Some(e),
         }
     };
 
@@ -337,14 +337,14 @@ fn poll_perfarray<W: std::io::Write + std::io::Seek>(
         for event in pending.borrow_mut().drain(..) {
             reorder.push(event, &mut write_cb);
         }
-        if let Some(e) = write_err.take() {
+        if let Some(e) = write_err.borrow_mut().take() {
             return Err(RecordError::Io(e));
         }
     }
 
     // Final drain: flush reorder buffer.
     reorder.drain(&mut write_cb);
-    if let Some(e) = write_err.take() {
+    if let Some(e) = write_err.borrow_mut().take() {
         return Err(RecordError::Io(e));
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -313,6 +313,17 @@ fn poll_perfarray<W: std::io::Write + std::io::Seek>(
         .map_err(|e| RecordError::Bpf(format!("perf buffer build: {e}")))?;
 
     let mut reorder = ReorderBuf::new();
+    let mut write_err: Option<io::Error> = None;
+
+    let mut write_cb = |ev: &WperfEvent| {
+        if write_err.is_some() {
+            return;
+        }
+        match writer.write_event(ev) {
+            Ok(()) => *event_count += 1,
+            Err(e) => write_err = Some(e),
+        }
+    };
 
     loop {
         if stop_requested.load(Ordering::Relaxed) {
@@ -324,18 +335,18 @@ fn poll_perfarray<W: std::io::Write + std::io::Seek>(
         let _ = perf.poll(std::time::Duration::from_millis(100));
 
         for event in pending.borrow_mut().drain(..) {
-            reorder.push(event, &mut |ev| {
-                let _ = writer.write_event(ev);
-                *event_count += 1;
-            });
+            reorder.push(event, &mut write_cb);
+        }
+        if let Some(e) = write_err.take() {
+            return Err(RecordError::Io(e));
         }
     }
 
     // Final drain: flush reorder buffer.
-    reorder.drain(&mut |ev| {
-        let _ = writer.write_event(ev);
-        *event_count += 1;
-    });
+    reorder.drain(&mut write_cb);
+    if let Some(e) = write_err.take() {
+        return Err(RecordError::Io(e));
+    }
 
     Ok(*lost_count.borrow())
 }


### PR DESCRIPTION
## Summary
- Replace silent `let _ = writer.write_event(ev)` in `poll_perfarray()` with error-capturing `write_cb` closure
- On write failure: stops processing, propagates `RecordError::Io`, reports accurate `event_count`
- Mirrors the `write_err: RefCell<Option<io::Error>>` pattern already used in `poll_ringbuf()`

## Authoritative Inputs
- ADR-004 (transport abstraction)
- final-design.md §4.1-4.4 (wPRF format + crash recovery)

## Deviations
None — this is a bug fix for behavior that deviated from the design's error-handling intent.

## P1 Debt Context
Identified during PR #102 review: perfarray path silently dropped write errors and inflated `event_count` on I/O failure. The `ReorderBuf` callback signature (`&mut dyn FnMut(&WperfEvent)`) doesn't support `Result`, so we use an `Option<io::Error>` capture checked after each batch — same approach as the ringbuf path.

## Test plan
- [x] `cargo check` — clean
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo test --quiet` — 266 tests pass
- [ ] Reviewer: confirm error propagation logic matches ringbuf path
- [ ] Reviewer: confirm `event_count` only increments on successful write

## PR Review Checklist
- [ ] Reviewer validated: error path stops processing on first failure
- [ ] Reviewer validated: no silent `let _ =` on fallible I/O remains