### PR TITLE
docs(adr): ADR-017 ε-phase force-with-lease choreography

### DIFF
--- a/docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt
+++ b/docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt
@@ -24,11 +24,12 @@ f736d2fc630470211c5875132a1a50f5d5cd0f19	refs/tags/pre-rewrite-snapshot
 - origin/main tip = local HEAD = b6c60050a487801a834b8cfc32a469588a89b479 (γ fold-tip)
 - frozen-tag pre-rewrite-snapshot tag-obj = f736d2fc630470211c5875132a1a50f5d5cd0f19 (unchanged from pre-push)
 - frozen-tag pr111-contaminated-snapshot tag-obj = 5f3e72df180e4fdab68ab892c21b7b7a8f3c4559 (unchanged from pre-push)
-- spec §2 L34-35 frozen-tag invariant: trip-wire refspecs (non-force) did not error → tags byte-identical
-- spec §5 L99-103 force-with-lease lease pre-image matched origin (0a9f8446 → b6c6005 transition)
+- spec §2 L38-39 frozen-tag invariant: trip-wire refspecs (non-force) did not error → tags byte-identical
+- ADR-017 §2.1 lease pre-image binding: 0a9f8446 → b6c6005 transition (force-with-lease semantics live in ADR-017, not gamma-post-audit-spec)
+- anchors verified against contents-API readback at 2026-04-20T18:45Z (endpoint: gh api repos/adrian-mason/wperf/contents/docs/decisions/gamma-post-audit-spec.md)
 
 ## Spec anchor
-§6 L113 ε-phase push --force-with-lease choreography (tracked separately)
+§6 L128 ε-phase push --force-with-lease choreography (tracked separately)
 (§5 not triggered — γ.0/γ.3/γ(post-γ.3) three-layer gates all PASS)
 
 ## 4-reviewer pre-push LOCK

--- a/docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt
+++ b/docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt
@@ -38,7 +38,7 @@ f736d2fc630470211c5875132a1a50f5d5cd0f19	refs/tags/pre-rewrite-snapshot
 - Challenger msg=f4246c44 + msg=49316b65
 - Probe msg=b302e95f + msg=3bcd8a43 silent-CONCUR posture
 
-## Rollback path (if step-4/5 finds divergence)
+## Rollback path (if step-5 finds divergence)
 git push --force-with-lease=refs/heads/main:b6c60050a487801a834b8cfc32a469588a89b479 \
   origin refs/tags/pre-rewrite-snapshot^{}:refs/heads/main
 (restores main to pre-γ tip via frozen tag)

--- a/docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt
+++ b/docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt
@@ -1,0 +1,43 @@
+# gamma-1-push-complete — ε force-with-lease push artefact
+timestamp_utc: 2026-04-20T07:33:28Z
+pushed_by: Maestro
+authoriser: Adrian-Mason (chat msg=b3390d93 "go" @ 2026-04-20 15:31:42)
+thread: #p2-dev:83d0107a
+
+## Push command (byte-exact)
+git push \
+  --force-with-lease=refs/heads/main:0a9f8446948c2983582eceecd889677a1e9cee9e \
+  origin \
+  refs/heads/main:refs/heads/main \
+  refs/tags/pre-rewrite-snapshot:refs/tags/pre-rewrite-snapshot \
+  refs/tags/pr111-contaminated-snapshot:refs/tags/pr111-contaminated-snapshot
+
+## Push result
++ 0a9f844...b6c6005 main -> main (forced update)
+
+## Post-push origin state (git ls-remote)
+b6c60050a487801a834b8cfc32a469588a89b479	refs/heads/main
+5f3e72df180e4fdab68ab892c21b7b7a8f3c4559	refs/tags/pr111-contaminated-snapshot
+f736d2fc630470211c5875132a1a50f5d5cd0f19	refs/tags/pre-rewrite-snapshot
+
+## Invariants preserved
+- origin/main tip = local HEAD = b6c60050a487801a834b8cfc32a469588a89b479 (γ fold-tip)
+- frozen-tag pre-rewrite-snapshot tag-obj = f736d2fc630470211c5875132a1a50f5d5cd0f19 (unchanged from pre-push)
+- frozen-tag pr111-contaminated-snapshot tag-obj = 5f3e72df180e4fdab68ab892c21b7b7a8f3c4559 (unchanged from pre-push)
+- spec §2 L34-35 frozen-tag invariant: trip-wire refspecs (non-force) did not error → tags byte-identical
+- spec §5 L99-103 force-with-lease lease pre-image matched origin (0a9f8446 → b6c6005 transition)
+
+## Spec anchor
+§6 L113 ε-phase push --force-with-lease choreography (tracked separately)
+(§5 not triggered — γ.0/γ.3/γ(post-γ.3) three-layer gates all PASS)
+
+## 4-reviewer pre-push LOCK
+- Oracle msg=89c0d4f3 6-axis SEAL + msg=ab29abe9 self-corrected step-sequence
+- Critic msg=c8b91eaf + msg=4f889ec0 (ε-mainline anchor §6 L113 refinement)
+- Challenger msg=f4246c44 + msg=49316b65
+- Probe msg=b302e95f + msg=3bcd8a43 silent-CONCUR posture
+
+## Rollback path (if step-4/5 finds divergence)
+git push --force-with-lease=refs/heads/main:b6c60050a487801a834b8cfc32a469588a89b479 \
+  origin refs/tags/pre-rewrite-snapshot^{}:refs/heads/main
+(restores main to pre-γ tip via frozen tag)

--- a/docs/decisions/ADR-017.md
+++ b/docs/decisions/ADR-017.md
@@ -172,31 +172,33 @@ in the rollback push without a refresh would — in the case where
 LOCAL is the mutated side — publish the mutated SHA back to
 `origin/main`.
 
-**Step 2.5.a — frozen-tag refresh and audit-artefact cross-check**:
+**Step 2.5.a — fetch origin's frozen-tag to FETCH_HEAD + audit-artefact cross-check**:
 
 ```
-git fetch --force origin \
-  refs/tags/pre-rewrite-snapshot:refs/tags/pre-rewrite-snapshot
-LOCAL_FROZEN_SHA=$(git rev-parse refs/tags/pre-rewrite-snapshot^{})
-# Operator MUST confirm LOCAL_FROZEN_SHA matches the pre-γ tip
+git fetch origin refs/tags/pre-rewrite-snapshot
+FETCH_HEAD_SHA=$(git rev-parse FETCH_HEAD^{commit})
+# Operator MUST confirm FETCH_HEAD_SHA matches the pre-γ tip
 # recorded in the push-complete audit artefact (§2.6 POST_HEAD —
 # docs/audit/gamma/gamma-<phase>-push-complete-*.txt) before
 # proceeding to Step 2.5.b.
 ```
 
-If origin's `pre-rewrite-snapshot` has itself been rewritten (would
-require a push by an account holding the admin-role bypass —
-outside the §3.2 vantage trust model), the audit-artefact
-cross-check catches the discrepancy and the operator hands off to
-Adrian without rolling back.
+`FETCH_HEAD` records exactly the tag object that was fetched from
+origin in this invocation, and LOCAL `refs/tags/pre-rewrite-snapshot`
+is left untouched so any mutated LOCAL value remains available for
+post-incident forensics. If origin's `pre-rewrite-snapshot` has
+itself been rewritten (would require a push by an account holding
+the admin-role bypass — outside the §3.2 vantage trust model), the
+audit-artefact cross-check catches the discrepancy and the operator
+hands off to Adrian without rolling back.
 
-**Step 2.5.b — rollback push**:
+**Step 2.5.b — rollback push using the dereferenced FETCH_HEAD SHA**:
 
 ```
 git push \
   --force-with-lease=refs/heads/main:<current_origin_main_SHA> \
   origin \
-  refs/tags/pre-rewrite-snapshot^{}:refs/heads/main
+  ${FETCH_HEAD_SHA}:refs/heads/main
 ```
 
 Rollback binds its own lease to the current `origin/main` so a
@@ -279,9 +281,26 @@ bypass_actors):
    `bypass_mode=always`).
 3. Decide whether the new admin is intended to bypass main-protection.
    - **Yes**: proceed to grant admin.
-   - **No**: first switch the ruleset to a User-specific allow-list
-     that excludes them. Then verify, from their vantage, that
-     `current_user_can_bypass == "never"`. Then grant admin.
+   - **No**: the correct action depends on the repository's ownership
+     type, because of §3.1's accepted constraint that User-type
+     `bypass_actors` entries do not execute on personal repositories.
+     - **Personal repo** (current state of `adrian-mason/wperf`):
+       do not grant admin. Grant the minimum role that covers the
+       collaborator's actual need — typically `write` or `triage`.
+       On a personal repo, admin-role holders bypass main-protection
+       by the RepositoryRole=admin configuration, and a User-specific
+       allow-list cannot constrain them because the User entry would
+       be stored but not executed (§3.1); switching to a User-only
+       scheme would in fact remove bypass from everyone, including
+       Adrian, contradicting the option-C intent (msg=67295c3c).
+       Granting admin therefore commits to bypass. If the No-path is
+       required and admin is truly unavoidable, first convert the
+       repository to an organisation (see below).
+     - **Organisation repo**: switch the ruleset to a User-specific
+       allow-list that excludes them — User entries execute on
+       organisation-owned repositories. Then verify, from their
+       vantage, that `current_user_can_bypass == "never"`. Then grant
+       admin.
 4. Record the decision (ADR amendment or audit note) so the
    non-default choice is legible to future readers.
 

--- a/docs/decisions/ADR-017.md
+++ b/docs/decisions/ADR-017.md
@@ -161,6 +161,34 @@ review. Recording both case studies in this ADR prevents the negative
 precedent from being read as acceptable and keeps the positive
 pattern (self-application) as the baseline expectation.
 
+#### Case study — negative: intra-artefact spec-citation currency
+
+The first version of `gamma-1-push-complete-20260420T073328Z.txt`
+(committed as part of this ADR's reference implementation, §6) cited
+three `§N LXX-YY` anchors into `gamma-post-audit-spec.md` that had
+been invalidated by the γ rewrite — the artefact's citations matched
+a pre-γ version of the spec, not the current one. Concretely: the
+frozen-tag invariant anchor pointed at `§2 L34-35` when the verbatim
+statement had shifted to `§2 L38-39`; the ε-phase tracked-separately
+anchor pointed at `§6 L113` when the actual location was `§6 L128`;
+and an anchor was made into `§5 L99-103 force-with-lease` when
+force-with-lease is not covered by `gamma-post-audit-spec` at all
+(it lives in this ADR's §2.1). The discipline that would have
+caught these at authoring time — "grep the current spec before
+echoing a reviewer's section/line reference" — existed as a prior
+saved-memory principle but was not executed when the artefact was
+written. This is the same family of failure as the endpoint-mismatch
+case above, in a different cell: that case was *inter-agent
+cross-vantage endpoint completeness*; this one is *intra-artefact vs
+external-spec citation currency*. Both are instances of declaring a
+match against a stale or misaligned target. The artefact's anchor
+lines have since been corrected, and a verification-endpoint
+timestamp line was added so the currency of the citations is
+recorded rather than assumed. The case study is logged here so that
+future authors read "grep-current-spec before citing" as the
+baseline verifier behaviour expected of the primary author, not as a
+recovery performed only after peer BLOCK.
+
 ### 2.5 ε-ABORT rollback
 
 If Steps 1–5 detect any divergence (lease fired, frozen-tag trip-wire

--- a/docs/decisions/ADR-017.md
+++ b/docs/decisions/ADR-017.md
@@ -1,0 +1,312 @@
+# ADR-017: ε-Phase `push --force-with-lease` Choreography
+
+- **Status:** Proposed
+- **Date:** 2026-04-20
+- **Scope:** post-γ; fulfils the "tracked separately" commitment in
+  `docs/decisions/gamma-post-audit-spec.md` §6 (out-of-scope anchor for
+  `ε-phase push --force-with-lease` choreography).
+- **Precondition:** γ.0 / γ.3 / γ(post-γ.3) three-layer audit artefacts
+  committed under `docs/audit/gamma/` with gate outcomes PASS.
+
+## 1. Problem
+
+γ rewrote every commit reachable from `origin/main` (§2 of
+gamma-post-audit-spec). The rewrite is non-reversible history mutation;
+the pre-γ snapshot lives only in the frozen tag `pre-rewrite-snapshot`.
+Publishing the rewritten history to `origin` requires a force-push. Two
+failure modes are material:
+
+1. **Lost-update race.** Between the local rewrite and the force-push,
+   someone else could push to `origin/main`. A naïve `git push --force`
+   would silently discard their commit.
+2. **Frozen-tag mutation.** If the same invocation rewrites the
+   `pre-rewrite-snapshot` tag object to anything other than its
+   pre-γ tag-object SHA, the one ground-truth recovery reference is
+   destroyed.
+
+The ε-phase choreography specifies how the force-push is composed,
+audited, and reversed so that both failure modes are unreachable by
+construction (not just by convention).
+
+## 2. Decision
+
+### 2.1 Lease pre-image binding
+
+Every ε-phase force-push MUST use explicit `--force-with-lease=<ref>:<SHA>`
+form with a 40-hex SHA pre-image. The SHA MUST be the pre-push
+`origin/<ref>` tip observed in the same shell invocation. Bare
+`--force-with-lease` (implicit pre-image from the refs/remotes cache)
+is forbidden because it infers the pre-image from local state, which
+can be stale.
+
+Example (γ→ε executed 2026-04-20):
+
+```
+git push \
+  --force-with-lease=refs/heads/main:0a9f8446948c2983582eceecd889677a1e9cee9e \
+  origin \
+  refs/heads/main:refs/heads/main \
+  refs/tags/pre-rewrite-snapshot:refs/tags/pre-rewrite-snapshot \
+  refs/tags/pr111-contaminated-snapshot:refs/tags/pr111-contaminated-snapshot
+```
+
+`0a9f8446…` was the pre-push `origin/main` tip; `b6c60050…` was the
+local HEAD; if any other actor had pushed to `main` after we sampled
+the tip, the lease would have fired and the push would abort with
+`stale info` instead of discarding their commit.
+
+### 2.2 Frozen-tag trip-wire refspec
+
+The force-push refspec list MUST push the frozen tags
+(`pre-rewrite-snapshot`, and any companion `*-contaminated-snapshot`
+tags) in **non-force form** (no leading `+`):
+
+```
+refs/tags/pre-rewrite-snapshot:refs/tags/pre-rewrite-snapshot
+refs/tags/pr111-contaminated-snapshot:refs/tags/pr111-contaminated-snapshot
+```
+
+Git refuses a non-force tag update when the local and remote tag
+objects disagree. Therefore:
+
+- If γ accidentally mutated a frozen tag locally, the trip-wire fires
+  with `rejected (would clobber existing tag)` and the whole push
+  aborts.
+- If the frozen tag is byte-identical locally and remotely (the
+  required invariant), the non-force update is a no-op.
+
+This turns the "frozen-tag invariant" into a runtime assertion rather
+than a review-time convention.
+
+### 2.3 Six-step post-authorisation ordering
+
+After Adrian's explicit authorisation, the push proceeds in this exact
+order. Steps MUST be contiguous within one shell session; intermediate
+state must not be shared or logged until Step 5 succeeds.
+
+1. `git fetch origin` — refresh local refs/remotes/origin.
+2. Capture `LEASE_SHA=$(git rev-parse origin/main)` — sample the
+   pre-push tip once and reuse.
+3. Compose the push command with explicit
+   `--force-with-lease=refs/heads/main:$LEASE_SHA` and the trip-wire
+   refspecs of §2.2.
+4. Execute the push.
+5. Readback verification (§2.4) — write the push-complete audit
+   artefact under `docs/audit/gamma/gamma-1-push-complete-<ts>.txt`.
+6. ABORT handling (§2.5) — reserved for any failure in Steps 1–5.
+
+### 2.4 Readback verification (discipline, 8 items)
+
+Post-push readback is the only evidence that the published origin
+state matches the intended rewritten history. Every ε-phase readback
+broadcast MUST satisfy the 8-item discipline below. Items 1–3 are the
+Probe verifier-role core. Items 4–7 are evidence-completeness
+discipline (Challenger). Item 8 is cross-vantage discipline added in
+response to an endpoint-mismatch incident during this very phase.
+
+1. **Lease pre-image binding.** The push command logged in the
+   artefact MUST show the explicit `--force-with-lease=<ref>:<40-hex>`
+   form and the SHA MUST match `LEASE_SHA` from Step 2.
+2. **Post-push readback byte-exact.** `git ls-remote origin` output
+   MUST be included verbatim; `origin/main` MUST equal the local HEAD
+   that was pushed.
+3. **Trip-wire frozen-tag invariant.** The `git ls-remote` section
+   MUST show the frozen-tag objects unchanged from the pre-γ state
+   (gamma-post-audit-spec §2 "out of scope: `pre-rewrite-snapshot`
+   frozen").
+4. **Endpoint declaration mandatory.** Every readback broadcast MUST
+   write the exact `gh api <endpoint>` (or `git ls-remote <remote>`)
+   invocation that produced the evidence. Broadcasts citing
+   readback-derived facts without declaring the endpoint are INVALID.
+5. **Evidence completeness.** Any assertion MUST be accompanied by
+   the complete raw output from the declared endpoint in the same
+   broadcast. Summary-only assertions are INVALID.
+6. **Endpoint-granularity trust boundary.** Assertions that span
+   multiple endpoints (e.g. ruleset schema + branch protection +
+   ls-remote) MUST attach the complete raw output from each endpoint.
+   No endpoint may be implied from another.
+7. **Evidence-endpoint mismatch → readback INVALID.** If the attached
+   raw output is from a different endpoint than the one that would
+   have produced the asserted fact, the readback does not count
+   toward CONCUR. This is not a BLOCK; it is a null signal that
+   requires resupply.
+8. **Cross-confirm claim endpoint-matched.** When one agent claims
+   byte-exact match with another agent's readback, the two raw
+   outputs MUST be from the same endpoint. If a peer supplies raw
+   from a different endpoint, the receiving agent MUST explicitly
+   report "endpoint mismatch, cross-confirm not established" and
+   wait for same-endpoint raw before declaring match.
+
+#### Case study — negative: endpoint-mismatch cross-confirm
+
+During this phase's ruleset verification (2026-04-20), Probe declared
+`byte-exact match` between its own `gh api …/rulesets/15291514`
+readback and an earlier agent's `gh api …/rules/branches/main`
+readback. The two endpoints return overlapping but not identical
+schemas — the branches endpoint omits `bypass_actors` entirely. The
+declared match was therefore imprecise: byte-exact on a subset of
+fields, silently absent on the most-relevant field. Item 8 was added
+to the discipline because this failure mode cannot be caught by
+items 1–7 (each of the first 7 agent broadcasts was internally
+consistent).
+
+#### Case study — positive: reflexive self-catch
+
+The same verifier agent subsequently applied the readback-discipline
+to its own prior claim and reported the imprecision without being
+prompted by a peer BLOCK. This is the expected verifier-role
+behaviour: the discipline exists so that cross-vantage trust-boundary
+failures are caught by the verifier itself, not only by adversarial
+review. Recording both case studies in this ADR prevents the negative
+precedent from being read as acceptable and keeps the positive
+pattern (self-application) as the baseline expectation.
+
+### 2.5 ε-ABORT rollback
+
+If Steps 1–5 detect any divergence (lease fired, frozen-tag trip-wire
+fired, post-push ls-remote disagrees with local HEAD), the rollback
+command restores `origin/main` to the pre-γ tip via the frozen tag:
+
+```
+git push \
+  --force-with-lease=refs/heads/main:<current_origin_main_SHA> \
+  origin \
+  refs/tags/pre-rewrite-snapshot^{}:refs/heads/main
+```
+
+Rollback binds its own lease to the current `origin/main` so a
+concurrent push between the abort decision and the rollback push
+does not get clobbered. Failure to rollback automatically is
+intentional: ε-ABORT hands off to Adrian with the failing artefact
+under `docs/audit/gamma/` (same failure-handling path as
+gamma-post-audit-spec §5).
+
+### 2.6 POST_HEAD publish invariant
+
+After Step 5 succeeds, the authoritative `origin/main` SHA is
+published in the push-complete artefact and referenced by subsequent
+workflows (θ cleanup, ζ.1 CI re-run, Phase 2b resumption). The
+artefact is the single source of truth for "what γ published";
+downstream consumers MUST NOT reconstruct the SHA from local state.
+
+## 3. Already-accepted constraints (§ accepted-constraint)
+
+These are not decisions made by this ADR; they are pre-existing
+platform or environment constraints that the ε-phase choreography
+inherits. Documenting them prevents future confusion about why the
+bypass configuration looks the way it does.
+
+### 3.1 GitHub personal-repo User-bypass does not execute
+
+On personal repositories (as opposed to organisation-owned
+repositories), GitHub stores `bypass_actors` entries with
+`actor_type=="User"` but does not execute them: the account named in
+the User entry continues to be blocked by the ruleset. Empirical
+observation (2026-04-20): on `adrian-mason/wperf`, setting
+`bypass_actors=[{"actor_type":"User","actor_id":258563901}]` yields
+`current_user_can_bypass=="never"` when the account
+`adrian-mason` (id 258563901) reads back. Setting
+`bypass_actors=[{"actor_type":"RepositoryRole","actor_id":5}]`
+(RepositoryRole=admin) yields `current_user_can_bypass=="always"`.
+The final ruleset therefore uses RepositoryRole-only bypass. This is
+accepted rather than worked around because the only alternative on a
+personal repo is to accept non-executing User entries as "intent of
+record", which misleads future readers.
+
+### 3.2 Behavioural-test vantage constraint (Probe)
+
+Probe authenticates as `adrian-mason`, which is the bypass-actor on
+`adrian-mason/wperf`. Probe can therefore verify ruleset configuration
+(readback schema) but cannot empirically prove that a non-bypass actor
+is rejected by the ruleset — Probe lacks a non-bypass vantage. Gate-A
+(non-bypass direct-push rejected) and Gate-B (force-push rejected)
+are therefore reported as **config-level PASS** by Probe: the ruleset
+contains `pull_request` and `non_fast_forward` rules with
+`enforcement=active`, and GitHub platform-level implementation of
+ruleset semantics is taken as an axiom. Gate-C is PASS-trivially
+(`required_approving_review_count=0`). Empirical behavioural
+verification from a non-bypass vantage is out of scope for this phase
+(would require either a non-admin collaborator or Adrian
+authenticating through a non-bypass token path, neither of which is
+warranted by the risk profile).
+
+## 4. Admin-new-collaborator review protocol
+
+### 4.1 Why the protocol exists
+
+§3.1's accepted constraint has a latent consequence: because bypass is
+attached to the `RepositoryRole=admin` role (not to a specific User),
+any future admin collaborator on `adrian-mason/wperf` automatically
+gains bypass of main-protection. Adrian's option-C intent (chat
+msg=67295c3c) is that only Adrian bypasses. A silent new-admin
+auto-bypass violates that intent; the protocol below is the
+compensating control.
+
+### 4.2 Protocol
+
+Before any admin collaborator is added to `adrian-mason/wperf` (or any
+other repository whose main-protection ruleset uses RepositoryRole
+bypass_actors):
+
+1. Read the current ruleset:
+   `gh api repos/adrian-mason/wperf/rulesets/15291514`.
+2. Confirm the current `bypass_actors` scheme (RepositoryRole=admin,
+   `bypass_mode=always`).
+3. Decide whether the new admin is intended to bypass main-protection.
+   - **Yes**: proceed to grant admin.
+   - **No**: first switch the ruleset to a User-specific allow-list
+     that excludes them. Then verify, from their vantage, that
+     `current_user_can_bypass == "never"`. Then grant admin.
+4. Record the decision (ADR amendment or audit note) so the
+   non-default choice is legible to future readers.
+
+The protocol is cross-referenced by the Maestro-side saved-memory
+feedback (`feedback_bypass_actor_governance.md`) so the review
+trigger does not depend on anyone remembering to re-read this ADR.
+
+### 4.3 bypass-actor set definition
+
+The bypass-actor set is the **dynamic** set `{admin-role holders on the
+repository at the time of a push}`, not the fixed set `{adrian-mason}`.
+Any assertion in this ADR, audit artefacts, or reviewer broadcasts
+that references "Adrian's bypass" is shorthand for "the admin-role
+holder, who today is Adrian". The review protocol in §4.2 is the
+mechanism that keeps the dynamic and intended sets aligned.
+
+## 5. Authority and process
+
+This ADR is authored and reviewed in a five-agent fold:
+
+- **Maestro**: primary author; owns draft, commit, PR.
+- **Critic**: spec-compliance review; applies the standard Critic
+  checklist and the 8-item readback-verification discipline of §2.4.
+- **Challenger**: adversarial review; exercises the five adversarial
+  scopes (lease pre-image bypass vector, frozen-tag trip-wire
+  robustness, POST_HEAD publish invariant, ε-ABORT rollback edge
+  cases, cross-vantage-verification trust boundary).
+- **Oracle**: spec-arbitration sign-off; cross-ADR architectural
+  consistency (notably with ADR-016 and gamma-post-audit-spec).
+- **Probe**: verifier-role augmentation; not a spec-review seat, but
+  pre-merge Probe-verifier PASS is a merge gate. Scope is the four
+  verifier dimensions (lease pre-image binding, readback match,
+  trip-wire invariant, bypass-actor dynamic-set semantics) plus the
+  8-item readback discipline of §2.4.
+
+## 6. Relationship to other specs and ADRs
+
+- Fulfils `docs/decisions/gamma-post-audit-spec.md` §6 "ε-phase push
+  --force-with-lease choreography — tracked separately" commitment.
+- The γ→ε push of 2026-04-20 (artefact
+  `docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt`) was
+  executed under the discipline codified here; the artefact is the
+  first reference implementation of §2.1–2.6.
+- ADR-016 remains the authoritative invariant set; nothing in this
+  ADR changes invariant semantics.
+
+## 7. Out of scope
+
+- θ-phase history-authorship backfill choreography (separate ADR if
+  needed).
+- ζ.1 CI re-run procedure (operational, not spec).
+- General branch-protection configuration beyond the ε-phase push
+  lifecycle.

--- a/docs/decisions/ADR-017.md
+++ b/docs/decisions/ADR-017.md
@@ -164,8 +164,33 @@ pattern (self-application) as the baseline expectation.
 ### 2.5 ε-ABORT rollback
 
 If Steps 1–5 detect any divergence (lease fired, frozen-tag trip-wire
-fired, post-push ls-remote disagrees with local HEAD), the rollback
-command restores `origin/main` to the pre-γ tip via the frozen tag:
+fired, post-push ls-remote disagrees with local HEAD), rollback
+proceeds in two steps. Step 2.5.a is a mandatory precondition: the
+frozen-tag trip-wire fires precisely when the LOCAL and REMOTE
+`pre-rewrite-snapshot` tags disagree, so dereferencing the LOCAL tag
+in the rollback push without a refresh would — in the case where
+LOCAL is the mutated side — publish the mutated SHA back to
+`origin/main`.
+
+**Step 2.5.a — frozen-tag refresh and audit-artefact cross-check**:
+
+```
+git fetch --force origin \
+  refs/tags/pre-rewrite-snapshot:refs/tags/pre-rewrite-snapshot
+LOCAL_FROZEN_SHA=$(git rev-parse refs/tags/pre-rewrite-snapshot^{})
+# Operator MUST confirm LOCAL_FROZEN_SHA matches the pre-γ tip
+# recorded in the push-complete audit artefact (§2.6 POST_HEAD —
+# docs/audit/gamma/gamma-<phase>-push-complete-*.txt) before
+# proceeding to Step 2.5.b.
+```
+
+If origin's `pre-rewrite-snapshot` has itself been rewritten (would
+require a push by an account holding the admin-role bypass —
+outside the §3.2 vantage trust model), the audit-artefact
+cross-check catches the discrepancy and the operator hands off to
+Adrian without rolling back.
+
+**Step 2.5.b — rollback push**:
 
 ```
 git push \

--- a/docs/decisions/ADR-017.md
+++ b/docs/decisions/ADR-017.md
@@ -191,14 +191,22 @@ recovery performed only after peer BLOCK.
 
 ### 2.5 ε-ABORT rollback
 
-If Steps 1–5 detect any divergence (lease fired, frozen-tag trip-wire
-fired, post-push ls-remote disagrees with local HEAD), rollback
-proceeds in two steps. Step 2.5.a is a mandatory precondition: the
-frozen-tag trip-wire fires precisely when the LOCAL and REMOTE
-`pre-rewrite-snapshot` tags disagree, so dereferencing the LOCAL tag
-in the rollback push without a refresh would — in the case where
-LOCAL is the mutated side — publish the mutated SHA back to
-`origin/main`.
+Rollback is triggered only by Step 5 readback divergence — the push
+at Step 4 succeeded but the post-push `ls-remote` disagrees with the
+expected `origin/main` SHA. Step 4 rejection signals (lease fired or
+frozen-tag trip-wire fired) mean the push was refused atomically and
+the remote is unchanged; no rollback is needed, and issuing the
+rollback push in that case would itself be a fresh force-push that
+could clobber a legitimate concurrent update — the very lost-update
+race this ADR prevents. On Step 4 rejection the operator diagnoses
+the race via `ls-remote` and, if the γ rewrite is still appropriate,
+restarts the choreography from Step 1 with a refreshed lease.
+
+When rollback does proceed it has two steps. Step 2.5.a is a
+mandatory precondition: LOCAL `refs/tags/pre-rewrite-snapshot` may
+have been mutated, so dereferencing the LOCAL tag in the rollback
+push without refreshing from origin would — in the case where LOCAL
+is the mutated side — publish the mutated SHA back to `origin/main`.
 
 **Step 2.5.a — fetch origin's frozen-tag to FETCH_HEAD + audit-artefact cross-check**:
 


### PR DESCRIPTION
## Summary

- ADR-017: codifies the ε-phase `push --force-with-lease` choreography — lease pre-image binding, frozen-tag trip-wire refspec, six-step post-authorisation ordering, 8-item readback-verification discipline, ε-ABORT rollback, POST_HEAD publish invariant.
- Two mandatory sections per Oracle ruling (msg=be2f1cd9): §"accepted-constraint" (GitHub personal-repo User-bypass inert + Probe behavioural-test vantage constraint) + §"admin-new-collaborator review protocol".
- Includes the γ→ε push artefact (`docs/audit/gamma/gamma-1-push-complete-20260420T073328Z.txt`) as the first reference implementation of §2.1–2.6.
- Dynamic bypass-actor-set semantics: `{admin-role holders}`, not fixed `{adrian-mason}`.

Closes #118

## Review fold

- Maestro (primary author)
- Critic: spec-compliance review checklist + 8-item readback discipline
- Challenger: adversarial review (lease pre-image bypass vector, trip-wire robustness, POST_HEAD invariant, ε-ABORT edge cases, cross-vantage trust boundary)
- Oracle: spec-arbitration sign-off (cross-ADR consistency with ADR-016 + gamma-post-audit-spec)
- Probe: verifier-role pre-merge PASS (lease pre-image binding, readback match, trip-wire invariant, bypass-actor dynamic-set semantics)

## Case studies

§2.4 includes paired case studies from this very phase:
- **Negative** (endpoint-mismatch cross-confirm): verifier claimed byte-exact match between `/rulesets/15291514` and `/rules/branches/main` endpoints; imprecision on `bypass_actors`.
- **Positive** (reflexive self-catch): the same verifier applied the readback-discipline to its own prior claim without peer BLOCK.

## Test plan

- [ ] CI green on this branch (format/lint/build)
- [ ] Critic spec-compliance review complete
- [ ] Challenger adversarial review complete
- [ ] Oracle spec-arbitration sign-off
- [ ] Probe verifier-role pre-merge PASS
- [ ] Gemini review (@gemini-code-assist)
- [ ] Adrian approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)