### PR TITLE
feat: sys_enter_futex tracepoint probe (P2a-01)

### DIFF
--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -58,7 +58,7 @@ struct {
  * Read by user-space at end of recording. */
 __u64 drop_counter = 0;
 
-/* BSS: enable futex tracing (Phase 2a). Defaults to false; user-space
+/* RODATA: enable futex tracing (Phase 2a). Defaults to false; user-space
  * sets to true between open() and load() when futex annotation is wanted. */
 const volatile bool enable_futex_tracing = false;
 
@@ -268,7 +268,8 @@ int handle_sys_enter_futex(struct trace_event_raw_sys_enter *ctx)
 		return 0;
 
 	__u32 op = (__u32)ctx->args[1] & FUTEX_CMD_MASK;
-	if (op != FUTEX_WAIT && op != FUTEX_WAIT_BITSET && op != FUTEX_LOCK_PI)
+	if (op != FUTEX_WAIT && op != FUTEX_WAIT_BITSET &&
+	    op != FUTEX_LOCK_PI && op != FUTEX_WAIT_REQUEUE_PI)
 		return 0;
 
 	e = reserve_buf(sizeof(*e));

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -58,6 +58,10 @@ struct {
  * Read by user-space at end of recording. */
 __u64 drop_counter = 0;
 
+/* BSS: enable futex tracing (Phase 2a). Defaults to false; user-space
+ * sets to true between open() and load() when futex annotation is wanted. */
+const volatile bool enable_futex_tracing = false;
+
 /* BSS: wperf's own TGID, set by user-space before attach().
  * Probes skip events involving this TGID to prevent observer-effect
  * feedback loops (wperf's sleep/wake cycles triggering its own probes). */
@@ -228,6 +232,62 @@ int BPF_PROG(handle_sched_wakeup_raw,
 	e->tid = (__u32)pid_tgid;
 	e->prev_tid = e->tid;
 	e->prev_pid = e->pid;
+
+	submit_buf(ctx, e, sizeof(*e));
+	return 0;
+}
+
+/* --------------------------------------------------------------------------
+ * sys_enter_futex tracepoint (Phase 2a — wait cause annotation)
+ *
+ * Standard tracepoint (not tp_btf/raw_tp). Stable ABI across all 4.18+
+ * kernels — single handler, no dual-variant needed.
+ * Gated by const volatile bool enable_futex_tracing.
+ *
+ * Captures only wait-side operations (FUTEX_WAIT, FUTEX_WAIT_BITSET,
+ * FUTEX_LOCK_PI). Ignores FUTEX_WAKE and other non-blocking ops.
+ *
+ * Field mapping in wperf_event:
+ *   prev_tid  = uaddr lower 32 bits
+ *   next_tid  = uaddr upper 32 bits
+ *   flags     = futex op (masked by FUTEX_CMD_MASK)
+ * -------------------------------------------------------------------------- */
+
+SEC("tracepoint/syscalls/sys_enter_futex")
+int handle_sys_enter_futex(struct trace_event_raw_sys_enter *ctx)
+{
+	struct wperf_event *e;
+
+	if (!enable_futex_tracing)
+		return 0;
+
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tgid = (__u32)(pid_tgid >> 32);
+
+	if (self_tgid && tgid == self_tgid)
+		return 0;
+
+	__u32 op = (__u32)ctx->args[1] & FUTEX_CMD_MASK;
+	if (op != FUTEX_WAIT && op != FUTEX_WAIT_BITSET && op != FUTEX_LOCK_PI)
+		return 0;
+
+	e = reserve_buf(sizeof(*e));
+	if (!e)
+		return 0;
+
+	fill_timestamp_and_cpu(e);
+	e->event_type = WPERF_EVENT_FUTEX_WAIT;
+	e->pid = tgid;
+	e->tid = (__u32)pid_tgid;
+
+	__u64 uaddr = (__u64)ctx->args[0];
+	e->prev_tid = (__u32)uaddr;
+	e->next_tid = (__u32)(uaddr >> 32);
+
+	e->prev_pid = 0;
+	e->next_pid = 0;
+	e->prev_state = 0;
+	e->flags = op;
 
 	submit_buf(ctx, e, sizeof(*e));
 	return 0;

--- a/src/bpf/wperf.h
+++ b/src/bpf/wperf.h
@@ -24,7 +24,22 @@ enum wperf_event_type {
 	WPERF_EVENT_WAKEUP     = 2,
 	WPERF_EVENT_WAKEUP_NEW = 3,
 	WPERF_EVENT_EXIT       = 4,
+	WPERF_EVENT_FUTEX_WAIT = 5,
 };
+
+/* Futex operation constants (from linux/futex.h). */
+#define FUTEX_WAIT          0
+#define FUTEX_LOCK_PI       6
+#define FUTEX_WAIT_BITSET   9
+#define FUTEX_CMD_MASK      0x7f
+
+/*
+ * Futex event field mapping (reuses 40-byte wperf_event struct):
+ *   prev_tid  → uaddr lower 32 bits
+ *   next_tid  → uaddr upper 32 bits
+ *   flags     → futex op (after FUTEX_CMD_MASK)
+ *   prev_pid, next_pid, prev_state → unused (zero)
+ */
 
 /*
  * 40-byte event structure — Rust mirror: src/format/event.rs WperfEvent.

--- a/src/bpf/wperf.h
+++ b/src/bpf/wperf.h
@@ -27,12 +27,24 @@ enum wperf_event_type {
 	WPERF_EVENT_FUTEX_WAIT = 5,
 };
 
-/* Futex operation constants (from linux/futex.h). */
+/* Futex operation constants (from linux/futex.h).
+ * Guarded: vmlinux.h (BTF dump) doesn't define these macros today,
+ * but #ifndef is zero-cost insurance against future toolchain changes. */
+#ifndef FUTEX_WAIT
 #define FUTEX_WAIT              0
+#endif
+#ifndef FUTEX_LOCK_PI
 #define FUTEX_LOCK_PI           6
+#endif
+#ifndef FUTEX_WAIT_BITSET
 #define FUTEX_WAIT_BITSET       9
+#endif
+#ifndef FUTEX_WAIT_REQUEUE_PI
 #define FUTEX_WAIT_REQUEUE_PI  11
+#endif
+#ifndef FUTEX_CMD_MASK
 #define FUTEX_CMD_MASK         0x7f
+#endif
 
 /*
  * Futex event field mapping (reuses 40-byte wperf_event struct):

--- a/src/bpf/wperf.h
+++ b/src/bpf/wperf.h
@@ -28,10 +28,11 @@ enum wperf_event_type {
 };
 
 /* Futex operation constants (from linux/futex.h). */
-#define FUTEX_WAIT          0
-#define FUTEX_LOCK_PI       6
-#define FUTEX_WAIT_BITSET   9
-#define FUTEX_CMD_MASK      0x7f
+#define FUTEX_WAIT              0
+#define FUTEX_LOCK_PI           6
+#define FUTEX_WAIT_BITSET       9
+#define FUTEX_WAIT_REQUEUE_PI  11
+#define FUTEX_CMD_MASK         0x7f
 
 /*
  * Futex event field mapping (reuses 40-byte wperf_event struct):

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -103,8 +103,9 @@ pub fn correlate_events(events: &[WperfEvent]) -> (WaitForGraph, CorrelationStat
                 // Clean up off-CPU record if thread exits.
                 off_cpu.remove(&event.tid);
             }
-            None => {
-                // Unknown event type — skip (forward-compat).
+            Some(EventType::FutexWait) | None => {
+                // FutexWait: consumed by wait_type annotation (task #35).
+                // None: unknown event type — skip (forward-compat).
             }
         }
     }

--- a/src/format/event.rs
+++ b/src/format/event.rs
@@ -23,6 +23,13 @@ use std::io::{self, Read, Write};
 /// Event size in bytes. Naturally aligned, no padding waste.
 pub const EVENT_SIZE: usize = 40;
 
+/// Futex operation constants (matching BPF-side definitions from linux/futex.h).
+pub mod futex_op {
+    pub const FUTEX_WAIT: u32 = 0;
+    pub const FUTEX_LOCK_PI: u32 = 6;
+    pub const FUTEX_WAIT_BITSET: u32 = 9;
+}
+
 /// Event type discriminants — must match BPF `enum wperf_event_type`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -31,6 +38,7 @@ pub enum EventType {
     Wakeup = 2,
     WakeupNew = 3,
     Exit = 4,
+    FutexWait = 5,
 }
 
 impl EventType {
@@ -40,6 +48,7 @@ impl EventType {
             2 => Some(Self::Wakeup),
             3 => Some(Self::WakeupNew),
             4 => Some(Self::Exit),
+            5 => Some(Self::FutexWait),
             _ => None,
         }
     }
@@ -120,6 +129,18 @@ impl WperfEvent {
     pub fn event_type_enum(&self) -> Option<EventType> {
         EventType::from_u8(self.event_type)
     }
+
+    /// Futex user address (64-bit). Only meaningful for `FutexWait` events.
+    /// Stored as: `prev_tid` = lower 32 bits, `next_tid` = upper 32 bits.
+    pub fn futex_uaddr(&self) -> u64 {
+        u64::from(self.next_tid) << 32 | u64::from(self.prev_tid)
+    }
+
+    /// Futex operation (after `FUTEX_CMD_MASK`). Only meaningful for `FutexWait` events.
+    /// Stored in `flags` field.
+    pub fn futex_op(&self) -> u32 {
+        self.flags
+    }
 }
 
 #[cfg(test)]
@@ -183,18 +204,60 @@ mod tests {
         assert_eq!(ev, parsed);
     }
 
+    fn sample_futex_event() -> WperfEvent {
+        WperfEvent {
+            timestamp_ns: 1_000_100_000,
+            pid: 100,
+            tid: 101,
+            prev_tid: 0xDEAD_BEEFu32, // uaddr lower 32
+            next_tid: 0x0000_7FFEu32,  // uaddr upper 32
+            prev_pid: 0,
+            next_pid: 0,
+            cpu: 2,
+            event_type: EventType::FutexWait as u8,
+            prev_state: 0,
+            flags: futex_op::FUTEX_WAIT,
+        }
+    }
+
     #[test]
     fn event_type_enum_known() {
         assert_eq!(EventType::from_u8(1), Some(EventType::Switch));
         assert_eq!(EventType::from_u8(2), Some(EventType::Wakeup));
         assert_eq!(EventType::from_u8(3), Some(EventType::WakeupNew));
         assert_eq!(EventType::from_u8(4), Some(EventType::Exit));
+        assert_eq!(EventType::from_u8(5), Some(EventType::FutexWait));
     }
 
     #[test]
     fn event_type_enum_unknown() {
         assert_eq!(EventType::from_u8(0), None);
         assert_eq!(EventType::from_u8(255), None);
+    }
+
+    #[test]
+    fn futex_event_roundtrip() {
+        let ev = sample_futex_event();
+        let bytes = ev.to_bytes();
+        let parsed = WperfEvent::from_bytes(&bytes);
+        assert_eq!(ev, parsed);
+        assert_eq!(parsed.event_type_enum(), Some(EventType::FutexWait));
+    }
+
+    #[test]
+    fn futex_uaddr_accessor() {
+        let ev = sample_futex_event();
+        assert_eq!(ev.futex_uaddr(), 0x0000_7FFE_DEAD_BEEFu64);
+    }
+
+    #[test]
+    fn futex_op_accessor() {
+        let ev = sample_futex_event();
+        assert_eq!(ev.futex_op(), futex_op::FUTEX_WAIT);
+
+        let mut ev2 = ev;
+        ev2.flags = futex_op::FUTEX_LOCK_PI;
+        assert_eq!(ev2.futex_op(), futex_op::FUTEX_LOCK_PI);
     }
 
     #[test]

--- a/src/format/event.rs
+++ b/src/format/event.rs
@@ -210,7 +210,7 @@ mod tests {
             pid: 100,
             tid: 101,
             prev_tid: 0xDEAD_BEEFu32, // uaddr lower 32
-            next_tid: 0x0000_7FFEu32,  // uaddr upper 32
+            next_tid: 0x0000_7FFEu32, // uaddr upper 32
             prev_pid: 0,
             next_pid: 0,
             cpu: 2,

--- a/src/format/event.rs
+++ b/src/format/event.rs
@@ -28,6 +28,7 @@ pub mod futex_op {
     pub const FUTEX_WAIT: u32 = 0;
     pub const FUTEX_LOCK_PI: u32 = 6;
     pub const FUTEX_WAIT_BITSET: u32 = 9;
+    pub const FUTEX_WAIT_REQUEUE_PI: u32 = 11;
 }
 
 /// Event type discriminants — must match BPF `enum wperf_event_type`.

--- a/src/record.rs
+++ b/src/record.rs
@@ -177,6 +177,13 @@ fn record_impl(args: &RecordArgs, stop_requested: &Arc<AtomicBool>) -> Result<()
         .ok_or_else(|| RecordError::Bpf("BSS data not available".into()))?
         .self_tgid = global_tgid();
 
+    open_skel
+        .maps
+        .rodata_data
+        .as_mut()
+        .ok_or_else(|| RecordError::Bpf("rodata not available".into()))?
+        .enable_futex_tracing = true;
+
     if features.transport == TransportMode::RingBuf {
         open_skel
             .maps


### PR DESCRIPTION
## Summary
- Add BPF `sys_enter_futex` tracepoint probe for futex wait operation capture
- New `EventType::FutexWait` variant with `futex_uaddr()`/`futex_op()` accessors
- Feature flag gating via `const volatile bool enable_futex_tracing`
- Correlate module updated to skip futex events (consumed in task #35)

## Changes
- `src/bpf/wperf.h` — `WPERF_EVENT_FUTEX_WAIT = 5`, futex constants, field mapping docs
- `src/bpf/wperf.bpf.c` — `handle_sys_enter_futex` handler (standard tracepoint, no dual-variant)
- `src/format/event.rs` — `FutexWait` variant, `futex_op` module, accessor methods, tests
- `src/correlate.rs` — skip arm for `FutexWait` events
- `src/record.rs` — `enable_futex_tracing` rodata flag wiring

## Authoritative inputs
- final-design.md §2.1 (sys_enter_futex as Auxiliary probe)
- ADR-013 line 177 (standard `tp/` for futex, not tp_btf)
- ADR-004 (transport abstraction)

## Test plan
- [ ] `cargo test` — all existing tests pass + new futex event roundtrip/accessor tests
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo check --features bpf` / `cargo clippy --features bpf` clean
- [ ] CI green (cross-kernel E2E, mutation testing)
- [ ] Gemini review addressed

Closes #34