### PR TITLE
P2b-01: block_rq tracepoints + IO synth-edge scaffolding (WIP, commits 1-3 of 6)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -18,6 +18,19 @@ exclude_re = [
     "probe_bpf_loop",
     "probe_tp_btf",
     "probe_fentry",
+    # Phase 2b #38 P2b-01 (commit-2): block_rq BTF arity probe + helpers.
+    # All cfg(feature = "bpf")-gated, require BTF + libbpf to exercise.
+    "probe_block_rq_issue_single_arg",
+    "btf_typedef_func_proto_vlen",
+    "btf_kind",
+    "btf_vlen",
+    "kernel_version_ge",
+    "BtfGuard",
+    # Equivalent mutant: `|` vs `^` are indistinguishable when operands
+    # occupy disjoint bit regions. WperfEvent::io_sector packs prev_tid
+    # (lower 32 bits) with next_tid << 32 (upper 32 bits) — by construction
+    # the bit regions never overlap, so `|` → `^` has no observable effect.
+    "WperfEvent::io_sector",
     "record_impl",
     "poll_ringbuf",
     "poll_perfarray",

--- a/docs/audit/p2b-01/btf-matrix-5.4-5.8-6.18.md
+++ b/docs/audit/p2b-01/btf-matrix-5.4-5.8-6.18.md
@@ -1,0 +1,100 @@
+# P2b-01 BTF matrix — kernel 5.4 / 5.8 / 6.18 datapoints
+
+**Captured:** 2026-04-21 (Maestro)
+**Sources:**
+- 6.18 — local `/sys/kernel/btf/vmlinux` (`6.18.22-1-lts`)
+- 5.4  — btfhub-archive `ubuntu/20.04/x86_64/5.4.0-91-generic.btf`
+- 5.8  — btfhub-archive `ubuntu/20.04/x86_64/5.8.0-33-generic.btf`
+**Tool:** `bpftool btf dump file <path> format raw`
+
+## Tracepoint handler BTF shape
+
+### `btf_trace_block_rq_issue`
+
+```
+[27601] TYPEDEF 'btf_trace_block_rq_issue' type_id=13837
+[13837] PTR '(anon)' type_id=13836
+[13836] FUNC_PROTO '(anon)' ret_type_id=0 vlen=2
+        '(anon)' type_id=109   -> void *  (__data)
+        '(anon)' type_id=2610  -> struct request *
+```
+
+**ABI:** `void handler(void *__data, struct request *rq)` — **post-5.11 form** (no `struct request_queue *q`).
+
+### `btf_trace_block_rq_complete`
+
+```
+[27595] TYPEDEF 'btf_trace_block_rq_complete' type_id=13839
+[13839] PTR '(anon)' type_id=13838
+[13838] FUNC_PROTO '(anon)' ret_type_id=0 vlen=4
+        '(anon)' type_id=109   -> void *  (__data)
+        '(anon)' type_id=2610  -> struct request *
+        '(anon)' type_id=2058  -> blk_status_t  (error)
+        '(anon)' type_id=9     -> unsigned int  (nr_bytes)
+```
+
+**ABI:** `void handler(void *__data, struct request *rq, blk_status_t error, unsigned int nr_bytes)` — 4-arg, stable across the post-5.11 range.
+
+## Kernel 5.8 — `btf_trace_block_rq_issue` present, 3-arg ABI
+
+```
+[54659] TYPEDEF 'btf_trace_block_rq_issue' type_id=26557
+[26557] PTR '(anon)' type_id=26556
+[26556] FUNC_PROTO '(anon)' ret_type_id=0 vlen=3
+        '(anon)' type_id=93    -> void *             (__data)
+        '(anon)' type_id=925   -> struct request_queue *  (q)
+        '(anon)' type_id=2592  -> struct request *
+
+[54655] TYPEDEF 'btf_trace_block_rq_complete' type_id=26559
+[26559] PTR '(anon)' type_id=26558
+[26558] FUNC_PROTO '(anon)' ret_type_id=0 vlen=4
+        '(anon)' type_id=93    -> void *             (__data)
+        '(anon)' type_id=2592  -> struct request *   (rq)
+        '(anon)' type_id=21    -> int                (error)
+        '(anon)' type_id=9     -> unsigned int       (nr_bytes)
+```
+
+**ABI:** `void handler(void *__data, struct request_queue *q, struct request *rq)` for issue — **pre-fork form with `q` as 2nd arg**.
+Complete handler is 4-arg, same shape as 6.18.
+
+`btf_trace_block_rq_insert` and `btf_trace_block_rq_requeue` share the same `type_id=26557` → same 3-arg proto.
+
+## Kernel 5.4 — `btf_trace_block_rq_issue` ABSENT
+
+```
+$ bpftool btf dump file 5.4.0-91-generic.btf format raw | grep btf_trace_block_rq
+(no output — no btf_trace_block_rq_* typedefs exist in 5.4 vmlinux BTF)
+```
+
+5.4 vmlinux BTF contains `trace_event_raw_block_rq_*` structs and `__bpf_trace_block_rq_*` functions (the legacy perf-event tracepoint path) but **no `btf_trace_*` typedefs**. These typedefs were added mainline in the same series as tp_btf program support (landed ~5.5, generalized ~5.8).
+
+**Implication:** tp_btf programs targeting `block_rq_issue` / `block_rq_complete` / `block_rq_insert` **cannot load on 5.4 at all** — the verifier fails type resolution before ever reaching the handler body.
+
+## Kernel matrix summary
+
+| Kernel | `btf_trace_block_rq_issue` | issue ABI | complete ABI | tp_btf viable? |
+|--------|----------------------------|-----------|--------------|----------------|
+| 5.4.0-91-generic  | **absent**               | N/A       | N/A          | **NO**         |
+| 5.8.0-33-generic  | present                  | 3-arg (`__data, q, rq`) | 4-arg | yes (pre-fork) |
+| 6.18.22-1-lts     | present                  | 2-arg (`__data, rq`)    | 4-arg | yes (post-fork) |
+
+Two independent compatibility axes, not one:
+1. **tp_btf presence** — 5.4 fails before ABI even matters.
+2. **issue handler arg shape** — 3-arg (pre-5.11 / pre-5.10.137 stable) vs 2-arg (post-patch). BCC `biosnoop.bpf.c` handles this with `LINUX_KERNEL_VERSION` + `ctx[0]` / `ctx[1]` indexing inside a single `tp_btf/block_rq_issue` program.
+
+## Implementation-path options for commit-2
+
+| Option | 5.4 ok? | 5.8–5.10 ok? | 5.11+ ok? | Programs | Complexity |
+|--------|---------|--------------|-----------|----------|------------|
+| A. classic `tracepoint/block/block_rq_issue` (format-file) | YES | YES | YES | 6 | low — ABI-stable across all kernels, reads fields via `bpf_probe_read_kernel` or format-offsets |
+| B. tp_btf 2a+2b split (pre/post-fork) | NO | YES (2a) | YES (2b) | 8 | medium — but drops 5.4 |
+| C. tp_btf single-program + `ctx[0]` / `ctx[1]` runtime branch | NO | YES | YES | 6 | medium — drops 5.4, but single code path |
+
+**Recommendation:** option A (classic tracepoint) if 5.4 support is a requirement.
+`get_disk()` CO-RE helper (just vendored into `src/bpf/core_fixes.bpf.h`) works transparently under both classic and tp_btf attach styles, so the rq_disk/q→disk rename is independently handled regardless of option.
+
+## Next
+
+- Decide on option A / B / C based on 5.4 support requirement.
+- If option A: commit-2 stays single path, no 2a/2b split. 7-gate self-checklist proceeds as planned.
+- If dropping 5.4: pick B or C based on whether the simpler-single-program (C) or stricter-typed-signature (B) reads better.

--- a/scripts/sync-libbpf-compat.sh
+++ b/scripts/sync-libbpf-compat.sh
@@ -3,14 +3,27 @@
 #
 # This script documents the provenance of vendored BPF headers:
 #   - src/bpf/compat.bpf.h  (reserve_buf/submit_buf transport abstraction)
-#   - src/bpf/core_fixes.bpf.h (CO-RE field rename fixes, e.g. state/__state)
+#   - src/bpf/core_fixes.bpf.h (CO-RE field rename fixes)
+#
+# Vendored allowlist for core_fixes.bpf.h (subset of upstream — keep in sync
+# with the "Vendored sections" comment in src/bpf/core_fixes.bpf.h):
+#   - task_struct state/__state rename          (sched path)
+#   - bio bi_disk/bi_bdev + get_gendisk()        (block layer, bio side)
+#   - trace_event_raw_block_rq_complete[ion]    (block_rq_error struct rename)
+#   - request rq_disk + request_queue->disk
+#     + get_disk()                               (block layer, rq side — needed
+#                                                 by Phase 2b #38 P2b-01)
+# Upstream helpers NOT vendored: renamedata, kmem_alloc/free, inet_sock
+# bitfields, cfs_rq nr_running. Add here + in core_fixes.bpf.h if/when used.
 #
 # Fetches directly from iovisor/bcc GitHub repo (no local clone needed).
 # By default, fetches at the pinned upstream commits recorded in the vendored
 # file headers. Pass --ref <sha-or-branch> to compare against a different ref.
 #
 # Vendored files are NOT verbatim copies — they are adapted for wPerf.
-# When updating, diff the upstream changes and manually apply relevant fixes.
+# When updating, diff the upstream changes and manually apply relevant fixes
+# that fall within the allowlist above. Expansions to the allowlist require
+# updating both this script's doc comment and core_fixes.bpf.h's header.
 #
 # Usage: ./scripts/sync-libbpf-compat.sh [--ref <sha-or-branch>]
 #   Default: fetches at the pinned upstream commits from vendored file headers

--- a/src/bpf/core_fixes.bpf.h
+++ b/src/bpf/core_fixes.bpf.h
@@ -5,8 +5,15 @@
  * Upstream commit: 82ad428c40cb270fda6c0de5a9914705c94dd4c7
  * Source: https://github.com/iovisor/bcc/blob/master/libbpf-tools/core_fixes.bpf.h
  *
- * Only the task_struct state/\__state rename fix is included here.
- * Other CO-RE fixes from upstream are not needed by wPerf.
+ * Vendored sections (allowlist — keep in sync with scripts/sync-libbpf-compat.sh):
+ *   - task_struct state/\__state rename fix (used by src/bpf/wperf.bpf.c sched path)
+ *   - bio \__o/\__x + get_gendisk()           — bio → gendisk CO-RE helper
+ *   - trace_event_raw_block_rq_complete[ion]  — handler-struct rename detector
+ *   - request \__x + request_queue \__x + get_disk() — rq → gendisk CO-RE helper
+ *     (rq_disk removal — commit f3fa33acca9f; needed by Phase 2b issue #38 P2b-01)
+ *
+ * Other CO-RE fixes from upstream (renamedata, kmem, inet_sock, cfs_rq) are not
+ * used by wPerf and intentionally omitted.
  *
  * To update, run: scripts/sync-libbpf-compat.sh
  */
@@ -38,6 +45,85 @@ static __always_inline __s64 get_task_state(void *task)
 	if (bpf_core_field_exists(t->__state))
 		return BPF_CORE_READ(t, __state);
 	return BPF_CORE_READ((struct task_struct___o *)task, state);
+}
+
+/**
+ * commit 309dca309fc3 ("block: store a block_device pointer in struct bio")
+ * adds a new member bi_bdev which is a pointer to struct block_device
+ * see:
+ *     https://github.com/torvalds/linux/commit/309dca309fc3
+ */
+struct bio___o {
+	struct gendisk *bi_disk;
+} __attribute__((preserve_access_index));
+
+struct bio___x {
+	struct block_device *bi_bdev;
+} __attribute__((preserve_access_index));
+
+static __always_inline struct gendisk *get_gendisk(void *bio)
+{
+	struct bio___x *b = bio;
+
+	if (bpf_core_field_exists(b->bi_bdev))
+		return BPF_CORE_READ(b, bi_bdev, bd_disk);
+	return BPF_CORE_READ((struct bio___o *)bio, bi_disk);
+}
+
+/**
+ * commit d5869fdc189f ("block: introduce block_rq_error tracepoint")
+ * adds a new tracepoint block_rq_error and it shares the same arguments
+ * with tracepoint block_rq_complete. As a result, the kernel BTF now has
+ * a `struct trace_event_raw_block_rq_completion` instead of
+ * `struct trace_event_raw_block_rq_complete`.
+ * see:
+ *     https://github.com/torvalds/linux/commit/d5869fdc189f
+ */
+struct trace_event_raw_block_rq_complete___x {
+	dev_t dev;
+	sector_t sector;
+	unsigned int nr_sector;
+} __attribute__((preserve_access_index));
+
+struct trace_event_raw_block_rq_completion___x {
+	dev_t dev;
+	sector_t sector;
+	unsigned int nr_sector;
+} __attribute__((preserve_access_index));
+
+static __always_inline bool has_block_rq_completion()
+{
+	if (bpf_core_type_exists(struct trace_event_raw_block_rq_completion___x))
+		return true;
+	return false;
+}
+
+/**
+ * commit d152c682f03c ("block: add an explicit ->disk backpointer to the
+ * request_queue") and commit f3fa33acca9f ("block: remove the ->rq_disk
+ * field in struct request") make some changes to `struct request` and
+ * `struct request_queue`. Now, to get the `struct gendisk *` field in a CO-RE
+ * way, we need both `struct request` and `struct request_queue`.
+ * see:
+ *     https://github.com/torvalds/linux/commit/d152c682f03c
+ *     https://github.com/torvalds/linux/commit/f3fa33acca9f
+ */
+struct request_queue___x {
+	struct gendisk *disk;
+} __attribute__((preserve_access_index));
+
+struct request___x {
+	struct request_queue___x *q;
+	struct gendisk *rq_disk;
+} __attribute__((preserve_access_index));
+
+static __always_inline struct gendisk *get_disk(void *request)
+{
+	struct request___x *r = request;
+
+	if (bpf_core_field_exists(r->rq_disk))
+		return BPF_CORE_READ(r, rq_disk);
+	return BPF_CORE_READ(r, q, disk);
 }
 
 #endif /* __CORE_FIXES_BPF_H */

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -322,12 +322,27 @@ int handle_sys_enter_futex(struct trace_event_raw_sys_enter *ctx)
 #define PF_KTHREAD 0x00200000
 #endif
 
+/* Per-CPU counters exposed via the io_counters map. Userspace reads these
+ * for HealthMetrics (#38 commit-5) and observability.
+ *
+ *   KTHREAD_SKIP          — issue from a kernel thread (filtered, not an error)
+ *   PENDING_DROP          — pending_io map insert failed (map full → forward
+ *                           progress lost, will orphan the matching complete)
+ *   ORPHAN_COMPLETE       — complete with no matching pending_io entry
+ *                           (issue was dropped or predates attach)
+ *   COMPLETION_LOCALITY   — completion ran OUTSIDE the submitter's task context
+ *     (renamed from `SUBMITTER_MISS` per Gemini PR #120 review: the original
+ *     name read as "error", but under async I/O this fires on nearly every
+ *     completion because completions run in softirq/IRQ context — not the
+ *     submitter's task. It's a locality metric, not an error signal.
+ *     High fraction = mostly-async workload; low fraction = mostly-sync.)
+ */
 enum wperf_io_counter {
-	IO_CNT_KTHREAD_SKIP     = 0,
-	IO_CNT_PENDING_DROP     = 1,
-	IO_CNT_ORPHAN_COMPLETE  = 2,
-	IO_CNT_SUBMITTER_MISS   = 3,
-	IO_CNT_MAX              = 4,
+	IO_CNT_KTHREAD_SKIP        = 0,
+	IO_CNT_PENDING_DROP        = 1,
+	IO_CNT_ORPHAN_COMPLETE     = 2,
+	IO_CNT_COMPLETION_LOCALITY = 3,
+	IO_CNT_MAX                 = 4,
 };
 
 struct {
@@ -434,9 +449,12 @@ static __always_inline int handle_block_rq_complete(void *ctx, struct request *r
 		return 0;
 	}
 
+	/* Locality metric — for async I/O this fires ~always (completion runs
+	 * in softirq/IRQ, not the submitter's task); for sync/polled I/O it
+	 * rarely fires. Not an error signal. See enum wperf_io_counter docs. */
 	__u64 cur_pid_tgid = bpf_get_current_pid_tgid();
 	if ((__u32)cur_pid_tgid != val->submitter_tid)
-		io_counter_inc(IO_CNT_SUBMITTER_MISS);
+		io_counter_inc(IO_CNT_COMPLETION_LOCALITY);
 
 	struct wperf_event *e = reserve_buf(sizeof(*e));
 	if (!e) {

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -294,4 +294,204 @@ int handle_sys_enter_futex(struct trace_event_raw_sys_enter *ctx)
 	return 0;
 }
 
+/* --------------------------------------------------------------------------
+ * Block IO tracepoints (Phase 2b #38 P2b-01)
+ *
+ * Emit User→PseudoDisk (issue) + PseudoDisk→User (complete) synthetic edges
+ * via tp_btf/raw_tp dual-attach (bcc biolatency pattern). Both variants
+ * share handlers; autoload is gated by probe_tp_btf() result in record.rs.
+ *
+ * Kernel ABI history:
+ *   - 5.4  : btf_trace_block_rq_issue ABSENT → raw_tp fallback only
+ *   - 5.8  : btf_trace_block_rq_issue present, args = (__data, q, rq)
+ *   - 5.11 : commit a54895fa dropped q → args = (__data, rq) [single-arg form]
+ *   - 5.17 : rq_disk removed (f3fa33acca9f) → use q->disk (core_fixes get_disk)
+ *
+ * block_rq_complete signature stable across 5.8+: (__data, rq, error, nr_bytes).
+ *
+ * rodata targ_single: set by user-space from btf_vlen probe; selects ctx
+ * slot holding `rq`. Single-arg (5.11+): ctx[0]. Dual-arg (pre-5.11): ctx[1].
+ *
+ * Attribution: submitter tgid/tid is captured at issue time (task context)
+ * and replayed at complete time (softirq/IRQ context). Per ADR-009
+ * / Challenger C11: edges attach to the submitting user task, not to the
+ * interrupted task at completion.
+ * -------------------------------------------------------------------------- */
+
+#ifndef PF_KTHREAD
+#define PF_KTHREAD 0x00200000
+#endif
+
+enum wperf_io_counter {
+	IO_CNT_KTHREAD_SKIP     = 0,
+	IO_CNT_PENDING_DROP     = 1,
+	IO_CNT_ORPHAN_COMPLETE  = 2,
+	IO_CNT_SUBMITTER_MISS   = 3,
+	IO_CNT_MAX              = 4,
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, IO_CNT_MAX);
+	__type(key, __u32);
+	__type(value, __u64);
+} io_counters SEC(".maps");
+
+struct pending_io_val {
+	__u32 submitter_tgid;
+	__u32 submitter_tid;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 16384);
+	__type(key, __u64);
+	__type(value, struct pending_io_val);
+} pending_io SEC(".maps");
+
+/* Set by user-space from btf_vlen("btf_trace_block_rq_issue"): true when
+ * kernel has the post-5.11 single-arg form (rq at ctx[0]). Default true is
+ * harmless for raw_tp path — raw_tp block_rq_issue ABI is (q, rq) pre-5.11
+ * and (rq) post-5.11; only kernels ≥5.11 expose tp_btf here. */
+const volatile bool targ_single = true;
+
+static __always_inline void io_counter_inc(__u32 slot)
+{
+	__u64 *v = bpf_map_lookup_elem(&io_counters, &slot);
+	if (v)
+		__sync_fetch_and_add(v, 1);
+}
+
+static __always_inline bool is_kthread(struct task_struct *t)
+{
+	return (BPF_CORE_READ(t, flags) & PF_KTHREAD) != 0;
+}
+
+static __always_inline __u32 rq_dev(struct request *rq)
+{
+	struct gendisk *disk = get_disk(rq);
+	if (!disk)
+		return 0;
+	__u32 major = BPF_CORE_READ(disk, major);
+	__u32 first_minor = BPF_CORE_READ(disk, first_minor);
+	return (major << 20) | first_minor;
+}
+
+static __always_inline int handle_block_rq_issue(void *ctx, struct request *rq)
+{
+	struct task_struct *cur = (struct task_struct *)bpf_get_current_task();
+	struct wperf_event *e;
+
+	if (is_kthread(cur)) {
+		io_counter_inc(IO_CNT_KTHREAD_SKIP);
+		return 0;
+	}
+
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tgid = (__u32)(pid_tgid >> 32);
+	__u32 tid  = (__u32)pid_tgid;
+
+	if (self_tgid && tgid == self_tgid)
+		return 0;
+
+	__u64 key = (__u64)(unsigned long)rq;
+	struct pending_io_val val = {
+		.submitter_tgid = tgid,
+		.submitter_tid  = tid,
+	};
+	if (bpf_map_update_elem(&pending_io, &key, &val, BPF_ANY) != 0) {
+		io_counter_inc(IO_CNT_PENDING_DROP);
+		return 0;
+	}
+
+	e = reserve_buf(sizeof(*e));
+	if (!e)
+		return 0;
+
+	fill_timestamp_and_cpu(e);
+	e->event_type = WPERF_EVENT_IO_ISSUE;
+	e->pid = tgid;
+	e->tid = tid;
+
+	__u64 sector = BPF_CORE_READ(rq, __sector);
+	e->prev_tid = (__u32)sector;
+	e->next_tid = (__u32)(sector >> 32);
+
+	e->prev_pid = rq_dev(rq);
+	e->next_pid = BPF_CORE_READ(rq, __data_len) >> 9;
+	e->prev_state = 0;
+
+	submit_buf(ctx, e, sizeof(*e));
+	return 0;
+}
+
+static __always_inline int handle_block_rq_complete(void *ctx, struct request *rq)
+{
+	__u64 key = (__u64)(unsigned long)rq;
+	struct pending_io_val *val = bpf_map_lookup_elem(&pending_io, &key);
+	if (!val) {
+		io_counter_inc(IO_CNT_ORPHAN_COMPLETE);
+		return 0;
+	}
+
+	__u64 cur_pid_tgid = bpf_get_current_pid_tgid();
+	if ((__u32)cur_pid_tgid != val->submitter_tid)
+		io_counter_inc(IO_CNT_SUBMITTER_MISS);
+
+	struct wperf_event *e = reserve_buf(sizeof(*e));
+	if (!e) {
+		bpf_map_delete_elem(&pending_io, &key);
+		return 0;
+	}
+
+	fill_timestamp_and_cpu(e);
+	e->event_type = WPERF_EVENT_IO_COMPLETE;
+	/* Attribute to submitter recorded at issue time — completion runs in
+	 * softirq/IRQ context where current task is unrelated. ADR-009 §3. */
+	e->pid = val->submitter_tgid;
+	e->tid = val->submitter_tid;
+
+	__u64 sector = BPF_CORE_READ(rq, __sector);
+	e->prev_tid = (__u32)sector;
+	e->next_tid = (__u32)(sector >> 32);
+
+	e->prev_pid = rq_dev(rq);
+	e->next_pid = BPF_CORE_READ(rq, __data_len) >> 9;
+	e->prev_state = 0;
+
+	submit_buf(ctx, e, sizeof(*e));
+	bpf_map_delete_elem(&pending_io, &key);
+	return 0;
+}
+
+SEC("tp_btf/block_rq_issue")
+int BPF_PROG(handle_block_rq_issue_btf)
+{
+	struct request *rq = targ_single
+		? (struct request *)ctx[0]
+		: (struct request *)ctx[1];
+	return handle_block_rq_issue(ctx, rq);
+}
+
+SEC("raw_tp/block_rq_issue")
+int BPF_PROG(handle_block_rq_issue_raw)
+{
+	struct request *rq = targ_single
+		? (struct request *)ctx[0]
+		: (struct request *)ctx[1];
+	return handle_block_rq_issue(ctx, rq);
+}
+
+SEC("tp_btf/block_rq_complete")
+int BPF_PROG(handle_block_rq_complete_btf)
+{
+	return handle_block_rq_complete(ctx, (struct request *)ctx[0]);
+}
+
+SEC("raw_tp/block_rq_complete")
+int BPF_PROG(handle_block_rq_complete_raw)
+{
+	return handle_block_rq_complete(ctx, (struct request *)ctx[0]);
+}
+
 char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/src/bpf/wperf.bpf.c
+++ b/src/bpf/wperf.bpf.c
@@ -352,9 +352,26 @@ struct {
 	__type(value, __u64);
 } io_counters SEC(".maps");
 
+/* Cached at issue time, read at complete time. We do NOT re-read sector /
+ * data_len / dev from `struct request` at completion: `blk_update_request`
+ * advances `__sector` and decrements `__data_len` BEFORE firing
+ * `block_rq_complete` on the second and subsequent invocations during
+ * partial / multi-bio completion (verified across 4.18 → 6.6 LTS). For
+ * single-call completion (Phase 2b CI dd workload) the rq fields are still
+ * stable at tracepoint fire, but multi-bio paths (PostgreSQL fsync /
+ * fio iodepth>1 / NVMe retries / SAN multipath) would mutate the
+ * (sector, nr_sector) tuple and break userspace IoKey pairing.
+ *
+ * Probe kernel-source audit msg=8202789c §1-2 + Critic msg=d1893b74 +
+ * Oracle msg=e645e54f + Challenger msg=01643e20 5-way convergent:
+ * cache issue-time values in BPF map, decoupled from kernel-internal
+ * blk_update_request mutation timing. */
 struct pending_io_val {
 	__u32 submitter_tgid;
 	__u32 submitter_tid;
+	__u64 sector;     /* issue-time `__sector` — stable across partial completion */
+	__u32 nr_sector;  /* issue-time `__data_len >> 9` — sectors of 512 bytes */
+	__u32 dev;        /* issue-time (major << 20 | first_minor) — rq_disk may be cleared at completion */
 };
 
 struct {
@@ -410,9 +427,15 @@ static __always_inline int handle_block_rq_issue(void *ctx, struct request *rq)
 		return 0;
 
 	__u64 key = (__u64)(unsigned long)rq;
+	__u64 sector = BPF_CORE_READ(rq, __sector);
+	__u32 nr_sector = (__u32)(BPF_CORE_READ(rq, __data_len) >> 9);
+	__u32 dev = rq_dev(rq);
 	struct pending_io_val val = {
 		.submitter_tgid = tgid,
 		.submitter_tid  = tid,
+		.sector         = sector,
+		.nr_sector      = nr_sector,
+		.dev            = dev,
 	};
 	if (bpf_map_update_elem(&pending_io, &key, &val, BPF_ANY) != 0) {
 		io_counter_inc(IO_CNT_PENDING_DROP);
@@ -428,12 +451,11 @@ static __always_inline int handle_block_rq_issue(void *ctx, struct request *rq)
 	e->pid = tgid;
 	e->tid = tid;
 
-	__u64 sector = BPF_CORE_READ(rq, __sector);
 	e->prev_tid = (__u32)sector;
 	e->next_tid = (__u32)(sector >> 32);
 
-	e->prev_pid = rq_dev(rq);
-	e->next_pid = BPF_CORE_READ(rq, __data_len) >> 9;
+	e->prev_pid = dev;
+	e->next_pid = nr_sector;
 	e->prev_state = 0;
 
 	submit_buf(ctx, e, sizeof(*e));
@@ -469,12 +491,15 @@ static __always_inline int handle_block_rq_complete(void *ctx, struct request *r
 	e->pid = val->submitter_tgid;
 	e->tid = val->submitter_tid;
 
-	__u64 sector = BPF_CORE_READ(rq, __sector);
-	e->prev_tid = (__u32)sector;
-	e->next_tid = (__u32)(sector >> 32);
+	/* Read (sector, nr_sector, dev) from the cached val instead of the rq:
+	 * the userspace IoKey requires issue-time values to pair correctly
+	 * with the IoIssue event. See `struct pending_io_val` doc-comment for
+	 * the kernel-source rationale. */
+	e->prev_tid = (__u32)val->sector;
+	e->next_tid = (__u32)(val->sector >> 32);
 
-	e->prev_pid = rq_dev(rq);
-	e->next_pid = BPF_CORE_READ(rq, __data_len) >> 9;
+	e->prev_pid = val->dev;
+	e->next_pid = val->nr_sector;
 	e->prev_state = 0;
 
 	submit_buf(ctx, e, sizeof(*e));

--- a/src/bpf/wperf.h
+++ b/src/bpf/wperf.h
@@ -20,11 +20,13 @@
 
 /* Event type discriminants — must match Rust EventType repr(u8). */
 enum wperf_event_type {
-	WPERF_EVENT_SWITCH     = 1,
-	WPERF_EVENT_WAKEUP     = 2,
-	WPERF_EVENT_WAKEUP_NEW = 3,
-	WPERF_EVENT_EXIT       = 4,
-	WPERF_EVENT_FUTEX_WAIT = 5,
+	WPERF_EVENT_SWITCH       = 1,
+	WPERF_EVENT_WAKEUP       = 2,
+	WPERF_EVENT_WAKEUP_NEW   = 3,
+	WPERF_EVENT_EXIT         = 4,
+	WPERF_EVENT_FUTEX_WAIT   = 5,
+	WPERF_EVENT_IO_ISSUE     = 6,
+	WPERF_EVENT_IO_COMPLETE  = 7,
 };
 
 /* Futex operation constants (from linux/futex.h).
@@ -52,6 +54,23 @@ enum wperf_event_type {
  *   next_tid  → uaddr upper 32 bits
  *   flags     → futex op (after FUTEX_CMD_MASK)
  *   prev_pid, next_pid, prev_state → unused (zero)
+ */
+
+/*
+ * IO event field mapping (reuses 40-byte wperf_event struct, Phase 2b issue #38):
+ *   timestamp_ns     → block_rq_issue / block_rq_complete ktime_get_boot_ns()
+ *   pid              → submitter tgid (userspace PID; block_rq_complete reads from pending_io)
+ *   tid              → submitter kernel tid (same source as pid)
+ *   prev_tid         → sector lower 32 bits  (packed u64 sector)
+ *   next_tid         → sector upper 32 bits  (packed u64 sector)
+ *   prev_pid         → dev_t (u32)           — observability-only per ADR-009 / Challenger C11
+ *   next_pid         → nr_sector (u32)       — request size in 512-byte sectors
+ *   flags            → reserved (0; Path 1 sync-direct IO does not differentiate rw flags)
+ *   prev_state, cpu  → unused / standard fill
+ *
+ * Discipline: correlate.rs Phase 2b MUST NOT dispatch on event.dev — load-bearing
+ * comment required at the dev-read site. Retained for forward-compat with per-device
+ * disk nodes (#115).
  */
 
 /*

--- a/src/cascade/engine.rs
+++ b/src/cascade/engine.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 use petgraph::graph::EdgeIndex;
 
 use crate::graph::sweep::sweep_line_partition;
-use crate::graph::types::{ThreadId, TimeWindow};
+use crate::graph::types::{EdgeKind, ThreadId, TimeWindow};
 use crate::graph::wfg::WaitForGraph;
 
 use super::invariants;
@@ -142,9 +142,20 @@ fn count_concurrent_waiters(graph: &WaitForGraph, target: ThreadId, window: &Tim
         return 1;
     };
 
+    // ADR-009 Amendment 2026-04-25 (final-design.md §3.3): synthetic
+    // closure-return edges (`EdgeKind::SyntheticClosureReturn`) are
+    // cascade-terminal and must NOT count as concurrent waiters; they
+    // represent SCC closure bookkeeping, not real wait dependencies.
+    // Skipping them here is the second of the two filter sites
+    // mandated by the amendment (the first is in
+    // `sweep_line_partition`). Applying only one of the two leaves
+    // the divisor polluted by bookkeeping edges and silently halves
+    // cascade transfer on the forward direction (PR #120 5-way
+    // thread, Probe Gap 5).
     let count = graph
         .incoming_edges(node_idx)
         .iter()
+        .filter(|(_, _, ew)| ew.kind != EdgeKind::SyntheticClosureReturn)
         .filter(|(_, _, ew)| ew.time_window.overlap(window).is_some())
         .map(|(_, src_tid, _)| *src_tid)
         .collect::<BTreeSet<_>>()

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -170,6 +170,24 @@ pub struct CorrelationStats {
     /// the matching Rust variant lands is dropped here rather than panicking.
     /// *Internal diagnostic stat* — not a canonical coverage metric.
     pub unknown_event_type_count: u64,
+
+    // --- Block-IO synthetic edge health (Phase 2b #38 commit-5) -------------
+    // See `HealthMetrics` in src/report.rs for the exported contract.
+    /// `IoComplete` events with no matching `pending_io` entry. Causes:
+    /// BPF dropped the paired `IoIssue` (per-CPU buffer full), the issue
+    /// predates BPF attach, or the userspace key collided.
+    pub io_orphan_complete_count: u64,
+    /// `IoIssue` records still in `pending_io` when correlation ends — no
+    /// matching `IoComplete` arrived before the capture terminated. Upper
+    /// bound on "in-flight I/O at exit"; excessive values suggest capture
+    /// was truncated mid-I/O.
+    pub io_pending_at_end_count: u64,
+    /// `IoIssue` events that overwrote an existing `pending_io` entry with
+    /// the same `(dev, sector, nr_sector)` key. Observability guardrail
+    /// for the collision window Gemini flagged on PR #120 (review id
+    /// 3118320504). If this fires under real workloads, the event ABI
+    /// needs to carry `struct request *` as an opaque `u64`.
+    pub io_userspace_pair_collision_count: u64,
 }
 
 /// Correlate a globally timestamp-sorted event stream into a `WaitForGraph`.
@@ -229,7 +247,7 @@ pub fn correlate_events(
                 handle_futex_wait(event, &mut pending_futex);
             }
             Some(EventType::IoIssue) => {
-                handle_io_issue(event, &mut pending_io);
+                handle_io_issue(event, &mut pending_io, &mut stats);
             }
             Some(EventType::IoComplete) => {
                 handle_io_complete(event, &mut pending_io, &mut graph, &mut stats);
@@ -249,6 +267,11 @@ pub fn correlate_events(
     for (_, pe) in pending_edges.drain() {
         add_edge_from_pending(&mut graph, pe, &mut stats);
     }
+
+    // Pending-at-end: I/Os whose issue arrived but whose completion never
+    // landed before the capture ended. Safe to cast — u64 holds any
+    // plausible in-flight count (max_entries = 16 384 on BPF side).
+    stats.io_pending_at_end_count = pending_io.len() as u64;
 
     (graph, stats)
 }
@@ -373,10 +396,15 @@ fn handle_futex_wait(event: &WperfEvent, pending_futex: &mut HashMap<u32, Pendin
 /// Handle a `block_rq_issue` event — record the in-flight request so the
 /// matching `block_rq_complete` can recover `(submitter, issue_ts)`.
 ///
-/// Orphan / pending-at-end accounting is deferred to commit-5
-/// (`HealthMetrics`).
-fn handle_io_issue(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo>) {
-    pending_io.insert(
+/// Collisions (same `IoKey` already in the map) are counted and the
+/// pre-existing entry is overwritten (last-writer-wins, matching BPF's
+/// `bpf_map_update_elem(.., BPF_ANY)` semantics).
+fn handle_io_issue(
+    event: &WperfEvent,
+    pending_io: &mut HashMap<IoKey, PendingIo>,
+    stats: &mut CorrelationStats,
+) {
+    let previous = pending_io.insert(
         IoKey::from_event(event),
         PendingIo {
             submitter_tgid: event.pid,
@@ -384,6 +412,9 @@ fn handle_io_issue(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo
             issue_ts_ns: event.timestamp_ns,
         },
     );
+    if previous.is_some() {
+        stats.io_userspace_pair_collision_count += 1;
+    }
 }
 
 /// Handle a `block_rq_complete` event — drain the matching issue record
@@ -398,8 +429,8 @@ fn handle_io_issue(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo
 /// with `WaitType::IoBlock`.
 ///
 /// Orphan completions (no matching `pending_io` entry — issue was dropped,
-/// predates attach, or key collided) return without mutating the graph;
-/// orphan counters land in commit-5.
+/// predates attach, or key collided) return without mutating the graph and
+/// are counted into `io_orphan_complete_count`.
 fn handle_io_complete(
     event: &WperfEvent,
     pending_io: &mut HashMap<IoKey, PendingIo>,
@@ -407,6 +438,7 @@ fn handle_io_complete(
     stats: &mut CorrelationStats,
 ) {
     let Some(pending) = pending_io.remove(&IoKey::from_event(event)) else {
+        stats.io_orphan_complete_count += 1;
         return;
     };
 
@@ -1235,11 +1267,13 @@ mod tests {
     #[test]
     fn handle_io_issue_records_submitter_and_ts() {
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let mut stats = CorrelationStats::default();
         let ev = io_issue_event(1_000_000, 100, 101, 0x800_0002, 0xDEAD_BEEF_0000_1234);
 
-        handle_io_issue(&ev, &mut pending_io);
+        handle_io_issue(&ev, &mut pending_io, &mut stats);
 
         assert_eq!(pending_io.len(), 1);
+        assert_eq!(stats.io_userspace_pair_collision_count, 0);
         let key = IoKey {
             dev: 0x800_0002,
             sector: 0xDEAD_BEEF_0000_1234,
@@ -1259,7 +1293,7 @@ mod tests {
         let issue = io_issue_event(1_000_000, 100, 101, 0x800_0002, 0x1000);
         let complete = io_complete_event(1_500_000, 100, 101, 0x800_0002, 0x1000);
 
-        handle_io_issue(&issue, &mut pending_io);
+        handle_io_issue(&issue, &mut pending_io, &mut stats);
         handle_io_complete(&complete, &mut pending_io, &mut graph, &mut stats);
 
         assert!(pending_io.is_empty(), "issue/complete pair must drain");
@@ -1279,10 +1313,9 @@ mod tests {
     }
 
     #[test]
-    fn handle_io_complete_without_matching_issue_is_noop() {
+    fn handle_io_complete_without_matching_issue_counts_orphan() {
         // Orphan completion: BPF dropped the issue (per-CPU buffer full),
-        // buffer reorder/truncation, or key collided. Commit-5 adds
-        // io_orphan_complete_count; for now, assert no panic + no edges.
+        // buffer reorder/truncation, or key collided.
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
         let mut graph = WaitForGraph::new();
         let mut stats = CorrelationStats::default();
@@ -1293,6 +1326,7 @@ mod tests {
         assert!(pending_io.is_empty());
         assert_eq!(stats.edges_created, 0);
         assert_eq!(graph.node_count(), 0);
+        assert_eq!(stats.io_orphan_complete_count, 1, "orphan must be counted");
     }
 
     #[test]
@@ -1300,18 +1334,19 @@ mod tests {
         // Two devices, same sector — must NOT collide. `dev` is the first
         // disambiguator in the IoKey tuple.
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let mut stats = CorrelationStats::default();
         let issue_dev1 = io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x2000);
         let issue_dev2 = io_issue_event(1_000_001, 200, 201, 0x800_0002, 0x2000);
 
-        handle_io_issue(&issue_dev1, &mut pending_io);
-        handle_io_issue(&issue_dev2, &mut pending_io);
+        handle_io_issue(&issue_dev1, &mut pending_io, &mut stats);
+        handle_io_issue(&issue_dev2, &mut pending_io, &mut stats);
 
         assert_eq!(pending_io.len(), 2);
+        assert_eq!(stats.io_userspace_pair_collision_count, 0);
 
         // Completing dev1's IO must not touch dev2's entry.
         let complete_dev1 = io_complete_event(1_500_000, 100, 101, 0x800_0001, 0x2000);
         let mut graph = WaitForGraph::new();
-        let mut stats = CorrelationStats::default();
         handle_io_complete(&complete_dev1, &mut pending_io, &mut graph, &mut stats);
 
         assert_eq!(pending_io.len(), 1);
@@ -1330,18 +1365,19 @@ mod tests {
         // targeting the same starting sector would collide. Including
         // `nr_sector` in IoKey must let them pair independently.
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let mut stats = CorrelationStats::default();
         let small = io_issue_event_sized(1_000_000, 100, 101, 0x800_0001, 0x2000, 1);
         let large = io_issue_event_sized(1_000_001, 200, 201, 0x800_0001, 0x2000, 16);
 
-        handle_io_issue(&small, &mut pending_io);
-        handle_io_issue(&large, &mut pending_io);
+        handle_io_issue(&small, &mut pending_io, &mut stats);
+        handle_io_issue(&large, &mut pending_io, &mut stats);
 
         assert_eq!(pending_io.len(), 2, "different nr_sector must not collide");
+        assert_eq!(stats.io_userspace_pair_collision_count, 0);
 
         // Completing the large request must not disturb the small one.
         let complete_large = io_complete_event_sized(1_500_000, 200, 201, 0x800_0001, 0x2000, 16);
         let mut graph = WaitForGraph::new();
-        let mut stats = CorrelationStats::default();
         handle_io_complete(&complete_large, &mut pending_io, &mut graph, &mut stats);
 
         assert_eq!(pending_io.len(), 1);
@@ -1360,16 +1396,16 @@ mod tests {
         // Typical case: one tgid submits multiple IOs in flight concurrently
         // to the same device. Each (dev, sector) is independent.
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let mut stats = CorrelationStats::default();
         for sector in [0x1000u64, 0x2000, 0x3000, 0x4000] {
             let ev = io_issue_event(1_000_000 + sector, 100, 101, 0x800_0001, sector);
-            handle_io_issue(&ev, &mut pending_io);
+            handle_io_issue(&ev, &mut pending_io, &mut stats);
         }
 
         assert_eq!(pending_io.len(), 4);
 
         // Out-of-order completions (NVMe queue reorder is realistic).
         let mut graph = WaitForGraph::new();
-        let mut stats = CorrelationStats::default();
         for sector in [0x3000u64, 0x1000, 0x4000, 0x2000] {
             let ev = io_complete_event(2_000_000 + sector, 100, 101, 0x800_0001, sector);
             handle_io_complete(&ev, &mut pending_io, &mut graph, &mut stats);
@@ -1377,6 +1413,7 @@ mod tests {
 
         assert!(pending_io.is_empty());
         assert_eq!(stats.edges_created, 8, "4 I/Os × 2 edges = 8");
+        assert_eq!(stats.io_orphan_complete_count, 0);
     }
 
     #[test]
@@ -1387,13 +1424,18 @@ mod tests {
         // matches BPF-side `bpf_map_update_elem(.., BPF_ANY)` semantics
         // (wperf.bpf.c handle_block_rq_issue).
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let mut stats = CorrelationStats::default();
         let first = io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x1000);
         let second = io_issue_event(2_000_000, 200, 201, 0x800_0001, 0x1000);
 
-        handle_io_issue(&first, &mut pending_io);
-        handle_io_issue(&second, &mut pending_io);
+        handle_io_issue(&first, &mut pending_io, &mut stats);
+        handle_io_issue(&second, &mut pending_io, &mut stats);
 
         assert_eq!(pending_io.len(), 1);
+        assert_eq!(
+            stats.io_userspace_pair_collision_count, 1,
+            "second issue with same IoKey must be counted as collision"
+        );
         let key = IoKey {
             dev: 0x800_0001,
             sector: 0x1000,
@@ -1422,6 +1464,11 @@ mod tests {
         assert_eq!(stats.edges_created, 2);
         assert_eq!(stats.unknown_event_type_count, 0);
         assert_eq!(stats.events_processed, 3);
+        assert_eq!(
+            stats.io_pending_at_end_count, 1,
+            "T201's unpaired issue must count as pending-at-end"
+        );
+        assert_eq!(stats.io_orphan_complete_count, 0);
     }
 
     #[test]

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -455,8 +455,18 @@ fn handle_io_complete(
 
     graph.add_node(user, NodeKind::UserThread);
     graph.add_node(disk, NodeKind::PseudoDisk);
+    // Forward (issue) edge — real wait dependency, normal cascade traversal.
     graph.add_edge_with_wait_type(user, disk, window, WaitType::IoBlock);
-    graph.add_edge_with_wait_type(disk, user, window, WaitType::IoBlock);
+    // Return (completion) edge — ADR-009 *Amendment 2026-04-25*
+    // cascade-terminal. Participates in Tarjan SCC analysis and Knot
+    // detection; cascade engine skips it via the
+    // `EdgeKind::SyntheticClosureReturn` marker in both
+    // `sweep_line_partition` (outgoing-traversal) and
+    // `count_concurrent_waiters` (incoming-edge enumerator). P2c
+    // PseudoNic / PseudoSoftirq mirror return edges MUST reuse this
+    // same constructor when they land — the marker is type-system-
+    // enforced via `EdgeWeight::synthetic_closure_return`.
+    graph.add_synthetic_closure_return(disk, user, window, WaitType::IoBlock);
     stats.edges_created += 2;
 }
 

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -92,14 +92,26 @@ struct PendingEdge {
 ///
 /// BPF already pairs issue/complete kernel-side via `struct request *`, but
 /// that pointer is not propagated to userspace (ABI-unstable, and emitting
-/// it would add 8 bytes to every IO event). Userspace re-pairs using the
-/// stable tuple `(dev, sector)` carried on both `IoIssue` and `IoComplete`
-/// events. `dev` alone is insufficient — many concurrent requests target
-/// the same device — and `sector` alone collides across devices.
+/// it would add 8 bytes to every IO event — requires an event-layout
+/// version bump which is out of scope for #38). Userspace re-pairs using
+/// the tuple `(dev, sector, nr_sector)` carried on both `IoIssue` and
+/// `IoComplete` events.
+///
+/// **Collision surface** (Gemini review, PR #120): `(dev, sector)` alone is
+/// not globally unique for in-flight requests — two concurrent reads or a
+/// read+write targeting the same start sector would collide and misattribute
+/// on completion. Adding `nr_sector` narrows the window substantially (same
+/// dev + same start sector + same size is rare in practice — block layer
+/// serializes writes at the same LBA, and merged/split requests change
+/// `nr_sector`). The residual risk is observed in commit-5 via an
+/// `io_userspace_pair_collision_count` counter; if it fires in real
+/// workloads we bump the event ABI to carry `struct request *` as an opaque
+/// `u64` ID (Gemini's preferred long-term fix).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct IoKey {
     dev: u32,
     sector: u64,
+    nr_sector: u32,
 }
 
 impl IoKey {
@@ -107,6 +119,7 @@ impl IoKey {
         Self {
             dev: event.io_dev(),
             sector: event.io_sector(),
+            nr_sector: event.io_nr_sector(),
         }
     }
 }
@@ -1136,8 +1149,16 @@ mod tests {
     // in-scope is `pending_io`, which lives inside `correlate_events` and is
     // not exposed to callers.
 
-    #[allow(clippy::similar_names)] // tgid / tid mirror WperfEvent field names
-    fn io_issue_event(ts: u64, tgid: u32, tid: u32, dev: u32, sector: u64) -> WperfEvent {
+    // tgid / tid mirror WperfEvent field names — clippy false positive
+    #[allow(clippy::similar_names)]
+    fn io_issue_event_sized(
+        ts: u64,
+        tgid: u32,
+        tid: u32,
+        dev: u32,
+        sector: u64,
+        nr_sector: u32,
+    ) -> WperfEvent {
         WperfEvent {
             timestamp_ns: ts,
             pid: tgid,
@@ -1147,8 +1168,8 @@ mod tests {
             next_tid: u32::try_from(sector >> 32).unwrap(),
             // io_dev() reads prev_pid
             prev_pid: dev,
-            // io_nr_sector() reads next_pid — observability-only in Phase 2b
-            next_pid: 8,
+            // io_nr_sector() reads next_pid
+            next_pid: nr_sector,
             cpu: 0,
             event_type: EventType::IoIssue as u8,
             prev_state: 0,
@@ -1157,12 +1178,28 @@ mod tests {
     }
 
     #[allow(clippy::similar_names)]
-    fn io_complete_event(ts: u64, tgid: u32, tid: u32, dev: u32, sector: u64) -> WperfEvent {
+    fn io_issue_event(ts: u64, tgid: u32, tid: u32, dev: u32, sector: u64) -> WperfEvent {
+        io_issue_event_sized(ts, tgid, tid, dev, sector, 8)
+    }
+
+    #[allow(clippy::similar_names)]
+    fn io_complete_event_sized(
+        ts: u64,
+        tgid: u32,
+        tid: u32,
+        dev: u32,
+        sector: u64,
+        nr_sector: u32,
+    ) -> WperfEvent {
         WperfEvent {
             event_type: EventType::IoComplete as u8,
-            timestamp_ns: ts,
-            ..io_issue_event(ts, tgid, tid, dev, sector)
+            ..io_issue_event_sized(ts, tgid, tid, dev, sector, nr_sector)
         }
+    }
+
+    #[allow(clippy::similar_names)]
+    fn io_complete_event(ts: u64, tgid: u32, tid: u32, dev: u32, sector: u64) -> WperfEvent {
+        io_complete_event_sized(ts, tgid, tid, dev, sector, 8)
     }
 
     #[test]
@@ -1176,6 +1213,7 @@ mod tests {
         let key = IoKey {
             dev: 0x800_0002,
             sector: 0xDEAD_BEEF_0000_1234,
+            nr_sector: 8,
         };
         let rec = pending_io.get(&key).expect("IoKey must match");
         assert_eq!(rec.submitter_tgid, 100);
@@ -1209,9 +1247,9 @@ mod tests {
     }
 
     #[test]
-    fn pending_io_keyed_by_dev_and_sector_not_just_sector() {
-        // Two devices, same sector — must NOT collide. Disambiguation by
-        // (dev, sector) is the whole reason IoKey exists.
+    fn pending_io_keyed_by_dev_sector_nr_sector() {
+        // Two devices, same sector — must NOT collide. `dev` is the first
+        // disambiguator in the IoKey tuple.
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
         let issue_dev1 = io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x2000);
         let issue_dev2 = io_issue_event(1_000_001, 200, 201, 0x800_0002, 0x2000);
@@ -1229,8 +1267,39 @@ mod tests {
         let dev2_key = IoKey {
             dev: 0x800_0002,
             sector: 0x2000,
+            nr_sector: 8,
         };
         assert!(pending_io.contains_key(&dev2_key));
+    }
+
+    #[test]
+    fn pending_io_same_dev_same_sector_different_size_no_collision() {
+        // Gemini PR #120 review: `(dev, sector)` alone is not globally unique
+        // for in-flight requests — two concurrent reads or a read+write
+        // targeting the same starting sector would collide. Including
+        // `nr_sector` in IoKey must let them pair independently.
+        let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let small = io_issue_event_sized(1_000_000, 100, 101, 0x800_0001, 0x2000, 1);
+        let large = io_issue_event_sized(1_000_001, 200, 201, 0x800_0001, 0x2000, 16);
+
+        handle_io_issue(&small, &mut pending_io);
+        handle_io_issue(&large, &mut pending_io);
+
+        assert_eq!(pending_io.len(), 2, "different nr_sector must not collide");
+
+        // Completing the large request must not disturb the small one.
+        let complete_large = io_complete_event_sized(1_500_000, 200, 201, 0x800_0001, 0x2000, 16);
+        handle_io_complete(&complete_large, &mut pending_io);
+
+        assert_eq!(pending_io.len(), 1);
+        let small_key = IoKey {
+            dev: 0x800_0001,
+            sector: 0x2000,
+            nr_sector: 1,
+        };
+        let rec = pending_io[&small_key];
+        assert_eq!(rec.submitter_tgid, 100);
+        assert_eq!(rec.submitter_tid, 101);
     }
 
     #[test]
@@ -1272,6 +1341,7 @@ mod tests {
         let key = IoKey {
             dev: 0x800_0001,
             sector: 0x1000,
+            nr_sector: 8,
         };
         let rec = pending_io[&key];
         assert_eq!(rec.submitter_tgid, 200);

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -171,6 +171,11 @@ pub fn correlate_events(
             Some(EventType::FutexWait) => {
                 handle_futex_wait(event, &mut pending_futex);
             }
+            Some(EventType::IoIssue) | Some(EventType::IoComplete) => {
+                // IO synth-edge generation lands in a later commit (issue #38
+                // commit-4 per plan). Scaffold: enum variants wired end-to-end
+                // so BPF discriminants stay in lockstep; no graph mutation yet.
+            }
             None => {}
         }
     }

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -114,6 +114,12 @@ pub struct CorrelationStats {
     /// Edges filtered as spurious wakeups (on-CPU < threshold after wakeup).
     /// **Canonical coverage metric** (§2.5 / §3.8).
     pub false_wakeup_filtered_count: u64,
+    /// Events whose `event_type` byte did not match any known `EventType`
+    /// discriminant. Safety net for forward-compatible BPF→userspace bisects
+    /// across multi-commit PR ranges — a new BPF discriminant shipped before
+    /// the matching Rust variant lands is dropped here rather than panicking.
+    /// *Internal diagnostic stat* — not a canonical coverage metric.
+    pub unknown_event_type_count: u64,
 }
 
 /// Correlate a globally timestamp-sorted event stream into a `WaitForGraph`.
@@ -171,12 +177,20 @@ pub fn correlate_events(
             Some(EventType::FutexWait) => {
                 handle_futex_wait(event, &mut pending_futex);
             }
-            Some(EventType::IoIssue) | Some(EventType::IoComplete) => {
+            Some(EventType::IoIssue | EventType::IoComplete) => {
                 // IO synth-edge generation lands in a later commit (issue #38
                 // commit-4 per plan). Scaffold: enum variants wired end-to-end
                 // so BPF discriminants stay in lockstep; no graph mutation yet.
             }
-            None => {}
+            None => {
+                if stats.unknown_event_type_count == 0 {
+                    eprintln!(
+                        "correlate: unknown event_type discriminant {} at ts_ns={} — dropping (forward-compat bisect guard; further occurrences suppressed, see unknown_event_type_count)",
+                        event.event_type, event.timestamp_ns
+                    );
+                }
+                stats.unknown_event_type_count += 1;
+            }
         }
     }
 
@@ -394,6 +408,65 @@ mod tests {
         assert_eq!(graph.node_count(), 0);
         assert_eq!(stats.events_processed, 0);
         assert_eq!(stats.edges_created, 0);
+    }
+
+    #[test]
+    fn unknown_event_type_drops_and_counts() {
+        // Forward-compat bisect guard: a BPF discriminant shipped ahead of
+        // the matching Rust variant must drop safely with counter increment,
+        // never panic. Simulates commit-2-ships-before-commit-3 window.
+        let mut bad = WperfEvent {
+            timestamp_ns: 1_000_000,
+            pid: 100,
+            tid: 101,
+            prev_tid: 0,
+            next_tid: 0,
+            prev_pid: 0,
+            next_pid: 0,
+            cpu: 0,
+            event_type: 99,
+            prev_state: 0,
+            flags: 0,
+        };
+        let (graph, stats) = correlate(&[bad]);
+        assert_eq!(graph.node_count(), 0);
+        assert_eq!(stats.edges_created, 0);
+        assert_eq!(stats.unknown_event_type_count, 1);
+        assert_eq!(stats.events_processed, 1);
+
+        // Multiple unknown events accumulate.
+        bad.timestamp_ns = 2_000_000;
+        let (_, stats2) = correlate(&[bad, bad]);
+        assert_eq!(stats2.unknown_event_type_count, 2);
+    }
+
+    #[test]
+    fn io_discriminants_are_known_but_noop_in_commit_1() {
+        // commit-1 scaffold: IoIssue / IoComplete must NOT count as unknown —
+        // variants are wired; synth-edge generation lands in commit-4.
+        let io_issue = WperfEvent {
+            timestamp_ns: 1_000_000,
+            pid: 100,
+            tid: 101,
+            prev_tid: 0,
+            next_tid: 0,
+            prev_pid: 0,
+            next_pid: 0,
+            cpu: 0,
+            event_type: EventType::IoIssue as u8,
+            prev_state: 0,
+            flags: 0,
+        };
+        let io_complete = WperfEvent {
+            event_type: EventType::IoComplete as u8,
+            timestamp_ns: 2_000_000,
+            ..io_issue
+        };
+        let (graph, stats) = correlate(&[io_issue, io_complete]);
+        assert_eq!(graph.node_count(), 0);
+        assert_eq!(stats.edges_created, 0);
+        assert_eq!(stats.unknown_event_type_count, 0);
+        assert_eq!(stats.events_processed, 2);
     }
 
     #[test]

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -88,6 +88,43 @@ struct PendingEdge {
     wait_type: Option<WaitType>,
 }
 
+/// Key identifying an in-flight block I/O request in userspace.
+///
+/// BPF already pairs issue/complete kernel-side via `struct request *`, but
+/// that pointer is not propagated to userspace (ABI-unstable, and emitting
+/// it would add 8 bytes to every IO event). Userspace re-pairs using the
+/// stable tuple `(dev, sector)` carried on both `IoIssue` and `IoComplete`
+/// events. `dev` alone is insufficient — many concurrent requests target
+/// the same device — and `sector` alone collides across devices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct IoKey {
+    dev: u32,
+    sector: u64,
+}
+
+impl IoKey {
+    fn from_event(event: &WperfEvent) -> Self {
+        Self {
+            dev: event.io_dev(),
+            sector: event.io_sector(),
+        }
+    }
+}
+
+/// State retained between an `IoIssue` and its matching `IoComplete`.
+///
+/// Submitter attribution is taken verbatim from the event — BPF already
+/// records the submitter at issue time and re-stamps it onto the completion
+/// event, so `pid`/`tid` on the `IoComplete` event refer to the original
+/// submitter regardless of which task the softirq/IRQ completion ran on
+/// (ADR-009 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingIo {
+    submitter_tgid: u32,
+    submitter_tid: u32,
+    issue_ts_ns: u64,
+}
+
 /// Statistics from the correlation pass.
 ///
 /// # Canonical vs diagnostic metrics
@@ -150,6 +187,7 @@ pub fn correlate_events(
     let mut off_cpu: HashMap<u32, OffCpuRecord> = HashMap::new();
     let mut pending_futex: HashMap<u32, PendingFutex> = HashMap::new();
     let mut pending_edges: HashMap<u32, PendingEdge> = HashMap::new();
+    let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
 
     for event in events {
         stats.events_processed += 1;
@@ -177,10 +215,11 @@ pub fn correlate_events(
             Some(EventType::FutexWait) => {
                 handle_futex_wait(event, &mut pending_futex);
             }
-            Some(EventType::IoIssue | EventType::IoComplete) => {
-                // IO synth-edge generation lands in a later commit (issue #38
-                // commit-4 per plan). Scaffold: enum variants wired end-to-end
-                // so BPF discriminants stay in lockstep; no graph mutation yet.
+            Some(EventType::IoIssue) => {
+                handle_io_issue(event, &mut pending_io);
+            }
+            Some(EventType::IoComplete) => {
+                handle_io_complete(event, &mut pending_io);
             }
             None => {
                 if stats.unknown_event_type_count == 0 {
@@ -318,6 +357,34 @@ fn handle_futex_wait(event: &WperfEvent, pending_futex: &mut HashMap<u32, Pendin
     );
 }
 
+/// Handle a `block_rq_issue` event — record the in-flight request so the
+/// matching `block_rq_complete` can recover `(submitter, issue_ts)`.
+///
+/// Synthetic edge generation against the `block_device:<dev>` pseudo-thread
+/// lands in a later commit (issue #38 commit-4); this commit tracks only the
+/// userspace lifecycle. Orphan / pending-at-end accounting is deferred to
+/// commit-5 (`HealthMetrics`).
+fn handle_io_issue(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo>) {
+    pending_io.insert(
+        IoKey::from_event(event),
+        PendingIo {
+            submitter_tgid: event.pid,
+            submitter_tid: event.tid,
+            issue_ts_ns: event.timestamp_ns,
+        },
+    );
+}
+
+/// Handle a `block_rq_complete` event — drain the matching issue record.
+///
+/// BPF re-stamps the original submitter onto the completion event (ADR-009
+/// §3), so the `pid`/`tid` carried here are trustworthy for attribution; the
+/// only job of userspace is to pair with the issue and surface the (delta,
+/// submitter) tuple to commit-4's edge generator.
+fn handle_io_complete(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo>) {
+    pending_io.remove(&IoKey::from_event(event));
+}
+
 /// Handle a `sched_wakeup` or `sched_wakeup_new` event.
 ///
 /// Records the waker for an off-CPU thread. Last-wake-wins policy:
@@ -441,9 +508,10 @@ mod tests {
     }
 
     #[test]
-    fn io_discriminants_are_known_but_noop_in_commit_1() {
-        // commit-1 scaffold: IoIssue / IoComplete must NOT count as unknown —
-        // variants are wired; synth-edge generation lands in commit-4.
+    fn io_discriminants_dispatch_without_graph_mutation() {
+        // commit-3 scaffold: IoIssue / IoComplete dispatch into pending_io
+        // lifecycle handlers but must NOT count as unknown and must NOT
+        // mutate the graph — synth-edge generation lands in commit-4.
         let io_issue = WperfEvent {
             timestamp_ns: 1_000_000,
             pid: 100,
@@ -1058,5 +1126,175 @@ mod tests {
         assert_eq!(stats.false_wakeup_filtered_count, 2);
         assert_eq!(stats.edges_created, 0);
         assert_eq!(graph.edge_count(), 0);
+    }
+
+    // --- IO dispatch lifecycle (commit-3) -----------------------------------
+    //
+    // The handlers are tested directly rather than through `correlate()`
+    // because commit-3 deliberately produces no observable output (no edges,
+    // no counters — those are commit-4 / commit-5). The only state visible
+    // in-scope is `pending_io`, which lives inside `correlate_events` and is
+    // not exposed to callers.
+
+    #[allow(clippy::similar_names)] // tgid / tid mirror WperfEvent field names
+    fn io_issue_event(ts: u64, tgid: u32, tid: u32, dev: u32, sector: u64) -> WperfEvent {
+        WperfEvent {
+            timestamp_ns: ts,
+            pid: tgid,
+            tid,
+            // io_sector() packs prev_tid | next_tid<<32
+            prev_tid: u32::try_from(sector & 0xFFFF_FFFF).unwrap(),
+            next_tid: u32::try_from(sector >> 32).unwrap(),
+            // io_dev() reads prev_pid
+            prev_pid: dev,
+            // io_nr_sector() reads next_pid — observability-only in Phase 2b
+            next_pid: 8,
+            cpu: 0,
+            event_type: EventType::IoIssue as u8,
+            prev_state: 0,
+            flags: 0,
+        }
+    }
+
+    #[allow(clippy::similar_names)]
+    fn io_complete_event(ts: u64, tgid: u32, tid: u32, dev: u32, sector: u64) -> WperfEvent {
+        WperfEvent {
+            event_type: EventType::IoComplete as u8,
+            timestamp_ns: ts,
+            ..io_issue_event(ts, tgid, tid, dev, sector)
+        }
+    }
+
+    #[test]
+    fn handle_io_issue_records_submitter_and_ts() {
+        let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let ev = io_issue_event(1_000_000, 100, 101, 0x800_0002, 0xDEAD_BEEF_0000_1234);
+
+        handle_io_issue(&ev, &mut pending_io);
+
+        assert_eq!(pending_io.len(), 1);
+        let key = IoKey {
+            dev: 0x800_0002,
+            sector: 0xDEAD_BEEF_0000_1234,
+        };
+        let rec = pending_io.get(&key).expect("IoKey must match");
+        assert_eq!(rec.submitter_tgid, 100);
+        assert_eq!(rec.submitter_tid, 101);
+        assert_eq!(rec.issue_ts_ns, 1_000_000);
+    }
+
+    #[test]
+    fn handle_io_complete_drains_matching_issue() {
+        let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let issue = io_issue_event(1_000_000, 100, 101, 0x800_0002, 0x1000);
+        let complete = io_complete_event(1_500_000, 100, 101, 0x800_0002, 0x1000);
+
+        handle_io_issue(&issue, &mut pending_io);
+        handle_io_complete(&complete, &mut pending_io);
+
+        assert!(pending_io.is_empty(), "issue/complete pair must drain");
+    }
+
+    #[test]
+    fn handle_io_complete_without_matching_issue_is_noop() {
+        // Orphan completion: BPF dropped the issue (per-CPU buffer full) or
+        // buffer reorder/truncation. Commit-5 adds io_orphan_complete_count;
+        // for now, assert no panic and no insertion.
+        let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let complete = io_complete_event(1_500_000, 100, 101, 0x800_0002, 0x1000);
+
+        handle_io_complete(&complete, &mut pending_io);
+
+        assert!(pending_io.is_empty());
+    }
+
+    #[test]
+    fn pending_io_keyed_by_dev_and_sector_not_just_sector() {
+        // Two devices, same sector — must NOT collide. Disambiguation by
+        // (dev, sector) is the whole reason IoKey exists.
+        let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let issue_dev1 = io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x2000);
+        let issue_dev2 = io_issue_event(1_000_001, 200, 201, 0x800_0002, 0x2000);
+
+        handle_io_issue(&issue_dev1, &mut pending_io);
+        handle_io_issue(&issue_dev2, &mut pending_io);
+
+        assert_eq!(pending_io.len(), 2);
+
+        // Completing dev1's IO must not touch dev2's entry.
+        let complete_dev1 = io_complete_event(1_500_000, 100, 101, 0x800_0001, 0x2000);
+        handle_io_complete(&complete_dev1, &mut pending_io);
+
+        assert_eq!(pending_io.len(), 1);
+        let dev2_key = IoKey {
+            dev: 0x800_0002,
+            sector: 0x2000,
+        };
+        assert!(pending_io.contains_key(&dev2_key));
+    }
+
+    #[test]
+    fn concurrent_same_device_multiple_pending() {
+        // Typical case: one tgid submits multiple IOs in flight concurrently
+        // to the same device. Each (dev, sector) is independent.
+        let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        for sector in [0x1000u64, 0x2000, 0x3000, 0x4000] {
+            let ev = io_issue_event(1_000_000 + sector, 100, 101, 0x800_0001, sector);
+            handle_io_issue(&ev, &mut pending_io);
+        }
+
+        assert_eq!(pending_io.len(), 4);
+
+        // Out-of-order completions (NVMe queue reorder is realistic).
+        for sector in [0x3000u64, 0x1000, 0x4000, 0x2000] {
+            let ev = io_complete_event(2_000_000 + sector, 100, 101, 0x800_0001, sector);
+            handle_io_complete(&ev, &mut pending_io);
+        }
+
+        assert!(pending_io.is_empty());
+    }
+
+    #[test]
+    fn repeated_issue_same_key_overwrites() {
+        // A rare case: same (dev, sector) seen twice before any complete.
+        // Possible causes: BPF dropped an intermediate complete, or block
+        // layer reissued a request. Last-writer-wins is the safe default —
+        // matches BPF-side `bpf_map_update_elem(.., BPF_ANY)` semantics
+        // (wperf.bpf.c handle_block_rq_issue).
+        let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let first = io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x1000);
+        let second = io_issue_event(2_000_000, 200, 201, 0x800_0001, 0x1000);
+
+        handle_io_issue(&first, &mut pending_io);
+        handle_io_issue(&second, &mut pending_io);
+
+        assert_eq!(pending_io.len(), 1);
+        let key = IoKey {
+            dev: 0x800_0001,
+            sector: 0x1000,
+        };
+        let rec = pending_io[&key];
+        assert_eq!(rec.submitter_tgid, 200);
+        assert_eq!(rec.submitter_tid, 201);
+        assert_eq!(rec.issue_ts_ns, 2_000_000);
+    }
+
+    #[test]
+    fn io_stream_through_correlate_events_does_not_panic() {
+        // End-to-end: IoIssue / IoComplete events flow through correlate()
+        // without touching unknown counters, edges, or other stats.
+        let events = vec![
+            io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x1000),
+            io_complete_event(1_500_000, 100, 101, 0x800_0001, 0x1000),
+            io_issue_event(2_000_000, 200, 201, 0x800_0002, 0x2000),
+            // No matching complete for this second issue — pending-at-end.
+        ];
+
+        let (graph, stats) = correlate(&events);
+
+        assert_eq!(graph.node_count(), 0);
+        assert_eq!(stats.edges_created, 0);
+        assert_eq!(stats.unknown_event_type_count, 0);
+        assert_eq!(stats.events_processed, 3);
     }
 }

--- a/src/correlate.rs
+++ b/src/correlate.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use serde::Serialize;
 
 use crate::format::event::{EventType, WperfEvent, futex_op};
-use crate::graph::types::{NodeKind, ThreadId, TimeWindow, WaitType};
+use crate::graph::types::{DISK_TID, NodeKind, ThreadId, TimeWindow, WaitType};
 use crate::graph::wfg::WaitForGraph;
 
 /// Linux `TASK_RUNNING` state value. A `sched_switch` with `prev_state == 0`
@@ -232,7 +232,7 @@ pub fn correlate_events(
                 handle_io_issue(event, &mut pending_io);
             }
             Some(EventType::IoComplete) => {
-                handle_io_complete(event, &mut pending_io);
+                handle_io_complete(event, &mut pending_io, &mut graph, &mut stats);
             }
             None => {
                 if stats.unknown_event_type_count == 0 {
@@ -373,10 +373,8 @@ fn handle_futex_wait(event: &WperfEvent, pending_futex: &mut HashMap<u32, Pendin
 /// Handle a `block_rq_issue` event — record the in-flight request so the
 /// matching `block_rq_complete` can recover `(submitter, issue_ts)`.
 ///
-/// Synthetic edge generation against the `block_device:<dev>` pseudo-thread
-/// lands in a later commit (issue #38 commit-4); this commit tracks only the
-/// userspace lifecycle. Orphan / pending-at-end accounting is deferred to
-/// commit-5 (`HealthMetrics`).
+/// Orphan / pending-at-end accounting is deferred to commit-5
+/// (`HealthMetrics`).
 fn handle_io_issue(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo>) {
     pending_io.insert(
         IoKey::from_event(event),
@@ -388,14 +386,46 @@ fn handle_io_issue(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo
     );
 }
 
-/// Handle a `block_rq_complete` event — drain the matching issue record.
+/// Handle a `block_rq_complete` event — drain the matching issue record
+/// and emit the bidirectional User↔PseudoDisk synthetic edge pair.
 ///
-/// BPF re-stamps the original submitter onto the completion event (ADR-009
-/// §3), so the `pid`/`tid` carried here are trustworthy for attribution; the
-/// only job of userspace is to pair with the issue and surface the (delta,
-/// submitter) tuple to commit-4's edge generator.
-fn handle_io_complete(event: &WperfEvent, pending_io: &mut HashMap<IoKey, PendingIo>) {
-    pending_io.remove(&IoKey::from_event(event));
+/// Per ADR-009 §Consequences, Phase 2b uses a single `DISK_TID` pseudo-thread
+/// for all block I/O — per-device pseudo-disks (`block_device:<dev>`) are
+/// deferred to a future issue. The paper's two-edge construction (User→Disk
+/// for initiation, Disk→User for completion) produces a 2-cycle SCC so that
+/// Tarjan analysis can identify I/O-bound Knots; both edges share the same
+/// time window (`issue_ts` → `complete_ts` = service time) and are annotated
+/// with `WaitType::IoBlock`.
+///
+/// Orphan completions (no matching `pending_io` entry — issue was dropped,
+/// predates attach, or key collided) return without mutating the graph;
+/// orphan counters land in commit-5.
+fn handle_io_complete(
+    event: &WperfEvent,
+    pending_io: &mut HashMap<IoKey, PendingIo>,
+    graph: &mut WaitForGraph,
+    stats: &mut CorrelationStats,
+) {
+    let Some(pending) = pending_io.remove(&IoKey::from_event(event)) else {
+        return;
+    };
+
+    // ns → ms truncation — sub-millisecond I/Os (common on NVMe) collapse to
+    // zero-duration windows. This preserves the edge for SCC participation
+    // without introducing floating-point; cascade handles duration==0 windows
+    // correctly (raw_wait = attributed_delay = 0 satisfies I-2 / I-7).
+    let issue_ms = pending.issue_ts_ns / 1_000_000;
+    let complete_ms = event.timestamp_ns / 1_000_000;
+    let window = TimeWindow::new(issue_ms, complete_ms.max(issue_ms));
+
+    let user = ThreadId(i64::from(pending.submitter_tid));
+    let disk = ThreadId(DISK_TID);
+
+    graph.add_node(user, NodeKind::UserThread);
+    graph.add_node(disk, NodeKind::PseudoDisk);
+    graph.add_edge_with_wait_type(user, disk, window, WaitType::IoBlock);
+    graph.add_edge_with_wait_type(disk, user, window, WaitType::IoBlock);
+    stats.edges_created += 2;
 }
 
 /// Handle a `sched_wakeup` or `sched_wakeup_new` event.
@@ -521,10 +551,10 @@ mod tests {
     }
 
     #[test]
-    fn io_discriminants_dispatch_without_graph_mutation() {
-        // commit-3 scaffold: IoIssue / IoComplete dispatch into pending_io
-        // lifecycle handlers but must NOT count as unknown and must NOT
-        // mutate the graph — synth-edge generation lands in commit-4.
+    fn io_discriminants_known_and_emit_synthetic_edge_pair() {
+        // commit-4: a paired IoIssue + IoComplete emits the bidirectional
+        // User↔Disk synthetic edge pair. Discriminants must NOT count as
+        // unknown, and the pair must be annotated with WaitType::IoBlock.
         let io_issue = WperfEvent {
             timestamp_ns: 1_000_000,
             pid: 100,
@@ -544,8 +574,8 @@ mod tests {
             ..io_issue
         };
         let (graph, stats) = correlate(&[io_issue, io_complete]);
-        assert_eq!(graph.node_count(), 0);
-        assert_eq!(stats.edges_created, 0);
+        assert_eq!(graph.node_count(), 2, "user + DISK pseudo-thread");
+        assert_eq!(stats.edges_created, 2, "bidirectional synthetic pair");
         assert_eq!(stats.unknown_event_type_count, 0);
         assert_eq!(stats.events_processed, 2);
     }
@@ -1222,28 +1252,47 @@ mod tests {
     }
 
     #[test]
-    fn handle_io_complete_drains_matching_issue() {
+    fn handle_io_complete_drains_matching_issue_and_emits_edges() {
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let mut graph = WaitForGraph::new();
+        let mut stats = CorrelationStats::default();
         let issue = io_issue_event(1_000_000, 100, 101, 0x800_0002, 0x1000);
         let complete = io_complete_event(1_500_000, 100, 101, 0x800_0002, 0x1000);
 
         handle_io_issue(&issue, &mut pending_io);
-        handle_io_complete(&complete, &mut pending_io);
+        handle_io_complete(&complete, &mut pending_io, &mut graph, &mut stats);
 
         assert!(pending_io.is_empty(), "issue/complete pair must drain");
+        assert_eq!(stats.edges_created, 2, "bidirectional pair = 2 edges");
+        assert_eq!(graph.node_count(), 2, "user + DISK pseudo-thread");
+
+        // Both directions present with WaitType::IoBlock.
+        let edges = graph.all_edges();
+        let user = ThreadId(101);
+        let disk = ThreadId(DISK_TID);
+        assert!(edges.iter().any(|(_, s, d, w)| *s == user
+            && *d == disk
+            && w.wait_type == Some(WaitType::IoBlock)));
+        assert!(edges.iter().any(|(_, s, d, w)| *s == disk
+            && *d == user
+            && w.wait_type == Some(WaitType::IoBlock)));
     }
 
     #[test]
     fn handle_io_complete_without_matching_issue_is_noop() {
-        // Orphan completion: BPF dropped the issue (per-CPU buffer full) or
-        // buffer reorder/truncation. Commit-5 adds io_orphan_complete_count;
-        // for now, assert no panic and no insertion.
+        // Orphan completion: BPF dropped the issue (per-CPU buffer full),
+        // buffer reorder/truncation, or key collided. Commit-5 adds
+        // io_orphan_complete_count; for now, assert no panic + no edges.
         let mut pending_io: HashMap<IoKey, PendingIo> = HashMap::new();
+        let mut graph = WaitForGraph::new();
+        let mut stats = CorrelationStats::default();
         let complete = io_complete_event(1_500_000, 100, 101, 0x800_0002, 0x1000);
 
-        handle_io_complete(&complete, &mut pending_io);
+        handle_io_complete(&complete, &mut pending_io, &mut graph, &mut stats);
 
         assert!(pending_io.is_empty());
+        assert_eq!(stats.edges_created, 0);
+        assert_eq!(graph.node_count(), 0);
     }
 
     #[test]
@@ -1261,7 +1310,9 @@ mod tests {
 
         // Completing dev1's IO must not touch dev2's entry.
         let complete_dev1 = io_complete_event(1_500_000, 100, 101, 0x800_0001, 0x2000);
-        handle_io_complete(&complete_dev1, &mut pending_io);
+        let mut graph = WaitForGraph::new();
+        let mut stats = CorrelationStats::default();
+        handle_io_complete(&complete_dev1, &mut pending_io, &mut graph, &mut stats);
 
         assert_eq!(pending_io.len(), 1);
         let dev2_key = IoKey {
@@ -1289,7 +1340,9 @@ mod tests {
 
         // Completing the large request must not disturb the small one.
         let complete_large = io_complete_event_sized(1_500_000, 200, 201, 0x800_0001, 0x2000, 16);
-        handle_io_complete(&complete_large, &mut pending_io);
+        let mut graph = WaitForGraph::new();
+        let mut stats = CorrelationStats::default();
+        handle_io_complete(&complete_large, &mut pending_io, &mut graph, &mut stats);
 
         assert_eq!(pending_io.len(), 1);
         let small_key = IoKey {
@@ -1315,12 +1368,15 @@ mod tests {
         assert_eq!(pending_io.len(), 4);
 
         // Out-of-order completions (NVMe queue reorder is realistic).
+        let mut graph = WaitForGraph::new();
+        let mut stats = CorrelationStats::default();
         for sector in [0x3000u64, 0x1000, 0x4000, 0x2000] {
             let ev = io_complete_event(2_000_000 + sector, 100, 101, 0x800_0001, sector);
-            handle_io_complete(&ev, &mut pending_io);
+            handle_io_complete(&ev, &mut pending_io, &mut graph, &mut stats);
         }
 
         assert!(pending_io.is_empty());
+        assert_eq!(stats.edges_created, 8, "4 I/Os × 2 edges = 8");
     }
 
     #[test]
@@ -1350,9 +1406,9 @@ mod tests {
     }
 
     #[test]
-    fn io_stream_through_correlate_events_does_not_panic() {
-        // End-to-end: IoIssue / IoComplete events flow through correlate()
-        // without touching unknown counters, edges, or other stats.
+    fn io_stream_through_correlate_events_creates_edge_per_pair() {
+        // End-to-end: one completed I/O pair emits 2 edges (User↔Disk), a
+        // dangling issue (pending-at-end) emits nothing.
         let events = vec![
             io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x1000),
             io_complete_event(1_500_000, 100, 101, 0x800_0001, 0x1000),
@@ -1362,9 +1418,49 @@ mod tests {
 
         let (graph, stats) = correlate(&events);
 
-        assert_eq!(graph.node_count(), 0);
-        assert_eq!(stats.edges_created, 0);
+        assert_eq!(graph.node_count(), 2, "T101 + DISK (T201 never landed)");
+        assert_eq!(stats.edges_created, 2);
         assert_eq!(stats.unknown_event_type_count, 0);
         assert_eq!(stats.events_processed, 3);
+    }
+
+    #[test]
+    fn io_edges_form_scc_for_tarjan() {
+        // Sanity: the bidirectional pair must form a 2-cycle (User→Disk→User)
+        // so Tarjan SCC analysis can identify I/O-bound Knots per ADR-009.
+        // A non-cycling single edge would route I/O threads into a Sink
+        // Collector and miss the Knot classification.
+        let events = vec![
+            io_issue_event(1_000_000, 100, 101, 0x800_0001, 0x1000),
+            io_complete_event(1_500_000, 100, 101, 0x800_0001, 0x1000),
+        ];
+        let (graph, _) = correlate(&events);
+        let user = ThreadId(101);
+        let disk = ThreadId(DISK_TID);
+        let edges = graph.all_edges();
+
+        let forward = edges
+            .iter()
+            .any(|(_, s, d, w)| *s == user && *d == disk && w.wait_type == Some(WaitType::IoBlock));
+        let back = edges
+            .iter()
+            .any(|(_, s, d, w)| *s == disk && *d == user && w.wait_type == Some(WaitType::IoBlock));
+        assert!(
+            forward && back,
+            "must have both directions for SCC formation"
+        );
+
+        // Windows must match: service time is shared across both directions.
+        let forward_weight = edges
+            .iter()
+            .find(|(_, s, d, _)| *s == user && *d == disk)
+            .map(|(_, _, _, w)| w.time_window)
+            .unwrap();
+        let back_weight = edges
+            .iter()
+            .find(|(_, s, d, _)| *s == disk && *d == user)
+            .map(|(_, _, _, w)| w.time_window)
+            .unwrap();
+        assert_eq!(forward_weight, back_weight);
     }
 }

--- a/src/format/event.rs
+++ b/src/format/event.rs
@@ -40,6 +40,8 @@ pub enum EventType {
     WakeupNew = 3,
     Exit = 4,
     FutexWait = 5,
+    IoIssue = 6,
+    IoComplete = 7,
 }
 
 impl EventType {
@@ -50,6 +52,8 @@ impl EventType {
             3 => Some(Self::WakeupNew),
             4 => Some(Self::Exit),
             5 => Some(Self::FutexWait),
+            6 => Some(Self::IoIssue),
+            7 => Some(Self::IoComplete),
             _ => None,
         }
     }
@@ -142,6 +146,24 @@ impl WperfEvent {
     pub fn futex_op(&self) -> u32 {
         self.flags
     }
+
+    /// IO request sector (64-bit, packed). Only meaningful for `IoIssue` / `IoComplete` events.
+    /// Stored as: `prev_tid` = lower 32 bits, `next_tid` = upper 32 bits.
+    pub fn io_sector(&self) -> u64 {
+        u64::from(self.next_tid) << 32 | u64::from(self.prev_tid)
+    }
+
+    /// IO device (`dev_t`, 32-bit). Only meaningful for `IoIssue` / `IoComplete` events.
+    /// ADR-009 / issue #38 C11: observability-only in Phase 2b — MUST NOT be used for
+    /// graph dispatch. Retained for forward-compat with per-device disk nodes (#115).
+    pub fn io_dev(&self) -> u32 {
+        self.prev_pid
+    }
+
+    /// IO request size in 512-byte sectors. Only meaningful for `IoIssue` / `IoComplete` events.
+    pub fn io_nr_sector(&self) -> u32 {
+        self.next_pid
+    }
 }
 
 #[cfg(test)]
@@ -228,12 +250,63 @@ mod tests {
         assert_eq!(EventType::from_u8(3), Some(EventType::WakeupNew));
         assert_eq!(EventType::from_u8(4), Some(EventType::Exit));
         assert_eq!(EventType::from_u8(5), Some(EventType::FutexWait));
+        assert_eq!(EventType::from_u8(6), Some(EventType::IoIssue));
+        assert_eq!(EventType::from_u8(7), Some(EventType::IoComplete));
     }
 
     #[test]
     fn event_type_enum_unknown() {
         assert_eq!(EventType::from_u8(0), None);
+        assert_eq!(EventType::from_u8(8), None);
         assert_eq!(EventType::from_u8(255), None);
+    }
+
+    fn sample_io_issue_event() -> WperfEvent {
+        WperfEvent {
+            timestamp_ns: 1_000_200_000,
+            pid: 300,
+            tid: 301,
+            prev_tid: 0x0000_0040u32, // sector lower 32 (sector = 64)
+            next_tid: 0x0000_0000u32, // sector upper 32
+            prev_pid: 0x0000_0801u32, // dev_t (major=8, minor=1; observability-only)
+            next_pid: 8,              // nr_sector = 8 (4KiB)
+            cpu: 1,
+            event_type: EventType::IoIssue as u8,
+            prev_state: 0,
+            flags: 0,
+        }
+    }
+
+    #[test]
+    fn io_event_roundtrip() {
+        let ev = sample_io_issue_event();
+        let bytes = ev.to_bytes();
+        let parsed = WperfEvent::from_bytes(&bytes);
+        assert_eq!(ev, parsed);
+        assert_eq!(parsed.event_type_enum(), Some(EventType::IoIssue));
+    }
+
+    #[test]
+    fn io_sector_accessor() {
+        let ev = sample_io_issue_event();
+        assert_eq!(ev.io_sector(), 64u64);
+
+        let mut ev2 = ev;
+        ev2.prev_tid = 0xFFFF_FFFFu32;
+        ev2.next_tid = 0x0000_0001u32;
+        assert_eq!(ev2.io_sector(), 0x0000_0001_FFFF_FFFFu64);
+    }
+
+    #[test]
+    fn io_dev_accessor() {
+        let ev = sample_io_issue_event();
+        assert_eq!(ev.io_dev(), 0x0000_0801u32);
+    }
+
+    #[test]
+    fn io_nr_sector_accessor() {
+        let ev = sample_io_issue_event();
+        assert_eq!(ev.io_nr_sector(), 8);
     }
 
     #[test]

--- a/src/graph/sweep.rs
+++ b/src/graph/sweep.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeSet;
 
-use super::types::{ElementaryInterval, ThreadId, TimeWindow};
+use super::types::{EdgeKind, ElementaryInterval, ThreadId, TimeWindow};
 use super::wfg::WaitForGraph;
 
 use petgraph::Direction;
@@ -31,10 +31,25 @@ pub fn sweep_line_partition(
         return Vec::new();
     };
 
-    // Collect clipped intervals: (clipped_window, target_tid)
+    // Collect clipped intervals: (clipped_window, target_tid).
+    //
+    // ADR-009 Amendment 2026-04-25 (final-design.md §3.3): synthetic
+    // closure-return edges (`EdgeKind::SyntheticClosureReturn`) are
+    // cascade-terminal — they participate in Tarjan SCC analysis but
+    // are NOT traversed by cascade redistribution. Skip them here so
+    // recursion into the pseudo-thread sees no outgoing dependencies
+    // (the pseudo-thread becomes a leaf for cascade purposes). The
+    // analogous filter on incoming edges lives in
+    // `count_concurrent_waiters` (engine.rs); both filters MUST be
+    // applied — applying only one leaves the divisor polluted by
+    // bookkeeping edges and silently halves cascade transfer on the
+    // forward direction (PR #120 5-way thread, Probe Gap 5).
     let mut clipped: Vec<(TimeWindow, ThreadId)> = Vec::new();
     for edge_ref in graph.graph.edges_directed(node_idx, Direction::Outgoing) {
         let ew = edge_ref.weight();
+        if ew.kind == EdgeKind::SyntheticClosureReturn {
+            continue;
+        }
         if let Some(overlap) = window.overlap(&ew.time_window) {
             let target_tid = graph.graph[edge_ref.target()].tid;
             clipped.push((overlap, target_tid));

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -79,6 +79,10 @@ pub enum WaitType {
     FutexLockPi,
     FutexWaitBitset,
     FutexWaitRequeuePi,
+    /// Block-IO synthetic edge (User↔PseudoDisk, both directions share this
+    /// annotation — ADR-009 §Consequences). Edge weight = I/O service time
+    /// (`block_rq_complete_ts - block_rq_issue_ts`).
+    IoBlock,
 }
 
 /// Edge metadata in the Wait-For Graph.

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -85,6 +85,38 @@ pub enum WaitType {
     IoBlock,
 }
 
+/// Edge category for cascade traversal control (ADR-009 *Amendment
+/// 2026-04-25*, final-design.md §3.3).
+///
+/// `Normal` edges participate fully in cascade redistribution.
+///
+/// `SyntheticClosureReturn` edges (e.g., Disk→User completion-event edges,
+/// and the analogous Network→User and Softirq→User edges introduced by
+/// future phases) are SCC closure bookkeeping — they participate in
+/// Tarjan SCC analysis and Knot detection but are **cascade-terminal**:
+/// the cascade engine skips them in both `sweep_line_partition`
+/// (outgoing-traversal entry point) and `count_concurrent_waiters`
+/// (incoming-edge enumerator). Forward synthetic edges (User→Disk
+/// issue-event edges) remain `Normal` — they carry real I/O service
+/// time and participate in cascade as inbound waits.
+///
+/// Phase 2c forward-compat: `PseudoNic` / `PseudoSoftirq` mirror return
+/// edges MUST reuse this same marker. The cascade engine's filter
+/// predicate is keyed off this enum value; additional cascade-terminal
+/// classes would require either a new enum variant or migration of the
+/// predicate, both of which are out of scope for this Phase 2b
+/// amendment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeKind {
+    /// Real wait dependency. Default for `add_edge` and
+    /// `add_edge_with_wait_type`.
+    #[default]
+    Normal,
+    /// SCC closure-return edge (ADR-009 cascade-terminal).
+    SyntheticClosureReturn,
+}
+
 /// Edge metadata in the Wait-For Graph.
 #[derive(Debug, Clone, Serialize)]
 pub struct EdgeWeight {
@@ -92,6 +124,10 @@ pub struct EdgeWeight {
     pub raw_wait_ms: u64,
     pub attributed_delay_ms: u64,
     pub wait_type: Option<WaitType>,
+    /// Cascade-traversal classification. `Normal` for real wait
+    /// dependencies (default); `SyntheticClosureReturn` for ADR-009
+    /// cascade-terminal closure-return edges.
+    pub kind: EdgeKind,
 }
 
 impl EdgeWeight {
@@ -102,12 +138,25 @@ impl EdgeWeight {
             raw_wait_ms: raw,
             attributed_delay_ms: raw,
             wait_type: None,
+            kind: EdgeKind::Normal,
         }
     }
 
     pub fn with_wait_type(time_window: TimeWindow, wait_type: WaitType) -> Self {
         let mut this = Self::new(time_window);
         this.wait_type = Some(wait_type);
+        this
+    }
+
+    /// Constructor for ADR-009 synthetic closure-return edges (cascade-
+    /// terminal). The `wait_type` is annotated for downstream report
+    /// rendering (typically `WaitType::IoBlock` for block-IO return);
+    /// the kind is fixed at `SyntheticClosureReturn` so the cascade
+    /// engine's `sweep_line_partition` and `count_concurrent_waiters`
+    /// filters skip it consistently.
+    pub fn synthetic_closure_return(time_window: TimeWindow, wait_type: WaitType) -> Self {
+        let mut this = Self::with_wait_type(time_window, wait_type);
+        this.kind = EdgeKind::SyntheticClosureReturn;
         this
     }
 }

--- a/src/graph/wfg.rs
+++ b/src/graph/wfg.rs
@@ -148,13 +148,24 @@ impl WaitForGraph {
         for (&tid, &idx) in &self.node_map {
             new.add_node(tid, self.graph[idx].kind);
         }
-        // Clone edges
+        // Clone edges — preserve wait_type across cascade so downstream
+        // consumers (HealthMetrics attributed_delay_ratio, DOT rendering,
+        // SCC annotations) can still inspect per-edge semantics after
+        // redistribution. Attribution is reset by EdgeWeight::new /
+        // with_wait_type (both set attributed_delay_ms = raw_wait_ms).
         for eidx in self.graph.edge_indices() {
             let (src, dst) = self.graph.edge_endpoints(eidx).unwrap();
             let src_tid = self.graph[src].tid;
             let dst_tid = self.graph[dst].tid;
             let weight = &self.graph[eidx];
-            new.add_edge(src_tid, dst_tid, weight.time_window);
+            match weight.wait_type {
+                Some(wt) => {
+                    new.add_edge_with_wait_type(src_tid, dst_tid, weight.time_window, wt);
+                }
+                None => {
+                    new.add_edge(src_tid, dst_tid, weight.time_window);
+                }
+            }
         }
         new
     }

--- a/src/graph/wfg.rs
+++ b/src/graph/wfg.rs
@@ -8,7 +8,7 @@ use petgraph::Direction;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 
-use super::types::{EdgeWeight, NodeKind, NodeWeight, ThreadId, TimeWindow, WaitType};
+use super::types::{EdgeKind, EdgeWeight, NodeKind, NodeWeight, ThreadId, TimeWindow, WaitType};
 
 /// The Wait-For Graph. Directed graph where:
 /// - Nodes = threads (or pseudo-threads)
@@ -60,6 +60,30 @@ impl WaitForGraph {
             src_idx,
             dst_idx,
             EdgeWeight::with_wait_type(window, wait_type),
+        )
+    }
+
+    /// Add an ADR-009 synthetic closure-return edge (cascade-terminal).
+    ///
+    /// The edge is annotated with `wait_type` for downstream report
+    /// rendering and marked with `EdgeKind::SyntheticClosureReturn` so
+    /// that `sweep_line_partition` and `count_concurrent_waiters` skip
+    /// it during cascade redistribution. The edge still participates
+    /// in Tarjan SCC analysis and Knot detection (final-design.md
+    /// §3.3).
+    pub fn add_synthetic_closure_return(
+        &mut self,
+        src: ThreadId,
+        dst: ThreadId,
+        window: TimeWindow,
+        wait_type: WaitType,
+    ) -> EdgeIndex {
+        let src_idx = *self.node_map.get(&src).expect("src node not in graph");
+        let dst_idx = *self.node_map.get(&dst).expect("dst node not in graph");
+        self.graph.add_edge(
+            src_idx,
+            dst_idx,
+            EdgeWeight::synthetic_closure_return(window, wait_type),
         )
     }
 
@@ -148,21 +172,27 @@ impl WaitForGraph {
         for (&tid, &idx) in &self.node_map {
             new.add_node(tid, self.graph[idx].kind);
         }
-        // Clone edges — preserve wait_type across cascade so downstream
-        // consumers (HealthMetrics attributed_delay_ratio, DOT rendering,
-        // SCC annotations) can still inspect per-edge semantics after
-        // redistribution. Attribution is reset by EdgeWeight::new /
-        // with_wait_type (both set attributed_delay_ms = raw_wait_ms).
+        // Clone edges — preserve wait_type AND kind across cascade so
+        // downstream consumers (HealthMetrics attributed_delay_ratio,
+        // DOT rendering, SCC annotations, and the cascade engine's own
+        // SCR filter) can inspect per-edge semantics after
+        // redistribution. Attribution is reset by EdgeWeight constructors
+        // (all set attributed_delay_ms = raw_wait_ms).
         for eidx in self.graph.edge_indices() {
             let (src, dst) = self.graph.edge_endpoints(eidx).unwrap();
             let src_tid = self.graph[src].tid;
             let dst_tid = self.graph[dst].tid;
             let weight = &self.graph[eidx];
-            match weight.wait_type {
-                Some(wt) => {
+            match (weight.wait_type, weight.kind) {
+                (Some(wt), EdgeKind::SyntheticClosureReturn) => {
+                    new.add_synthetic_closure_return(src_tid, dst_tid, weight.time_window, wt);
+                }
+                (Some(wt), EdgeKind::Normal) => {
                     new.add_edge_with_wait_type(src_tid, dst_tid, weight.time_window, wt);
                 }
-                None => {
+                (None, _) => {
+                    // Edges without wait_type are by construction Normal
+                    // (no SCR factory leaves wait_type unset).
                     new.add_edge(src_tid, dst_tid, weight.time_window);
                 }
             }

--- a/src/graph/wfg.rs
+++ b/src/graph/wfg.rs
@@ -8,7 +8,7 @@ use petgraph::Direction;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 
-use super::types::{EdgeKind, EdgeWeight, NodeKind, NodeWeight, ThreadId, TimeWindow, WaitType};
+use super::types::{EdgeWeight, NodeKind, NodeWeight, ThreadId, TimeWindow, WaitType};
 
 /// The Wait-For Graph. Directed graph where:
 /// - Nodes = threads (or pseudo-threads)
@@ -175,27 +175,21 @@ impl WaitForGraph {
         // Clone edges — preserve wait_type AND kind across cascade so
         // downstream consumers (HealthMetrics attributed_delay_ratio,
         // DOT rendering, SCC annotations, and the cascade engine's own
-        // SCR filter) can inspect per-edge semantics after
-        // redistribution. Attribution is reset by EdgeWeight constructors
-        // (all set attributed_delay_ms = raw_wait_ms).
+        // SCR filter) can inspect per-edge semantics after redistribution.
+        // Direct EdgeWeight clone + attribution reset replaces the older
+        // factory-dispatch match — fewer arms, single source of truth for
+        // per-edge state. NodeIndex must be resolved through `node_map`
+        // because `new` was rebuilt in sorted-tid order (BTreeMap), so its
+        // NodeIndex assignments do not match `self.graph`.
         for eidx in self.graph.edge_indices() {
             let (src, dst) = self.graph.edge_endpoints(eidx).unwrap();
             let src_tid = self.graph[src].tid;
             let dst_tid = self.graph[dst].tid;
-            let weight = &self.graph[eidx];
-            match (weight.wait_type, weight.kind) {
-                (Some(wt), EdgeKind::SyntheticClosureReturn) => {
-                    new.add_synthetic_closure_return(src_tid, dst_tid, weight.time_window, wt);
-                }
-                (Some(wt), EdgeKind::Normal) => {
-                    new.add_edge_with_wait_type(src_tid, dst_tid, weight.time_window, wt);
-                }
-                (None, _) => {
-                    // Edges without wait_type are by construction Normal
-                    // (no SCR factory leaves wait_type unset).
-                    new.add_edge(src_tid, dst_tid, weight.time_window);
-                }
-            }
+            let new_src = new.node_map[&src_tid];
+            let new_dst = new.node_map[&dst_tid];
+            let mut new_weight = self.graph[eidx].clone();
+            new_weight.attributed_delay_ms = new_weight.raw_wait_ms;
+            new.graph.add_edge(new_src, new_dst, new_weight);
         }
         new
     }

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -90,6 +90,10 @@ pub struct FeatureMatrix {
     pub has_cgroupv2: bool,
     /// Whether `fentry` attachment is supported (kernel 5.5+).
     pub has_fentry: bool,
+    /// Whether `block_rq_issue` uses the post-5.11 single-arg form (rq at ctx[0]).
+    /// False → pre-5.11 dual-arg form (q, rq) with rq at ctx[1]. Consumed by
+    /// Phase 2b #38 P2b-01 `block_rq` tracepoints (`wperf.bpf.c` `targ_single` rodata).
+    pub block_rq_issue_single_arg: bool,
 }
 
 /// Sysfs/tracefs paths used by the probing layer.
@@ -251,17 +255,23 @@ pub fn probe_bpf_loop() -> Result<bool, ProbeError> {
 
 /// Probe whether `tp_btf` attachment is supported for scheduler tracepoints.
 ///
-/// Requires loading a minimal BPF program that attaches to `tp_btf/sched_switch`.
-/// Falls back to `RawTp` if the attach fails.
+/// Uses BTF typedef presence (`btf_trace_sched_switch`) as the gating signal:
+/// the typedef is emitted only when `DECLARE_TRACE(sched_switch, ...)` reaches
+/// BTF (kernel 5.5+ with `CONFIG_DEBUG_INFO_BTF`). An absent typedef means
+/// `tp_btf/sched_switch` is not loadable.
 ///
-/// Full implementation depends on skeleton infrastructure from task #5.
+/// Note: typedef presence is necessary but not sufficient — a restrictive BPF
+/// security policy or missing `CAP_BPF` can still block attach at load time.
+/// Those failures surface in `record.rs` at `open_skel.load()` / `attach()`.
 #[cfg(feature = "bpf")]
 pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
-    // TODO(probe): Implement minimal tp_btf attach test once skeleton infra lands.
-    // For now, attempt detection via BTF type existence as a proxy:
-    // if /sys/kernel/btf/vmlinux exists and kernel >= 5.5, tp_btf is likely available.
-    // The real test will use an actual attach attempt.
-    Ok(TracepointMode::RawTp)
+    use std::ffi::CString;
+    let name = CString::new("btf_trace_sched_switch").expect("literal has no NUL");
+    if btf_typedef_func_proto_vlen(&name).is_some() {
+        Ok(TracepointMode::TpBtf)
+    } else {
+        Ok(TracepointMode::RawTp)
+    }
 }
 
 /// Stub without `libbpf-rs`. Always returns `RawTp`.
@@ -269,6 +279,126 @@ pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
 #[allow(clippy::unnecessary_wraps)]
 pub fn probe_tp_btf() -> Result<TracepointMode, ProbeError> {
     Ok(TracepointMode::RawTp)
+}
+
+/// Probe whether `block_rq_issue` uses the post-5.11 single-arg form.
+///
+/// Kernel 5.11 commit `a54895fa` dropped the `request_queue *q` from
+/// `block_rq_issue`. The BPF tracepoint ABI flipped accordingly:
+///   - pre-5.11: args = `(__data, q, rq)` — `rq` at `ctx[1]`, vlen=3
+///   - 5.11+   : args = `(__data, rq)`    — `rq` at `ctx[0]`, vlen=2
+///
+/// This probe inspects the `btf_trace_block_rq_issue` `FUNC_PROTO` vlen. When
+/// BTF lacks the typedef (kernel < 5.8, `raw_tp`-only path), falls back to
+/// `uname()` — the `raw_tp` ABI flipped at the same kernel revision.
+#[cfg(feature = "bpf")]
+pub fn probe_block_rq_issue_single_arg() -> Result<bool, ProbeError> {
+    use std::ffi::CString;
+    let name = CString::new("btf_trace_block_rq_issue").expect("literal has no NUL");
+    match btf_typedef_func_proto_vlen(&name) {
+        Some(vlen) => Ok(vlen == 2),
+        None => Ok(kernel_version_ge(5, 11)),
+    }
+}
+
+/// Stub without `libbpf-rs`. Defaults to single-arg form (matches BPF rodata default).
+#[cfg(not(feature = "bpf"))]
+#[allow(clippy::unnecessary_wraps)]
+pub fn probe_block_rq_issue_single_arg() -> Result<bool, ProbeError> {
+    Ok(true)
+}
+
+/// RAII guard for a loaded vmlinux BTF. `btf__free` on drop.
+#[cfg(feature = "bpf")]
+struct BtfGuard(*mut libbpf_sys::btf);
+
+#[cfg(feature = "bpf")]
+impl BtfGuard {
+    fn load_vmlinux() -> Option<Self> {
+        let p = unsafe { libbpf_sys::btf__load_vmlinux_btf() };
+        if p.is_null() {
+            None
+        } else {
+            Some(Self(p))
+        }
+    }
+}
+
+#[cfg(feature = "bpf")]
+impl Drop for BtfGuard {
+    fn drop(&mut self) {
+        unsafe { libbpf_sys::btf__free(self.0) };
+    }
+}
+
+/// Given a typedef name, navigate typedef → ptr → `FUNC_PROTO` and return vlen.
+///
+/// Returns `None` if BTF is unavailable, the typedef is absent, or the type
+/// chain doesn't match the expected `typedef ptr-to-func-proto` shape.
+#[cfg(feature = "bpf")]
+fn btf_typedef_func_proto_vlen(name: &std::ffi::CStr) -> Option<u16> {
+    const BTF_KIND_PTR: u32 = 2;
+    const BTF_KIND_TYPEDEF: u32 = 8;
+    const BTF_KIND_FUNC_PROTO: u32 = 13;
+
+    let btf = BtfGuard::load_vmlinux()?;
+    unsafe {
+        let type_id = libbpf_sys::btf__find_by_name_kind(btf.0, name.as_ptr(), BTF_KIND_TYPEDEF);
+        if type_id < 0 {
+            return None;
+        }
+        #[allow(clippy::cast_sign_loss)]
+        let t1 = libbpf_sys::btf__type_by_id(btf.0, type_id as u32);
+        if t1.is_null() {
+            return None;
+        }
+        let t2 = libbpf_sys::btf__type_by_id(btf.0, (*t1).__bindgen_anon_1.type_);
+        if t2.is_null() || btf_kind((*t2).info) != BTF_KIND_PTR {
+            return None;
+        }
+        let t3 = libbpf_sys::btf__type_by_id(btf.0, (*t2).__bindgen_anon_1.type_);
+        if t3.is_null() || btf_kind((*t3).info) != BTF_KIND_FUNC_PROTO {
+            return None;
+        }
+        Some(btf_vlen((*t3).info))
+    }
+}
+
+#[cfg(feature = "bpf")]
+#[inline]
+const fn btf_kind(info: u32) -> u32 {
+    (info >> 24) & 0x1f
+}
+
+#[cfg(feature = "bpf")]
+#[inline]
+const fn btf_vlen(info: u32) -> u16 {
+    (info & 0xffff) as u16
+}
+
+/// Read kernel release via `uname(2)` and compare against (major, minor).
+///
+/// Returns `true` on probe failure — bias toward the modern form, since a
+/// misread is less harmful than a silently-wrong pre-5.11 attach on a new kernel.
+#[cfg(feature = "bpf")]
+fn kernel_version_ge(major: u32, minor: u32) -> bool {
+    let mut uts: libc::utsname = unsafe { std::mem::zeroed() };
+    if unsafe { libc::uname(&raw mut uts) } != 0 {
+        return true;
+    }
+    let release_ptr = uts.release.as_ptr().cast::<u8>();
+    let release_bytes = unsafe { std::slice::from_raw_parts(release_ptr, uts.release.len()) };
+    let end = release_bytes
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(release_bytes.len());
+    let Ok(release) = std::str::from_utf8(&release_bytes[..end]) else {
+        return true;
+    };
+    let mut parts = release.split(['.', '-']);
+    let maj: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let min: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (maj, min) >= (major, minor)
 }
 
 /// Probe whether `fentry` attachment is supported.
@@ -325,6 +455,10 @@ pub fn probe_all(paths: &ProbePaths<'_>) -> Result<FeatureMatrix, ProbeError> {
         eprintln!("probe: fentry probe failed ({e}), assuming unavailable");
         false
     });
+    let block_rq_issue_single_arg = probe_block_rq_issue_single_arg().unwrap_or_else(|e| {
+        eprintln!("probe: block_rq_issue arity probe failed ({e}), assuming single-arg");
+        true
+    });
 
     Ok(FeatureMatrix {
         transport,
@@ -333,6 +467,7 @@ pub fn probe_all(paths: &ProbePaths<'_>) -> Result<FeatureMatrix, ProbeError> {
         has_bpf_loop,
         has_cgroupv2,
         has_fentry,
+        block_rq_issue_single_arg,
     })
 }
 
@@ -510,6 +645,11 @@ mod tests {
         assert!(!probe_fentry().unwrap());
     }
 
+    #[test]
+    fn block_rq_issue_single_arg_stub_returns_true() {
+        assert!(probe_block_rq_issue_single_arg().unwrap());
+    }
+
     // -- Composite: probe_all --
 
     #[test]
@@ -528,6 +668,7 @@ mod tests {
         assert_eq!(matrix.tracepoint, TracepointMode::RawTp);
         assert!(!matrix.has_bpf_loop);
         assert!(!matrix.has_fentry);
+        assert!(matrix.block_rq_issue_single_arg);
     }
 
     #[test]

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -382,13 +382,11 @@ fn kernel_version_ge(major: u32, minor: u32) -> bool {
     if unsafe { libc::uname(&raw mut uts) } != 0 {
         return true;
     }
-    let release_ptr = uts.release.as_ptr().cast::<u8>();
-    let release_bytes = unsafe { std::slice::from_raw_parts(release_ptr, uts.release.len()) };
-    let end = release_bytes
-        .iter()
-        .position(|&b| b == 0)
-        .unwrap_or(release_bytes.len());
-    let Ok(release) = std::str::from_utf8(&release_bytes[..end]) else {
+    // SAFETY: `uname(2)` guarantees `uts.release` is NUL-terminated on
+    // success. `CStr::from_ptr` finds the terminator and returns a slice
+    // bounded by it; UTF-8 validation handled by `to_str`.
+    let release_cstr = unsafe { std::ffi::CStr::from_ptr(uts.release.as_ptr()) };
+    let Ok(release) = release_cstr.to_str() else {
         return true;
     };
     let mut parts = release.split(['.', '-']);

--- a/src/probe/features.rs
+++ b/src/probe/features.rs
@@ -316,11 +316,7 @@ struct BtfGuard(*mut libbpf_sys::btf);
 impl BtfGuard {
     fn load_vmlinux() -> Option<Self> {
         let p = unsafe { libbpf_sys::btf__load_vmlinux_btf() };
-        if p.is_null() {
-            None
-        } else {
-            Some(Self(p))
-        }
+        if p.is_null() { None } else { Some(Self(p)) }
     }
 }
 

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -2,6 +2,6 @@ mod features;
 
 pub use features::{
     FeatureMatrix, ProbeError, ProbePaths, TracepointMode, TransportMode, probe_all,
-    probe_bpf_loop, probe_btf, probe_cgroupv2, probe_fentry, probe_kprobe, probe_ringbuf,
-    probe_tp_btf, probe_tracepoint,
+    probe_block_rq_issue_single_arg, probe_bpf_loop, probe_btf, probe_cgroupv2, probe_fentry,
+    probe_kprobe, probe_ringbuf, probe_tp_btf, probe_tracepoint,
 };

--- a/src/record.rs
+++ b/src/record.rs
@@ -163,14 +163,26 @@ fn record_impl(args: &RecordArgs, stop_requested: &Arc<AtomicBool>) -> Result<()
         TracepointMode::TpBtf => {
             open_skel.progs.handle_sched_switch_raw.set_autoload(false);
             open_skel.progs.handle_sched_wakeup_raw.set_autoload(false);
-            open_skel.progs.handle_block_rq_issue_raw.set_autoload(false);
-            open_skel.progs.handle_block_rq_complete_raw.set_autoload(false);
+            open_skel
+                .progs
+                .handle_block_rq_issue_raw
+                .set_autoload(false);
+            open_skel
+                .progs
+                .handle_block_rq_complete_raw
+                .set_autoload(false);
         }
         TracepointMode::RawTp => {
             open_skel.progs.handle_sched_switch_btf.set_autoload(false);
             open_skel.progs.handle_sched_wakeup_btf.set_autoload(false);
-            open_skel.progs.handle_block_rq_issue_btf.set_autoload(false);
-            open_skel.progs.handle_block_rq_complete_btf.set_autoload(false);
+            open_skel
+                .progs
+                .handle_block_rq_issue_btf
+                .set_autoload(false);
+            open_skel
+                .progs
+                .handle_block_rq_complete_btf
+                .set_autoload(false);
         }
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -163,10 +163,14 @@ fn record_impl(args: &RecordArgs, stop_requested: &Arc<AtomicBool>) -> Result<()
         TracepointMode::TpBtf => {
             open_skel.progs.handle_sched_switch_raw.set_autoload(false);
             open_skel.progs.handle_sched_wakeup_raw.set_autoload(false);
+            open_skel.progs.handle_block_rq_issue_raw.set_autoload(false);
+            open_skel.progs.handle_block_rq_complete_raw.set_autoload(false);
         }
         TracepointMode::RawTp => {
             open_skel.progs.handle_sched_switch_btf.set_autoload(false);
             open_skel.progs.handle_sched_wakeup_btf.set_autoload(false);
+            open_skel.progs.handle_block_rq_issue_btf.set_autoload(false);
+            open_skel.progs.handle_block_rq_complete_btf.set_autoload(false);
         }
     }
 
@@ -177,12 +181,15 @@ fn record_impl(args: &RecordArgs, stop_requested: &Arc<AtomicBool>) -> Result<()
         .ok_or_else(|| RecordError::Bpf("BSS data not available".into()))?
         .self_tgid = global_tgid();
 
-    open_skel
-        .maps
-        .rodata_data
-        .as_mut()
-        .ok_or_else(|| RecordError::Bpf("rodata not available".into()))?
-        .enable_futex_tracing = true;
+    {
+        let rodata = open_skel
+            .maps
+            .rodata_data
+            .as_mut()
+            .ok_or_else(|| RecordError::Bpf("rodata not available".into()))?;
+        rodata.enable_futex_tracing = true;
+        rodata.targ_single = features.block_rq_issue_single_arg;
+    }
 
     if features.transport == TransportMode::RingBuf {
         open_skel

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,6 +7,7 @@
 //! This is NOT the final §1.2 / §5.1 self-contained HTML report (Phase 3).
 //! See plan v2 for the explicit JSON field inventory and deferred fields.
 
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufWriter, Read, Seek, Write};
 
@@ -138,12 +139,27 @@ pub struct HealthMetrics {
     /// collision window Gemini flagged on PR #120 — if this fires under
     /// real workloads, the event ABI needs to carry `struct request *`.
     pub io_userspace_pair_collision_count: Option<u64>,
-    /// Fraction of block-IO raw wait time that flowed through the cascade
-    /// to become attributed delay on `WaitType::IoBlock` edges. Phase 2b
-    /// gate: `≥ 0.70` (final-design.md §3.8). `None` when no `IoBlock`
-    /// edges exist (tracing disabled or no I/O observed) or when total
-    /// `raw_wait` is zero (all sub-ms I/Os — ratio is undefined).
-    pub attributed_delay_ratio: Option<f64>,
+    /// Per-pseudo-thread block-IO attribution ratios, keyed by the IO
+    /// pseudo-thread label (`"disk"`, `"nic"`, `"softirq"`).
+    ///
+    /// Encodes the §7.3 per-P quantification verbatim: for each IO
+    /// pseudo-thread `P`, `attributed_delay_ratio(P) = Σ(e.attributed_delay_ms)
+    /// / Σ(e.raw_wait_ms)` over edges where `e.dst == P` AND
+    /// `e.kind != EdgeKind::SyntheticClosureReturn`. Pseudo-threads whose
+    /// raw-wait sum is zero (all sub-ms I/Os collapsed to zero-duration
+    /// windows) are **omitted** from the map, matching the §7.3 P-level
+    /// `None` semantic.
+    ///
+    /// Outer `None` encodes §7.3 condition (b) — the hard precondition
+    /// that at least one IO pseudo-thread has a defined ratio. The Phase
+    /// 2b gate is `not None AND every value in [0.70, 1.0]`. CI tri-state
+    /// mapping (gate fail / pass / N/A) is applied at the test-runner
+    /// level per §7.3 multi-pseudo-thread scope (a)+(b).
+    ///
+    /// Phase 2c forward-compat: when NIC/Softirq pseudo-threads enter the
+    /// WFG, they will appear as additional keys (`"nic"`, `"softirq"`)
+    /// alongside `"disk"` with no spec amendment required.
+    pub attributed_delay_ratio: Option<BTreeMap<String, f64>>,
 }
 
 /// CLI entry point: opens the file, runs the pipeline, writes output to stdout.
@@ -241,60 +257,88 @@ pub fn build_report<R: Read + Seek>(
 }
 
 /// Compute the Phase 2b `attributed_delay_ratio` per the formal §7.3
-/// definition (final-design.md, post-PR-#121 amendment):
+/// definition (final-design.md, post-PR-#121 amendment), returning a
+/// **per-IO-pseudo-thread** map.
 ///
-/// `ratio = Σ(e.attributed_delay_ms) / Σ(e.raw_wait_ms)` for every edge
-/// `e` where `e.dst` is an IO pseudo-thread AND
-/// `e.kind != EdgeKind::SyntheticClosureReturn`.
+/// For each IO pseudo-thread `P`:
 ///
-/// The aggregate sums over all IO pseudo-thread destinations (currently
-/// only `PseudoDisk`; Phase 2c adds `PseudoNic` / `PseudoSoftirq`). This
-/// matches the gate's measurement domain — only forward edges entering
-/// pseudo-threads carry real I/O service-time blame; closure-return
-/// edges are SCC bookkeeping per ADR-009 *Amendment 2026-04-25* and
-/// have no semantic wait time.
+/// `attributed_delay_ratio(P) = Σ(e.attributed_delay_ms) / Σ(e.raw_wait_ms)`
 ///
-/// Returns `None` when no qualifying edge exists (no observable IO in
-/// this workload) or when total `raw_wait` sums to zero (all sub-ms
-/// I/Os collapsed to zero-duration windows). Per §7.3 the Phase 2b
-/// gate treats `None` as a hard precondition failure (workload didn't
-/// exercise the IO Attribution gate's subject); CI tri-state mapping
-/// is applied at the test-runner level.
-fn compute_io_attributed_delay_ratio(cascaded: &crate::graph::wfg::WaitForGraph) -> Option<f64> {
+/// over every edge `e` where `e.dst == P` AND
+/// `e.kind != EdgeKind::SyntheticClosureReturn`. Closure-return edges
+/// are SCC bookkeeping per [ADR-009 *Amendment 2026-04-25*](../decisions/ADR-009.md)
+/// and have no semantic wait time.
+///
+/// Map keys are stable IO-pseudo-thread labels (`"disk"`, `"nic"`,
+/// `"softirq"`). Pseudo-threads with no inbound non-SCR edges, or whose
+/// raw-wait sum is zero (typical of sub-millisecond IO bursts where
+/// ns→ms truncation collapses windows), are **omitted** from the map —
+/// the §7.3 P-level `None` semantic.
+///
+/// Outer `None` encodes §7.3 condition (b): the hard precondition that
+/// at least one IO pseudo-thread has a defined ratio. A workload that
+/// produces no defined per-P ratio at all fails the Phase 2b gate,
+/// preventing silent-pass under cascade bugs that zero out upstream
+/// `raw_wait`. CI tri-state mapping (gate fail / pass / N/A) is applied
+/// at the test-runner level per §7.3 multi-pseudo-thread scope (a)+(b).
+///
+/// Per-P (not aggregate) is mandatory per §7.3 (a) "for every IO
+/// pseudo-thread `P` with a defined `attributed_delay_ratio(P)` ≥ 0.70".
+/// Aggregate would mask Phase 2c regressions (e.g. DISK 1.0 + NIC 0.5
+/// → aggregate 0.75 ✓ silently masks NIC ≥ 0.70 violation). 5-way
+/// reviewer convergence locked per-P contract on 2026-04-27 (Oracle
+/// msg=62ec6c36 + Probe msg=a1f9b1bf + Critic msg=5bcd369d + Challenger
+/// msg=a21b9b2b + Maestro msg=54b49254).
+fn compute_io_attributed_delay_ratio(
+    cascaded: &crate::graph::wfg::WaitForGraph,
+) -> Option<BTreeMap<String, f64>> {
     use crate::graph::types::{EdgeKind, NodeKind};
 
-    let mut raw_sum: u64 = 0;
-    let mut attributed_sum: u64 = 0;
-    let mut saw_qualifying_edge = false;
+    // Per-P accumulators keyed by IO-pseudo-thread label.
+    let mut per_p_raw: BTreeMap<&'static str, u64> = BTreeMap::new();
+    let mut per_p_attr: BTreeMap<&'static str, u64> = BTreeMap::new();
 
     for (_, _, dst_tid, weight) in cascaded.all_edges() {
-        // §7.3 predicate: `e.dst` is an IO pseudo-thread.
-        let dst_is_io_pseudo = cascaded.node_index(&dst_tid).is_some_and(|idx| {
-            matches!(
-                cascaded.node_weight(idx).kind,
-                NodeKind::PseudoDisk | NodeKind::PseudoNic | NodeKind::PseudoSoftirq
-            )
-        });
-        if !dst_is_io_pseudo {
+        let Some(idx) = cascaded.node_index(&dst_tid) else {
             continue;
-        }
+        };
+        // §7.3 predicate: `e.dst` is an IO pseudo-thread.
+        let label = match cascaded.node_weight(idx).kind {
+            NodeKind::PseudoDisk => "disk",
+            NodeKind::PseudoNic => "nic",
+            NodeKind::PseudoSoftirq => "softirq",
+            _ => continue,
+        };
         // §7.3 predicate: `e.kind != EdgeKind::SyntheticClosureReturn`.
         if weight.kind == EdgeKind::SyntheticClosureReturn {
             continue;
         }
-        saw_qualifying_edge = true;
-        raw_sum += weight.raw_wait_ms;
-        attributed_sum += weight.attributed_delay_ms;
+        *per_p_raw.entry(label).or_insert(0) += weight.raw_wait_ms;
+        *per_p_attr.entry(label).or_insert(0) += weight.attributed_delay_ms;
     }
 
-    if !saw_qualifying_edge || raw_sum == 0 {
+    // Compute per-P ratio; omit Ps whose raw_sum is zero (P-level None
+    // per §7.3 — observed but no measurable wait time).
+    let mut result: BTreeMap<String, f64> = BTreeMap::new();
+    for (&label, &raw_sum) in &per_p_raw {
+        if raw_sum == 0 {
+            continue;
+        }
+        let attr_sum = per_p_attr.get(&label).copied().unwrap_or(0);
+        // u64→f64 cast: precision loss past 2^53 ms is well outside any
+        // single capture window. Values are bounded by `raw_sum`.
+        #[allow(clippy::cast_precision_loss)]
+        let ratio = attr_sum as f64 / raw_sum as f64;
+        result.insert(label.to_string(), ratio);
+    }
+
+    // §7.3 (b) hard precondition: at least one IO pseudo-thread has a
+    // defined ratio. Empty map → outer `None` (gate failure: workload
+    // did not exercise the IO Attribution subject).
+    if result.is_empty() {
         return None;
     }
-
-    // Cast via `as` is safe: u64→f64 loses precision past 2^53 but for
-    // millisecond wait sums in a single capture this is comfortable.
-    #[allow(clippy::cast_precision_loss)]
-    Some(attributed_sum as f64 / raw_sum as f64)
+    Some(result)
 }
 
 #[cfg(test)]
@@ -364,21 +408,23 @@ mod tests {
 
     #[test]
     fn attributed_delay_ratio_some_on_io_edges() {
-        // IoBlock edges contribute to the ratio; other edges are ignored.
+        // Inbound edges to a pseudo-thread destination contribute to its
+        // per-P entry. The Disk→User direction has dst=UserThread (not an
+        // IO pseudo-thread), so it is excluded; only User→Disk counts.
         use crate::graph::types::{DISK_TID, NodeKind, TimeWindow, WaitType};
         use crate::graph::wfg::WaitForGraph;
 
         let mut g = WaitForGraph::new();
         g.add_node(ThreadId(100), NodeKind::UserThread);
         g.add_node(ThreadId(DISK_TID), NodeKind::PseudoDisk);
-        // User→Disk (IoBlock), raw=10
+        // User→Disk (IoBlock), raw=10 — counts (dst=PseudoDisk).
         g.add_edge_with_wait_type(
             ThreadId(100),
             ThreadId(DISK_TID),
             TimeWindow::new(0, 10),
             WaitType::IoBlock,
         );
-        // Disk→User (IoBlock), raw=10
+        // Disk→User (IoBlock), raw=10 — excluded (dst=UserThread).
         g.add_edge_with_wait_type(
             ThreadId(DISK_TID),
             ThreadId(100),
@@ -387,12 +433,14 @@ mod tests {
         );
 
         // EdgeWeight::new sets raw_wait_ms = attributed_delay_ms = duration,
-        // so the ratio pre-cascade equals 1.0.
-        let ratio = compute_io_attributed_delay_ratio(&g).expect("IO edges present");
+        // so the per-P ratio pre-cascade equals 1.0 for "disk".
+        let map = compute_io_attributed_delay_ratio(&g).expect("IO edges present");
+        let disk = map.get("disk").copied().expect("disk entry present");
         assert!(
-            (ratio - 1.0).abs() < 1e-9,
-            "expected ratio=1.0, got {ratio}"
+            (disk - 1.0).abs() < 1e-9,
+            "expected disk ratio=1.0, got {disk}"
         );
+        assert_eq!(map.len(), 1, "only disk pseudo-thread observed");
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -124,6 +124,26 @@ pub struct HealthMetrics {
     pub cascade_depth_truncation_count: Option<u64>,
     /// Wakeup edges pruned by the spurious wakeup filter (§2.5).
     pub false_wakeup_filtered_count: Option<u64>,
+
+    // --- Block-IO attribution health (Phase 2b #38 commit-5) ---------------
+    /// `IoComplete` events with no matching `IoIssue` in the userspace
+    /// `pending_io` map. Populated if block-IO tracing ran, else `None`.
+    pub io_orphan_complete_count: Option<u64>,
+    /// `IoIssue` records still pending when correlation ended (no matching
+    /// `IoComplete` arrived before capture stopped). Populated if block-IO
+    /// tracing ran, else `None`.
+    pub io_pending_at_end_count: Option<u64>,
+    /// `IoIssue` events that overwrote an existing `pending_io` entry due
+    /// to a `(dev, sector, nr_sector)` key collision. Guardrail for the
+    /// collision window Gemini flagged on PR #120 — if this fires under
+    /// real workloads, the event ABI needs to carry `struct request *`.
+    pub io_userspace_pair_collision_count: Option<u64>,
+    /// Fraction of block-IO raw wait time that flowed through the cascade
+    /// to become attributed delay on `WaitType::IoBlock` edges. Phase 2b
+    /// gate: `≥ 0.70` (final-design.md §3.8). `None` when no `IoBlock`
+    /// edges exist (tracing disabled or no I/O observed) or when total
+    /// `raw_wait` is zero (all sub-ms I/Os — ratio is undefined).
+    pub attributed_delay_ratio: Option<f64>,
 }
 
 /// CLI entry point: opens the file, runs the pipeline, writes output to stdout.
@@ -194,6 +214,12 @@ pub fn build_report<R: Read + Seek>(
     let unmatched_wakeup_count = stats.correlation.unmatched_wakeup_count;
     let false_wakeup_filtered_count = stats.correlation.false_wakeup_filtered_count;
 
+    let io_orphan_complete_count = Some(stats.correlation.io_orphan_complete_count);
+    let io_pending_at_end_count = Some(stats.correlation.io_pending_at_end_count);
+    let io_userspace_pair_collision_count =
+        Some(stats.correlation.io_userspace_pair_collision_count);
+    let attributed_delay_ratio = compute_io_attributed_delay_ratio(&cascaded);
+
     Ok(ReportOutput {
         cascade,
         critical_path,
@@ -206,8 +232,43 @@ pub fn build_report<R: Read + Seek>(
             partial_stack_count: None,
             cascade_depth_truncation_count: None,
             false_wakeup_filtered_count: Some(false_wakeup_filtered_count),
+            io_orphan_complete_count,
+            io_pending_at_end_count,
+            io_userspace_pair_collision_count,
+            attributed_delay_ratio,
         },
     })
+}
+
+/// Compute `sum(attributed_delay) / sum(raw_wait)` across all `IoBlock`-typed
+/// edges in the cascaded graph. Returns `None` when no `IoBlock` edges exist
+/// (block-IO tracing disabled or no I/O observed) or when total `raw_wait`
+/// sums to zero (all sub-millisecond I/Os — ratio undefined).
+///
+/// Phase 2b gate (final-design.md §3.8): `≥ 0.70`.
+fn compute_io_attributed_delay_ratio(cascaded: &crate::graph::wfg::WaitForGraph) -> Option<f64> {
+    use crate::graph::types::WaitType;
+
+    let mut raw_sum: u64 = 0;
+    let mut attributed_sum: u64 = 0;
+    let mut saw_io_edge = false;
+
+    for (_, _, _, weight) in cascaded.all_edges() {
+        if weight.wait_type == Some(WaitType::IoBlock) {
+            saw_io_edge = true;
+            raw_sum += weight.raw_wait_ms;
+            attributed_sum += weight.attributed_delay_ms;
+        }
+    }
+
+    if !saw_io_edge || raw_sum == 0 {
+        return None;
+    }
+
+    // Cast via `as` is safe: u64→f64 loses precision past 2^53 but for
+    // millisecond wait sums in a single capture this is comfortable.
+    #[allow(clippy::cast_precision_loss)]
+    Some(attributed_sum as f64 / raw_sum as f64)
 }
 
 #[cfg(test)]
@@ -259,6 +320,73 @@ mod tests {
             prev_state: 0,
             flags: 0,
         }
+    }
+
+    #[test]
+    fn attributed_delay_ratio_none_when_no_io_edges() {
+        // Non-IO graph: ratio should be None (not measured).
+        use crate::graph::types::{NodeKind, TimeWindow};
+        use crate::graph::wfg::WaitForGraph;
+
+        let mut g = WaitForGraph::new();
+        g.add_node(ThreadId(100), NodeKind::UserThread);
+        g.add_node(ThreadId(200), NodeKind::UserThread);
+        g.add_edge(ThreadId(100), ThreadId(200), TimeWindow::new(0, 100));
+
+        assert_eq!(compute_io_attributed_delay_ratio(&g), None);
+    }
+
+    #[test]
+    fn attributed_delay_ratio_some_on_io_edges() {
+        // IoBlock edges contribute to the ratio; other edges are ignored.
+        use crate::graph::types::{DISK_TID, NodeKind, TimeWindow, WaitType};
+        use crate::graph::wfg::WaitForGraph;
+
+        let mut g = WaitForGraph::new();
+        g.add_node(ThreadId(100), NodeKind::UserThread);
+        g.add_node(ThreadId(DISK_TID), NodeKind::PseudoDisk);
+        // User→Disk (IoBlock), raw=10
+        g.add_edge_with_wait_type(
+            ThreadId(100),
+            ThreadId(DISK_TID),
+            TimeWindow::new(0, 10),
+            WaitType::IoBlock,
+        );
+        // Disk→User (IoBlock), raw=10
+        g.add_edge_with_wait_type(
+            ThreadId(DISK_TID),
+            ThreadId(100),
+            TimeWindow::new(0, 10),
+            WaitType::IoBlock,
+        );
+
+        // EdgeWeight::new sets raw_wait_ms = attributed_delay_ms = duration,
+        // so the ratio pre-cascade equals 1.0.
+        let ratio = compute_io_attributed_delay_ratio(&g).expect("IO edges present");
+        assert!(
+            (ratio - 1.0).abs() < 1e-9,
+            "expected ratio=1.0, got {ratio}"
+        );
+    }
+
+    #[test]
+    fn attributed_delay_ratio_none_when_all_io_edges_zero_duration() {
+        // Sub-ms I/Os collapse to zero-duration windows. Ratio is undefined
+        // when the raw denominator sums to zero — must return None, not NaN.
+        use crate::graph::types::{DISK_TID, NodeKind, TimeWindow, WaitType};
+        use crate::graph::wfg::WaitForGraph;
+
+        let mut g = WaitForGraph::new();
+        g.add_node(ThreadId(100), NodeKind::UserThread);
+        g.add_node(ThreadId(DISK_TID), NodeKind::PseudoDisk);
+        g.add_edge_with_wait_type(
+            ThreadId(100),
+            ThreadId(DISK_TID),
+            TimeWindow::new(5, 5),
+            WaitType::IoBlock,
+        );
+
+        assert_eq!(compute_io_attributed_delay_ratio(&g), None);
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -240,28 +240,54 @@ pub fn build_report<R: Read + Seek>(
     })
 }
 
-/// Compute `sum(attributed_delay) / sum(raw_wait)` across all `IoBlock`-typed
-/// edges in the cascaded graph. Returns `None` when no `IoBlock` edges exist
-/// (block-IO tracing disabled or no I/O observed) or when total `raw_wait`
-/// sums to zero (all sub-millisecond I/Os — ratio undefined).
+/// Compute the Phase 2b `attributed_delay_ratio` per the formal §7.3
+/// definition (final-design.md, post-PR-#121 amendment):
 ///
-/// Phase 2b gate (final-design.md §3.8): `≥ 0.70`.
+/// `ratio = Σ(e.attributed_delay_ms) / Σ(e.raw_wait_ms)` for every edge
+/// `e` where `e.dst` is an IO pseudo-thread AND
+/// `e.kind != EdgeKind::SyntheticClosureReturn`.
+///
+/// The aggregate sums over all IO pseudo-thread destinations (currently
+/// only `PseudoDisk`; Phase 2c adds `PseudoNic` / `PseudoSoftirq`). This
+/// matches the gate's measurement domain — only forward edges entering
+/// pseudo-threads carry real I/O service-time blame; closure-return
+/// edges are SCC bookkeeping per ADR-009 *Amendment 2026-04-25* and
+/// have no semantic wait time.
+///
+/// Returns `None` when no qualifying edge exists (no observable IO in
+/// this workload) or when total `raw_wait` sums to zero (all sub-ms
+/// I/Os collapsed to zero-duration windows). Per §7.3 the Phase 2b
+/// gate treats `None` as a hard precondition failure (workload didn't
+/// exercise the IO Attribution gate's subject); CI tri-state mapping
+/// is applied at the test-runner level.
 fn compute_io_attributed_delay_ratio(cascaded: &crate::graph::wfg::WaitForGraph) -> Option<f64> {
-    use crate::graph::types::WaitType;
+    use crate::graph::types::{EdgeKind, NodeKind};
 
     let mut raw_sum: u64 = 0;
     let mut attributed_sum: u64 = 0;
-    let mut saw_io_edge = false;
+    let mut saw_qualifying_edge = false;
 
-    for (_, _, _, weight) in cascaded.all_edges() {
-        if weight.wait_type == Some(WaitType::IoBlock) {
-            saw_io_edge = true;
-            raw_sum += weight.raw_wait_ms;
-            attributed_sum += weight.attributed_delay_ms;
+    for (_, _, dst_tid, weight) in cascaded.all_edges() {
+        // §7.3 predicate: `e.dst` is an IO pseudo-thread.
+        let dst_is_io_pseudo = cascaded.node_index(&dst_tid).is_some_and(|idx| {
+            matches!(
+                cascaded.node_weight(idx).kind,
+                NodeKind::PseudoDisk | NodeKind::PseudoNic | NodeKind::PseudoSoftirq
+            )
+        });
+        if !dst_is_io_pseudo {
+            continue;
         }
+        // §7.3 predicate: `e.kind != EdgeKind::SyntheticClosureReturn`.
+        if weight.kind == EdgeKind::SyntheticClosureReturn {
+            continue;
+        }
+        saw_qualifying_edge = true;
+        raw_sum += weight.raw_wait_ms;
+        attributed_sum += weight.attributed_delay_ms;
     }
 
-    if !saw_io_edge || raw_sum == 0 {
+    if !saw_qualifying_edge || raw_sum == 0 {
         return None;
     }
 

--- a/tests/p2b_io_fixtures.rs
+++ b/tests/p2b_io_fixtures.rs
@@ -184,29 +184,36 @@ fn fio_randread_direct() {
     assert_eq!(report.health.io_pending_at_end_count, Some(0));
     assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
 
-    // Post-PR-#121 cascade-terminal fix + post-commit-9 §7.3 ratio formula:
+    // Post-PR-#121 cascade-terminal fix + post-commit-10 §7.3 per-P ratio:
     // forward edges (User→Disk, kind=Normal) attribute to DISK at full
     // raw_wait under cascade (pseudo-thread is now a leaf for cascade —
     // its only outgoing is the SCR edge which the bilateral filter
     // skips). Return edges (kind=SyntheticClosureReturn) are excluded
-    // from the §7.3 numerator + denominator. So for 8 paired I/Os each
-    // with raw_wait=5ms (5_000_000ns / 1_000_000), ratio = 40/40 = 1.0.
+    // from §7.3 numerator + denominator. So for 8 paired I/Os each with
+    // raw_wait=5ms (5_000_000ns / 1_000_000), the per-P "disk" ratio =
+    // 40/40 = 1.0.
     //
-    // STRICT magnitude assertion per spec §7.3 L588 defense-in-depth
-    // requirement: ratio MUST be `Some(r) where 0.70 ≤ r ≤ 1.0`, not
-    // the looser `(0..=1.0)` or `is_some()`. Probe Gap 5 risk-asymmetry
-    // argument: silent ratio drift outside [0.70, 1.0] is a cascade /
-    // ratio impl regression that this fixture surfaces as fail at the
-    // unit-test layer, independent of the gate verdict at the
-    // integration-test layer.
-    let ratio = report
+    // STRICT magnitude assertion per spec §7.3 L588 defense-in-depth +
+    // per-P discipline: every observed pseudo-thread MUST be in
+    // [0.70, 1.0], and (b) hard-precondition demands at least one
+    // defined entry. 5-way reviewer convergence on per-P contract:
+    // Oracle msg=62ec6c36 + Probe msg=a1f9b1bf + Critic msg=5bcd369d +
+    // Challenger msg=a21b9b2b + Maestro msg=54b49254.
+    let ratio_map = report
         .health
         .attributed_delay_ratio
-        .expect("inbound-to-pseudo-thread edges present → ratio must be defined");
+        .as_ref()
+        .expect("inbound-to-pseudo-thread edges present → per-P map must be Some(_)");
     assert!(
-        (0.70..=1.0).contains(&ratio),
-        "ratio must be in [0.70, 1.0] per spec §7.3 L588 defense-in-depth, got {ratio}"
+        !ratio_map.is_empty(),
+        "(b) hard-precondition: ≥1 IO pseudo-thread must have a defined ratio"
     );
+    for (label, &r) in ratio_map {
+        assert!(
+            (0.70..=1.0).contains(&r),
+            "per-P {label} ratio must be in [0.70, 1.0] per spec §7.3 (a), got {r}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -330,25 +337,34 @@ fn concurrent_submitters_single_disk() {
         .count();
     assert_eq!(io_edges, 6, "3 submitters × 2 directions");
 
-    // Post-PR-#121 cascade-terminal fix + post-commit-9 §7.3 ratio formula:
+    // Post-PR-#121 cascade-terminal fix + post-commit-10 §7.3 per-P ratio:
     // forward edges (User→Disk per submitter, kind=Normal) attribute to
     // DISK at full raw_wait under cascade. Return edges (kind=SCR) excluded
     // from §7.3 numerator + denominator. With 3 submitters × 1 IO each
-    // (3ms service time), aggregate raw_sum = 3 × 3 = 9, attributed_sum =
-    // 3 × 3 = 9 (forward edges fully attributed), ratio = 1.0.
+    // (3ms service time), per-P "disk" raw_sum = 9, attributed_sum = 9,
+    // ratio = 1.0.
     //
     // STRICT magnitude assertion per spec §7.3 L588 — forward fan-in to a
     // single pseudo-thread should attribute correctly even when multiple
     // submitters share the same DISK target (Probe Gap 5 verifies the
-    // count_concurrent_waiters filter doesn't pollute fan-in).
-    let ratio = report
+    // `count_concurrent_waiters` filter doesn't pollute fan-in). Per-P
+    // ∀ check + (b) hard-precondition per 5-way reviewer convergence
+    // (Oracle msg=62ec6c36 et al.).
+    let ratio_map = report
         .health
         .attributed_delay_ratio
-        .expect("inbound-to-pseudo-thread edges present → ratio must be defined");
+        .as_ref()
+        .expect("inbound-to-pseudo-thread edges present → per-P map must be Some(_)");
     assert!(
-        (0.70..=1.0).contains(&ratio),
-        "ratio must be in [0.70, 1.0] per spec §7.3 L588 defense-in-depth, got {ratio}"
+        !ratio_map.is_empty(),
+        "(b) hard-precondition: ≥1 IO pseudo-thread must have a defined ratio"
     );
+    for (label, &r) in ratio_map {
+        assert!(
+            (0.70..=1.0).contains(&r),
+            "per-P {label} ratio must be in [0.70, 1.0] per spec §7.3 (a), got {r}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -523,25 +539,37 @@ fn commit9_magnitude_pinned_multi_io_ratio() {
     assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
 
     // STRICT pattern per Probe msg=a8a05157 §5(1) + Oracle msg=0c9bd48d
-    // §3 ratify: `Some(r) where 0.70 ≤ r ≤ 1.0`. Equivalently:
-    // None → fixture fails; Some(r < 0.70) → fixture fails;
-    // Some(r > 1.0) → fixture fails (would indicate I-2 amplification
-    // bug, but defense-in-depth: catch it here).
-    let ratio = report
+    // §3 ratify, plus per-P promotion per 5-way commit-10 convergence
+    // (Oracle msg=62ec6c36 + Probe msg=a1f9b1bf + Critic msg=5bcd369d +
+    // Challenger msg=a21b9b2b + Maestro msg=54b49254). Three layers:
+    //   1. Outer Option must be Some (§7.3 (b) hard precondition);
+    //      None means cascade or ratio impl regression.
+    //   2. Per-P value ∀ in [0.70, 1.0] (§7.3 (a) gate predicate).
+    //   3. The "disk" entry must be exactly 1.0 — clean pure-IO
+    //      workload with no upstream user-wait chain forces full
+    //      attribution to the pseudo-thread leaf (SCR filter).
+    let ratio_map = report
         .health
         .attributed_delay_ratio
-        .expect("inbound-to-pseudo-thread edges present → ratio MUST be Some(_); None means cascade or ratio impl regression");
+        .as_ref()
+        .expect("inbound-to-pseudo-thread edges present → per-P map MUST be Some(_); None means cascade or ratio impl regression");
     assert!(
-        (0.70..=1.0).contains(&ratio),
-        "Some(r) where 0.70 ≤ r ≤ 1.0 required per spec §7.3 L588 defense-in-depth, got Some({ratio})"
+        !ratio_map.is_empty(),
+        "(b) hard-precondition: ≥1 IO pseudo-thread must have a defined ratio"
     );
+    for (label, &r) in ratio_map {
+        assert!(
+            (0.70..=1.0).contains(&r),
+            "per-P {label} ratio must be in [0.70, 1.0] per spec §7.3 L588 defense-in-depth, got {r}"
+        );
+    }
 
-    // Pinned tighter — for this clean pure-IO workload with no upstream
-    // user-wait chain, post-fix attribution should be exactly 1.0
-    // (forward edges get full attribution because cascade hits the
-    // pseudo-thread leaf immediately via the SCR filter).
+    let disk = ratio_map
+        .get("disk")
+        .copied()
+        .expect("DISK pseudo-thread must appear with this all-DISK workload");
     assert!(
-        (ratio - 1.0).abs() < 1e-9,
-        "clean multi-IO workload MUST attribute exactly 1.0 (no upstream cascade chains divert blame from forward IO edges); got {ratio}"
+        (disk - 1.0).abs() < 1e-9,
+        "clean multi-IO workload MUST attribute exactly 1.0 to disk (no upstream cascade chains divert blame from forward IO edges); got {disk}"
     );
 }

--- a/tests/p2b_io_fixtures.rs
+++ b/tests/p2b_io_fixtures.rs
@@ -184,22 +184,28 @@ fn fio_randread_direct() {
     assert_eq!(report.health.io_pending_at_end_count, Some(0));
     assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
 
-    // Pure-IO 2-cycle workloads zero out under cascade: User→Disk recurses
-    // into Disk, Disk→User recurses back into User which is already in
-    // path, returns `self_blame = duration` → propagated back → attributed
-    // = raw - propagated = 0. This is correct cascade semantics for
-    // closed cycles (nobody is "directly responsible" in isolation). The
-    // Phase 2b gate `attributed_delay_ratio ≥ 0.70` applies to mixed
-    // workloads where IoBlock edges connect to futex/switch chains that
-    // pull attribution into the IO subgraph. Here we only assert the
-    // ratio is well-defined (not None, not NaN).
+    // Post-PR-#121 cascade-terminal fix + post-commit-9 §7.3 ratio formula:
+    // forward edges (User→Disk, kind=Normal) attribute to DISK at full
+    // raw_wait under cascade (pseudo-thread is now a leaf for cascade —
+    // its only outgoing is the SCR edge which the bilateral filter
+    // skips). Return edges (kind=SyntheticClosureReturn) are excluded
+    // from the §7.3 numerator + denominator. So for 8 paired I/Os each
+    // with raw_wait=5ms (5_000_000ns / 1_000_000), ratio = 40/40 = 1.0.
+    //
+    // STRICT magnitude assertion per spec §7.3 L588 defense-in-depth
+    // requirement: ratio MUST be `Some(r) where 0.70 ≤ r ≤ 1.0`, not
+    // the looser `(0..=1.0)` or `is_some()`. Probe Gap 5 risk-asymmetry
+    // argument: silent ratio drift outside [0.70, 1.0] is a cascade /
+    // ratio impl regression that this fixture surfaces as fail at the
+    // unit-test layer, independent of the gate verdict at the
+    // integration-test layer.
     let ratio = report
         .health
         .attributed_delay_ratio
-        .expect("IoBlock edges present → ratio must be defined");
+        .expect("inbound-to-pseudo-thread edges present → ratio must be defined");
     assert!(
-        (0.0..=1.0).contains(&ratio),
-        "ratio must be in [0, 1], got {ratio}"
+        (0.70..=1.0).contains(&ratio),
+        "ratio must be in [0.70, 1.0] per spec §7.3 L588 defense-in-depth, got {ratio}"
     );
 }
 
@@ -324,15 +330,24 @@ fn concurrent_submitters_single_disk() {
         .count();
     assert_eq!(io_edges, 6, "3 submitters × 2 directions");
 
-    // Ratio is well-defined (raw_sum > 0). Concrete value depends on the
-    // same cascade-cycle behavior documented in `fio_randread_direct`.
+    // Post-PR-#121 cascade-terminal fix + post-commit-9 §7.3 ratio formula:
+    // forward edges (User→Disk per submitter, kind=Normal) attribute to
+    // DISK at full raw_wait under cascade. Return edges (kind=SCR) excluded
+    // from §7.3 numerator + denominator. With 3 submitters × 1 IO each
+    // (3ms service time), aggregate raw_sum = 3 × 3 = 9, attributed_sum =
+    // 3 × 3 = 9 (forward edges fully attributed), ratio = 1.0.
+    //
+    // STRICT magnitude assertion per spec §7.3 L588 — forward fan-in to a
+    // single pseudo-thread should attribute correctly even when multiple
+    // submitters share the same DISK target (Probe Gap 5 verifies the
+    // count_concurrent_waiters filter doesn't pollute fan-in).
     let ratio = report
         .health
         .attributed_delay_ratio
-        .expect("IoBlock edges present → ratio must be defined");
+        .expect("inbound-to-pseudo-thread edges present → ratio must be defined");
     assert!(
-        (0.0..=1.0).contains(&ratio),
-        "ratio must be in [0, 1], got {ratio}"
+        (0.70..=1.0).contains(&ratio),
+        "ratio must be in [0.70, 1.0] per spec §7.3 L588 defense-in-depth, got {ratio}"
     );
 }
 
@@ -425,4 +440,108 @@ fn all_io_edges_annotated_with_ioblock_wait_type() {
             "every edge produced by IO dispatch must carry WaitType::IoBlock"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2b commit-9 magnitude-pinned multi-IO fixture
+// (per spec final-design.md §7.3 L588 byte-encoded defense-in-depth)
+// ---------------------------------------------------------------------------
+
+/// Magnitude-pinned multi-IO fixture per spec final-design.md §7.3 L588:
+///
+/// > "commit-9 multi-IO fixtures (issue #38) MUST assert
+/// >  `attributed_delay_ratio` is `Some(r) where 0.70 ≤ r ≤ 1.0` rather
+/// >  than the looser `(0..=1.0)` range"
+///
+/// Probe risk-asymmetry argument (PR #121 thread, Probe msg=a8a05157 §2):
+/// the spec gate is the system-level safety net (catches all-None /
+/// cascade producing zero `raw_wait`), and the fixture-level magnitude
+/// assert is the unit-test-level safety net (catches per-edge ratio
+/// computation bugs that produce `Some(r)` with `r < 0.70` when the
+/// real answer should be ~1.0). Both layers required per Oracle
+/// msg=0c9bd48d §3 ratification of Probe §5(1) two-layer
+/// defense-in-depth pattern.
+///
+/// Workload shape: 5 paired I/Os from a single submitter to one device,
+/// each with 4ms service time (well above ns→ms truncation threshold).
+/// Post-PR-#121 cascade: forward edges (Normal kind, dst=Disk) get full
+/// attribution; return edges (SCR kind) excluded from §7.3 ratio.
+/// Expected: ratio = 5×4 / 5×4 = 1.0 exactly.
+#[test]
+#[allow(clippy::similar_names)] // tgid / tid mirror WperfEvent field names
+fn commit9_magnitude_pinned_multi_io_ratio() {
+    use wperf::format::event::{EventType, WperfEvent};
+    use wperf::format::reader::WperfReader;
+    use wperf::format::writer::WperfWriter;
+    use wperf::report::{self, ReportOutput};
+
+    fn run(events: &[WperfEvent]) -> ReportOutput {
+        let buf = std::io::Cursor::new(Vec::new());
+        let mut w = WperfWriter::new(buf).expect("writer");
+        for ev in events {
+            w.write_event(ev).expect("write_event");
+        }
+        let data = w.finish(0).expect("finish").into_inner();
+        let mut r = WperfReader::open(std::io::Cursor::new(data)).expect("reader");
+        report::build_report(&mut r, wperf::correlate::DEFAULT_SPURIOUS_THRESHOLD_NS)
+            .expect("build_report")
+    }
+
+    let tgid = 700u32;
+    let tid = 700u32;
+    let dev = 0x800_0007u32;
+    let mut events: Vec<WperfEvent> = Vec::new();
+    for i in 0..5u64 {
+        let sector = 0x4000 + i * 0x100;
+        let issue_ts = 1_000_000 + i * 10_000_000;
+        let complete_ts = issue_ts + 4_000_000; // 4ms service time
+        events.push(io_event(
+            issue_ts,
+            tgid,
+            tid,
+            dev,
+            sector,
+            8,
+            EventType::IoIssue,
+        ));
+        events.push(io_event(
+            complete_ts,
+            tgid,
+            tid,
+            dev,
+            sector,
+            8,
+            EventType::IoComplete,
+        ));
+    }
+
+    let report = run(&events);
+
+    assert!(report.health.invariants_ok);
+    assert_eq!(report.health.io_orphan_complete_count, Some(0));
+    assert_eq!(report.health.io_pending_at_end_count, Some(0));
+    assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
+
+    // STRICT pattern per Probe msg=a8a05157 §5(1) + Oracle msg=0c9bd48d
+    // §3 ratify: `Some(r) where 0.70 ≤ r ≤ 1.0`. Equivalently:
+    // None → fixture fails; Some(r < 0.70) → fixture fails;
+    // Some(r > 1.0) → fixture fails (would indicate I-2 amplification
+    // bug, but defense-in-depth: catch it here).
+    let ratio = report
+        .health
+        .attributed_delay_ratio
+        .expect("inbound-to-pseudo-thread edges present → ratio MUST be Some(_); None means cascade or ratio impl regression");
+    assert!(
+        (0.70..=1.0).contains(&ratio),
+        "Some(r) where 0.70 ≤ r ≤ 1.0 required per spec §7.3 L588 defense-in-depth, got Some({ratio})"
+    );
+
+    // Pinned tighter — for this clean pure-IO workload with no upstream
+    // user-wait chain, post-fix attribution should be exactly 1.0
+    // (forward edges get full attribution because cascade hits the
+    // pseudo-thread leaf immediately via the SCR filter).
+    assert!(
+        (ratio - 1.0).abs() < 1e-9,
+        "clean multi-IO workload MUST attribute exactly 1.0 (no upstream cascade chains divert blame from forward IO edges); got {ratio}"
+    );
 }

--- a/tests/p2b_io_fixtures.rs
+++ b/tests/p2b_io_fixtures.rs
@@ -1,0 +1,428 @@
+//! Phase 2b #38 P2b-01 commit-6 — end-to-end block-IO fixture suite.
+//!
+//! Four named fixtures cover the behavioral matrix for `block_rq` synthetic
+//! edges: `cpu_only_baseline` (no I/O — regression guard that new counters
+//! stay inert), `fio_randread_direct` (single submitter, many paired I/Os),
+//! `mixed_cpu_io_futex` (I/O interleaved with `sched_switch` + futex), and
+//! `concurrent_submitters_single_disk` (fan-in to the single `DISK_TID`).
+//!
+//! Plus two sanity fixtures: `io_health_counters_surface_real_values`
+//! exercises the orphan + pair-collision counters, and
+//! `all_io_edges_annotated_with_ioblock_wait_type` guards `WaitType::IoBlock`
+//! annotation across cascade.
+//!
+//! Each fixture asserts `invariants_ok`, edge topology, and counter values;
+//! where meaningful, the attributed-delay ratio is checked for well-definedness
+//! (value depends on cascade semantics for closed cycles — see per-test docs).
+//! The proptest in `tests/property_tests.rs` covers the fuzz surface; these
+//! fixtures are the canonical named-scenario acceptance tests.
+
+use std::io::Cursor;
+
+use wperf::correlate::DEFAULT_SPURIOUS_THRESHOLD_NS;
+use wperf::format::event::{EventType, WperfEvent};
+use wperf::format::reader::WperfReader;
+use wperf::format::writer::WperfWriter;
+use wperf::graph::types::{DISK_TID, ThreadId, WaitType};
+use wperf::report::{self, ReportOutput};
+
+const TASK_INTERRUPTIBLE: u8 = 1;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_report_from(events: &[WperfEvent]) -> ReportOutput {
+    let buf = Cursor::new(Vec::new());
+    let mut w = WperfWriter::new(buf).expect("writer");
+    for ev in events {
+        w.write_event(ev).expect("write_event");
+    }
+    let data = w.finish(0).expect("finish").into_inner();
+    let mut r = WperfReader::open(Cursor::new(data)).expect("reader");
+    report::build_report(&mut r, DEFAULT_SPURIOUS_THRESHOLD_NS).expect("build_report")
+}
+
+fn switch(ts_ns: u64, prev_tid: u32, next_tid: u32, prev_state: u8) -> WperfEvent {
+    WperfEvent {
+        timestamp_ns: ts_ns,
+        pid: 0,
+        tid: 0,
+        prev_tid,
+        next_tid,
+        prev_pid: 0,
+        next_pid: 0,
+        cpu: 0,
+        event_type: EventType::Switch as u8,
+        prev_state,
+        flags: 0,
+    }
+}
+
+#[allow(clippy::similar_names)]
+fn wakeup(ts_ns: u64, waker_tid: u32, wakee_tid: u32) -> WperfEvent {
+    WperfEvent {
+        timestamp_ns: ts_ns,
+        pid: 0,
+        tid: 0,
+        prev_tid: waker_tid,
+        next_tid: wakee_tid,
+        prev_pid: 0,
+        next_pid: 0,
+        cpu: 0,
+        event_type: EventType::Wakeup as u8,
+        prev_state: 0,
+        flags: 0,
+    }
+}
+
+#[allow(clippy::similar_names)] // tgid / tid mirror WperfEvent field names
+fn io_event(
+    ts_ns: u64,
+    tgid: u32,
+    tid: u32,
+    dev: u32,
+    sector: u64,
+    nr_sector: u32,
+    kind: EventType,
+) -> WperfEvent {
+    WperfEvent {
+        timestamp_ns: ts_ns,
+        pid: tgid,
+        tid,
+        prev_tid: u32::try_from(sector & 0xFFFF_FFFF).unwrap(),
+        next_tid: u32::try_from(sector >> 32).unwrap(),
+        prev_pid: dev,
+        next_pid: nr_sector,
+        cpu: 0,
+        event_type: kind as u8,
+        prev_state: 0,
+        flags: 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 1 — cpu_only_baseline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cpu_only_baseline() {
+    // Two threads, a classic User→Holder wait chain. No IO events at all.
+    // Regression guard: the new io_* counters must all be 0 and
+    // attributed_delay_ratio must be None (no IoBlock edges present).
+    let events = vec![
+        switch(1_000_000, 100, 200, TASK_INTERRUPTIBLE), // T100 off
+        wakeup(2_000_000, 200, 100),                     // T200 wakes T100
+        switch(3_000_000, 200, 100, 0),                  // T100 back on
+    ];
+
+    let report = build_report_from(&events);
+
+    assert_eq!(report.cascade.edges.len(), 1, "one user-wait edge");
+    assert!(report.health.invariants_ok);
+    // No IO — all IO health fields must be the zero-default (tracing ran but
+    // saw nothing), except the ratio which is None (undefined without edges).
+    assert_eq!(report.health.io_orphan_complete_count, Some(0));
+    assert_eq!(report.health.io_pending_at_end_count, Some(0));
+    assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
+    assert_eq!(report.health.attributed_delay_ratio, None);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 2 — fio_randread_direct
+// ---------------------------------------------------------------------------
+
+#[test]
+#[allow(clippy::similar_names)]
+fn fio_randread_direct() {
+    // Single submitter T100 issues a burst of 8 paired I/Os to one device,
+    // each with distinct sectors. Every issue gets its matching complete;
+    // no orphans, no dangles, no collisions.
+    let tgid = 500u32;
+    let tid = 500u32;
+    let dev = 0x800_0001;
+    let mut events = Vec::new();
+    for i in 0..8u64 {
+        let sector = 0x1000 + i * 0x100;
+        let issue_ts = 1_000_000 + i * 10_000_000; // 1ms apart
+        let complete_ts = issue_ts + 5_000_000; // 5ms service time
+        events.push(io_event(
+            issue_ts,
+            tgid,
+            tid,
+            dev,
+            sector,
+            8,
+            EventType::IoIssue,
+        ));
+        events.push(io_event(
+            complete_ts,
+            tgid,
+            tid,
+            dev,
+            sector,
+            8,
+            EventType::IoComplete,
+        ));
+    }
+
+    let report = build_report_from(&events);
+
+    // 8 I/Os × 2 edges = 16 IoBlock edges; nodes = 1 user + 1 DISK.
+    let user = ThreadId(i64::from(tid));
+    let disk = ThreadId(DISK_TID);
+    let io_edges: Vec<_> = report
+        .cascade
+        .edges
+        .iter()
+        .filter(|e| (e.src == user && e.dst == disk) || (e.src == disk && e.dst == user))
+        .collect();
+    assert_eq!(io_edges.len(), 16, "8 pairs × 2 directions");
+
+    assert!(report.health.invariants_ok);
+    assert_eq!(report.health.io_orphan_complete_count, Some(0));
+    assert_eq!(report.health.io_pending_at_end_count, Some(0));
+    assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
+
+    // Pure-IO 2-cycle workloads zero out under cascade: User→Disk recurses
+    // into Disk, Disk→User recurses back into User which is already in
+    // path, returns `self_blame = duration` → propagated back → attributed
+    // = raw - propagated = 0. This is correct cascade semantics for
+    // closed cycles (nobody is "directly responsible" in isolation). The
+    // Phase 2b gate `attributed_delay_ratio ≥ 0.70` applies to mixed
+    // workloads where IoBlock edges connect to futex/switch chains that
+    // pull attribution into the IO subgraph. Here we only assert the
+    // ratio is well-defined (not None, not NaN).
+    let ratio = report
+        .health
+        .attributed_delay_ratio
+        .expect("IoBlock edges present → ratio must be defined");
+    assert!(
+        (0.0..=1.0).contains(&ratio),
+        "ratio must be in [0, 1], got {ratio}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 3 — mixed_cpu_io_futex
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_cpu_io_futex() {
+    // Heterogeneous workload: two threads that both sched_switch + issue I/O
+    // interleaved. Proves the correlate pipeline handles mixed event streams
+    // without cross-contamination (futex event for T100 must not contaminate
+    // T200's IO edge).
+    let events = vec![
+        // T100: goes off-CPU waiting on T200
+        switch(1_000_000, 100, 200, TASK_INTERRUPTIBLE),
+        // T200 issues + completes I/O while T100 is parked
+        io_event(
+            2_000_000,
+            200,
+            200,
+            0x800_0001,
+            0x2000,
+            16,
+            EventType::IoIssue,
+        ),
+        io_event(
+            5_000_000,
+            200,
+            200,
+            0x800_0001,
+            0x2000,
+            16,
+            EventType::IoComplete,
+        ),
+        // T200 wakes T100
+        wakeup(6_000_000, 200, 100),
+        switch(7_000_000, 200, 100, 0),
+    ];
+
+    let report = build_report_from(&events);
+
+    // Expect edges: User→Holder (T100→T200), plus User↔Disk (T200↔DISK).
+    assert!(report.health.invariants_ok);
+    assert_eq!(report.health.io_orphan_complete_count, Some(0));
+    assert_eq!(report.health.io_pending_at_end_count, Some(0));
+    assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
+
+    let t200 = ThreadId(200);
+    let t100 = ThreadId(100);
+    let disk = ThreadId(DISK_TID);
+    let io_edge_count = report
+        .cascade
+        .edges
+        .iter()
+        .filter(|e| (e.src == t200 && e.dst == disk) || (e.src == disk && e.dst == t200))
+        .count();
+    assert_eq!(io_edge_count, 2, "one User↔Disk pair");
+
+    let user_wait_edge = report
+        .cascade
+        .edges
+        .iter()
+        .find(|e| e.src == t100 && e.dst == t200);
+    assert!(user_wait_edge.is_some(), "T100→T200 wait edge preserved");
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 4 — concurrent_submitters_single_disk
+// ---------------------------------------------------------------------------
+
+#[test]
+fn concurrent_submitters_single_disk() {
+    // Three user threads hammer the same device concurrently. The single
+    // DISK_TID pseudo-thread receives inbound edges from each user and
+    // outbound return edges to each. This is the fan-in pattern that
+    // ADR-009 §Consequences flags as "per-device pseudo-disks deferred".
+    let dev = 0x800_0001;
+    let mut events = Vec::new();
+    for (i, tid) in [301u32, 302, 303].iter().enumerate() {
+        let sector = 0x1000 + (i as u64) * 0x100;
+        let issue_ts = 1_000_000 + (i as u64) * 100_000;
+        let complete_ts = issue_ts + 3_000_000;
+        events.push(io_event(
+            issue_ts,
+            *tid,
+            *tid,
+            dev,
+            sector,
+            8,
+            EventType::IoIssue,
+        ));
+        events.push(io_event(
+            complete_ts,
+            *tid,
+            *tid,
+            dev,
+            sector,
+            8,
+            EventType::IoComplete,
+        ));
+    }
+
+    let report = build_report_from(&events);
+
+    assert!(report.health.invariants_ok);
+    assert_eq!(report.health.io_orphan_complete_count, Some(0));
+    assert_eq!(report.health.io_pending_at_end_count, Some(0));
+    assert_eq!(report.health.io_userspace_pair_collision_count, Some(0));
+
+    // Each user tid contributes 2 IoBlock edges → 6 IO edges total.
+    let user_tids = [ThreadId(301), ThreadId(302), ThreadId(303)];
+    let disk = ThreadId(DISK_TID);
+    let io_edges = report
+        .cascade
+        .edges
+        .iter()
+        .filter(|e| {
+            user_tids.contains(&e.src) && e.dst == disk
+                || e.src == disk && user_tids.contains(&e.dst)
+        })
+        .count();
+    assert_eq!(io_edges, 6, "3 submitters × 2 directions");
+
+    // Ratio is well-defined (raw_sum > 0). Concrete value depends on the
+    // same cascade-cycle behavior documented in `fio_randread_direct`.
+    let ratio = report
+        .health
+        .attributed_delay_ratio
+        .expect("IoBlock edges present → ratio must be defined");
+    assert!(
+        (0.0..=1.0).contains(&ratio),
+        "ratio must be in [0, 1], got {ratio}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative fixture — orphan + collision health counters populate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn io_health_counters_surface_real_values() {
+    // One orphan complete (no prior issue), one pair collision (two issues
+    // on the same IoKey before any complete). Verifies the HealthMetrics
+    // surface actually wires to the underlying counters — not just zeros.
+    let dev = 0x800_0001;
+    let sector = 0x4000;
+    let events = vec![
+        // Orphan: complete with no prior issue.
+        io_event(1_000_000, 111, 111, dev, 0x1000, 8, EventType::IoComplete),
+        // Collision: two issues with identical (dev, sector, nr_sector).
+        io_event(2_000_000, 222, 222, dev, sector, 8, EventType::IoIssue),
+        io_event(3_000_000, 333, 333, dev, sector, 8, EventType::IoIssue),
+        // Drain the collided issue so only the pair-collision counter fires.
+        io_event(4_000_000, 333, 333, dev, sector, 8, EventType::IoComplete),
+    ];
+
+    let report = build_report_from(&events);
+
+    assert!(report.health.invariants_ok);
+    assert_eq!(
+        report.health.io_orphan_complete_count,
+        Some(1),
+        "one orphan"
+    );
+    assert_eq!(report.health.io_pending_at_end_count, Some(0));
+    assert_eq!(
+        report.health.io_userspace_pair_collision_count,
+        Some(1),
+        "second identical issue must register as collision"
+    );
+
+    // Match the ADR-009 bidirectional edge rule: one successful pair = 2 edges.
+    // Edges attribute to T333 (last-writer-wins on collision).
+    let t333 = ThreadId(333);
+    let disk = ThreadId(DISK_TID);
+    let io_edges = report
+        .cascade
+        .edges
+        .iter()
+        .filter(|e| (e.src == t333 && e.dst == disk) || (e.src == disk && e.dst == t333))
+        .count();
+    assert_eq!(io_edges, 2);
+}
+
+// ---------------------------------------------------------------------------
+// WaitType annotation — every IoBlock edge must be annotated
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_io_edges_annotated_with_ioblock_wait_type() {
+    // Structural guard: the CascadeResult serialization doesn't expose
+    // wait_type directly (edges only show src/dst/raw/attributed), so we go
+    // through `correlate_events` directly to inspect the WaitForGraph.
+    use wperf::correlate::correlate_events;
+
+    let events = vec![
+        io_event(
+            1_000_000,
+            100,
+            100,
+            0x800_0001,
+            0x1000,
+            8,
+            EventType::IoIssue,
+        ),
+        io_event(
+            2_000_000,
+            100,
+            100,
+            0x800_0001,
+            0x1000,
+            8,
+            EventType::IoComplete,
+        ),
+    ];
+
+    let (graph, _) = correlate_events(&events, 0);
+    for (_, _, _, weight) in graph.all_edges() {
+        assert_eq!(
+            weight.wait_type,
+            Some(WaitType::IoBlock),
+            "every edge produced by IO dispatch must carry WaitType::IoBlock"
+        );
+    }
+}

--- a/tests/probe_mixed_cascade.rs
+++ b/tests/probe_mixed_cascade.rs
@@ -1,0 +1,142 @@
+//! Cascade-cycle probe — mixed User-chain + IO 2-cycle graph
+//! ===========================================================
+//!
+//! Per-Adrian-request diagnostic: before any spec amendment, verify
+//! that the proposed cascade-terminal + inbound-filter fix behaves
+//! correctly in a MIXED workload (not just pure IO fixtures).
+//!
+//! Topology modeled (closest paper-like pattern for an IO-bound wait):
+//!
+//!     T100 ────[0, 10]────> T200 ←───[0, 10]─── DISK
+//!                             │                   ↑
+//!                             └───[0, 10]─────────┘
+//!                                (ADR-009 synthetic pair)
+//!
+//! Semantics: T100 (User) is blocked for 10ms waiting on T200 (Holder),
+//! which is itself doing synchronous I/O to Disk during the entire
+//! window. The ADR-009 User↔Disk pair is between T200 and Disk — the
+//! outer User→Holder wait is a normal scheduler edge, not synthetic.
+//!
+//! Expected intuition (paper-faithful):
+//!   T100→T200: 0   (T200 isn't at fault — it's itself waiting on Disk)
+//!   T200→DISK: 10  (Disk is the root cause for the full 10ms)
+//!   DISK→T200: 0   (return-edge bookkeeping, no semantic wait)
+//!   inbound-to-pseudo ratio = 10/10 = 1.0 ≥ 0.70 ✓
+//!
+//! This test records what the CURRENT (pre-fix) cascade produces so we
+//! have a before/after comparison in the thread discussion. The values
+//! asserted below are the OBSERVED pre-fix numbers, documenting the
+//! drift between code and spec §7.3. If the fix lands, this test
+//! **will fail** — that's the intended signal.
+
+use wperf::cascade::engine::cascade_engine;
+use wperf::graph::types::{DISK_TID, NodeKind, ThreadId, TimeWindow, WaitType};
+use wperf::graph::wfg::WaitForGraph;
+
+fn build_mixed_graph() -> WaitForGraph {
+    let mut g = WaitForGraph::new();
+    let user = ThreadId(100);
+    let holder = ThreadId(200);
+    let disk = ThreadId(DISK_TID);
+
+    g.add_node(user, NodeKind::UserThread);
+    g.add_node(holder, NodeKind::UserThread);
+    g.add_node(disk, NodeKind::PseudoDisk);
+
+    // Real scheduler-derived wait: T100 blocked on T200 for [0, 10]ms.
+    g.add_edge(user, holder, TimeWindow::new(0, 10));
+
+    // Synthetic IO edges (ADR-009) — both directions covering same window.
+    g.add_edge_with_wait_type(holder, disk, TimeWindow::new(0, 10), WaitType::IoBlock);
+    g.add_edge_with_wait_type(disk, holder, TimeWindow::new(0, 10), WaitType::IoBlock);
+
+    g
+}
+
+#[test]
+#[allow(clippy::similar_names)] // user_holder / holder_disk / disk_holder are intentional
+fn probe_mixed_cascade_current_behavior() {
+    let g = build_mixed_graph();
+    let result = cascade_engine(&g, None).expect("cascade must succeed");
+
+    let user = ThreadId(100);
+    let holder = ThreadId(200);
+    let disk = ThreadId(DISK_TID);
+
+    // Dump every edge for the thread discussion.
+    println!("\n=== probe_mixed_cascade_current_behavior ===");
+    for (_, src, dst, weight) in result.all_edges() {
+        println!(
+            "  {:>4} → {:<4}  raw={:>3}  attributed={:>3}  wait_type={:?}",
+            src.0, dst.0, weight.raw_wait_ms, weight.attributed_delay_ms, weight.wait_type,
+        );
+    }
+    println!();
+
+    let edges = result.all_edges();
+    let user_holder = edges
+        .iter()
+        .find(|(_, s, d, _)| *s == user && *d == holder)
+        .expect("T100→T200 edge present");
+    let holder_disk = edges
+        .iter()
+        .find(|(_, s, d, _)| *s == holder && *d == disk)
+        .expect("T200→DISK edge present");
+    let disk_holder = edges
+        .iter()
+        .find(|(_, s, d, _)| *s == disk && *d == holder)
+        .expect("DISK→T200 edge present");
+
+    // Observed pre-fix attribution — see docstring for paper-intent expected
+    // values.
+    let attr_uh = user_holder.3.attributed_delay_ms;
+    let attr_hd = holder_disk.3.attributed_delay_ms;
+    let attr_dh = disk_holder.3.attributed_delay_ms;
+
+    println!("pre-fix attribution:");
+    println!("  T100→T200 (real user wait): {attr_uh}  (paper-intent: 0)");
+    println!("  T200→DISK (IO initiation):  {attr_hd}  (paper-intent: 10)");
+    println!("  DISK→T200 (return bookkeeping): {attr_dh}  (paper-intent: 0)");
+
+    // Pseudo-thread ratio candidates:
+    let ratio_both = {
+        let raw: u64 = holder_disk.3.raw_wait_ms + disk_holder.3.raw_wait_ms;
+        let attr: u64 = attr_hd + attr_dh;
+        #[allow(clippy::cast_precision_loss)]
+        (attr as f64 / raw as f64)
+    };
+    let ratio_inbound = {
+        let raw: u64 = holder_disk.3.raw_wait_ms;
+        let attr: u64 = attr_hd;
+        #[allow(clippy::cast_precision_loss)]
+        (attr as f64 / raw as f64)
+    };
+    println!();
+    println!("ratio (current impl, both dirs):   {ratio_both:.3}  (gate ≥ 0.70: FAIL if < 0.70)");
+    println!("ratio (proposed inbound-only):     {ratio_inbound:.3}");
+    println!();
+
+    // Pre-fix assertions — these will BREAK when the fix lands, which is
+    // how we detect the fix has taken effect.
+    //
+    // Intentionally uses concrete numbers so the thread can cite them.
+    assert_eq!(
+        attr_uh, 5,
+        "pre-fix T100→T200 attribution (CURRENT buggy behavior — should be 0 post-fix)"
+    );
+    assert_eq!(
+        attr_hd, 5,
+        "pre-fix T200→DISK attribution (CURRENT buggy — should be 10 post-fix)"
+    );
+    assert_eq!(
+        attr_dh, 0,
+        "DISK→T200 return bookkeeping — already 0, fix preserves"
+    );
+
+    // Current-impl ratio does not meet the gate even on mixed workload.
+    assert!(ratio_both < 0.70, "pre-fix both-dirs ratio is below gate");
+    assert!(
+        ratio_inbound < 0.70,
+        "pre-fix inbound-only ratio ALSO below gate"
+    );
+}

--- a/tests/probe_mixed_cascade.rs
+++ b/tests/probe_mixed_cascade.rs
@@ -1,36 +1,42 @@
-//! Cascade-cycle probe — mixed User-chain + IO 2-cycle graph
-//! ===========================================================
+//! Cascade-cycle post-fix verification — mixed User-chain + IO 2-cycle graph
+//! ===========================================================================
 //!
-//! Per-Adrian-request diagnostic: before any spec amendment, verify
-//! that the proposed cascade-terminal + inbound-filter fix behaves
-//! correctly in a MIXED workload (not just pure IO fixtures).
+//! Originally written as a "pre-fix red baseline" probe (PR #120 Challenger
+//! Gap 1) to demonstrate the cascade-cycle bug on a mixed workload before
+//! the ADR-009 *Amendment 2026-04-25* (PR #121, merged at `ae7a6b3`)
+//! introduced `EdgeKind::SyntheticClosureReturn` and the bilateral edge
+//! filter in `sweep_line_partition` + `count_concurrent_waiters`.
 //!
-//! Topology modeled (closest paper-like pattern for an IO-bound wait):
+//! Now the fix has landed. This file pivots from "pre-fix bug demo" to
+//! "post-fix verification with empirically-pinned magnitudes":
+//!
+//! Topology:
 //!
 //!     T100 ────[0, 10]────> T200 ←───[0, 10]─── DISK
 //!                             │                   ↑
 //!                             └───[0, 10]─────────┘
-//!                                (ADR-009 synthetic pair)
+//!                  forward (Normal)        return (SyntheticClosureReturn)
 //!
 //! Semantics: T100 (User) is blocked for 10ms waiting on T200 (Holder),
-//! which is itself doing synchronous I/O to Disk during the entire
-//! window. The ADR-009 User↔Disk pair is between T200 and Disk — the
-//! outer User→Holder wait is a normal scheduler edge, not synthetic.
+//! which is itself doing synchronous I/O to Disk during the entire window.
+//! The return edge is constructed via `add_synthetic_closure_return` so
+//! the cascade engine's bilateral filter (`sweep_line_partition` +
+//! `count_concurrent_waiters`) treats it as cascade-terminal per ADR-009
+//! Amendment.
 //!
-//! Expected intuition (paper-faithful):
+//! Expected post-fix attribution (paper-faithful):
 //!   T100→T200: 0   (T200 isn't at fault — it's itself waiting on Disk)
 //!   T200→DISK: 10  (Disk is the root cause for the full 10ms)
 //!   DISK→T200: 0   (return-edge bookkeeping, no semantic wait)
 //!   inbound-to-pseudo ratio = 10/10 = 1.0 ≥ 0.70 ✓
 //!
-//! This test records what the CURRENT (pre-fix) cascade produces so we
-//! have a before/after comparison in the thread discussion. The values
-//! asserted below are the OBSERVED pre-fix numbers, documenting the
-//! drift between code and spec §7.3. If the fix lands, this test
-//! **will fail** — that's the intended signal.
+//! These pinned values are now load-bearing: the ADR-009 Amendment
+//! frontmatter (Verification Provenance) requires re-justification at
+//! the multi-reviewer hand-trace level if a future change shifts these
+//! numbers. They are not free parameters.
 
 use wperf::cascade::engine::cascade_engine;
-use wperf::graph::types::{DISK_TID, NodeKind, ThreadId, TimeWindow, WaitType};
+use wperf::graph::types::{DISK_TID, EdgeKind, NodeKind, ThreadId, TimeWindow, WaitType};
 use wperf::graph::wfg::WaitForGraph;
 
 fn build_mixed_graph() -> WaitForGraph {
@@ -46,16 +52,21 @@ fn build_mixed_graph() -> WaitForGraph {
     // Real scheduler-derived wait: T100 blocked on T200 for [0, 10]ms.
     g.add_edge(user, holder, TimeWindow::new(0, 10));
 
-    // Synthetic IO edges (ADR-009) — both directions covering same window.
+    // Forward synthetic IO edge (User→Disk issue event) — Normal kind,
+    // participates in cascade as a real wait dependency.
     g.add_edge_with_wait_type(holder, disk, TimeWindow::new(0, 10), WaitType::IoBlock);
-    g.add_edge_with_wait_type(disk, holder, TimeWindow::new(0, 10), WaitType::IoBlock);
+
+    // Return synthetic IO edge (Disk→User completion event) —
+    // SyntheticClosureReturn kind per ADR-009 Amendment 2026-04-25.
+    // Cascade-terminal: skipped in sweep_line_partition + count_concurrent_waiters.
+    g.add_synthetic_closure_return(disk, holder, TimeWindow::new(0, 10), WaitType::IoBlock);
 
     g
 }
 
 #[test]
 #[allow(clippy::similar_names)] // user_holder / holder_disk / disk_holder are intentional
-fn probe_mixed_cascade_current_behavior() {
+fn probe_mixed_cascade_post_fix_attribution() {
     let g = build_mixed_graph();
     let result = cascade_engine(&g, None).expect("cascade must succeed");
 
@@ -63,12 +74,17 @@ fn probe_mixed_cascade_current_behavior() {
     let holder = ThreadId(200);
     let disk = ThreadId(DISK_TID);
 
-    // Dump every edge for the thread discussion.
-    println!("\n=== probe_mixed_cascade_current_behavior ===");
+    // Dump every edge for documentation.
+    println!("\n=== probe_mixed_cascade_post_fix_attribution ===");
     for (_, src, dst, weight) in result.all_edges() {
         println!(
-            "  {:>4} → {:<4}  raw={:>3}  attributed={:>3}  wait_type={:?}",
-            src.0, dst.0, weight.raw_wait_ms, weight.attributed_delay_ms, weight.wait_type,
+            "  {:>4} → {:<4}  raw={:>3}  attributed={:>3}  wait_type={:?}  kind={:?}",
+            src.0,
+            dst.0,
+            weight.raw_wait_ms,
+            weight.attributed_delay_ms,
+            weight.wait_type,
+            weight.kind,
         );
     }
     println!();
@@ -87,160 +103,199 @@ fn probe_mixed_cascade_current_behavior() {
         .find(|(_, s, d, _)| *s == disk && *d == holder)
         .expect("DISK→T200 edge present");
 
-    // Observed pre-fix attribution — see docstring for paper-intent expected
-    // values.
     let attr_uh = user_holder.3.attributed_delay_ms;
     let attr_hd = holder_disk.3.attributed_delay_ms;
     let attr_dh = disk_holder.3.attributed_delay_ms;
 
-    println!("pre-fix attribution:");
+    println!("post-fix attribution:");
     println!("  T100→T200 (real user wait): {attr_uh}  (paper-intent: 0)");
     println!("  T200→DISK (IO initiation):  {attr_hd}  (paper-intent: 10)");
     println!("  DISK→T200 (return bookkeeping): {attr_dh}  (paper-intent: 0)");
 
-    // Pseudo-thread ratio candidates:
-    let ratio_both = {
-        let raw: u64 = holder_disk.3.raw_wait_ms + disk_holder.3.raw_wait_ms;
-        let attr: u64 = attr_hd + attr_dh;
-        #[allow(clippy::cast_precision_loss)]
-        (attr as f64 / raw as f64)
-    };
-    let ratio_inbound = {
-        let raw: u64 = holder_disk.3.raw_wait_ms;
-        let attr: u64 = attr_hd;
-        #[allow(clippy::cast_precision_loss)]
-        (attr as f64 / raw as f64)
-    };
-    println!();
-    println!("ratio (current impl, both dirs):   {ratio_both:.3}  (gate ≥ 0.70: FAIL if < 0.70)");
-    println!("ratio (proposed inbound-only):     {ratio_inbound:.3}");
-    println!();
+    // Inbound-to-pseudo ratio (per §7.3 formal definition: e.dst == DISK
+    // AND e.kind != SyntheticClosureReturn — only T200→DISK qualifies).
+    let inbound_raw: u64 = holder_disk.3.raw_wait_ms;
+    let inbound_attr: u64 = attr_hd;
+    #[allow(clippy::cast_precision_loss)]
+    let ratio_inbound = inbound_attr as f64 / inbound_raw as f64;
+    println!("ratio (inbound-only, §7.3 formal): {ratio_inbound:.3}  (gate ≥ 0.70)");
 
-    // Pre-fix assertions — these will BREAK when the fix lands, which is
-    // how we detect the fix has taken effect.
-    //
-    // Intentionally uses concrete numbers so the thread can cite them.
-    assert_eq!(
-        attr_uh, 5,
-        "pre-fix T100→T200 attribution (CURRENT buggy behavior — should be 0 post-fix)"
-    );
-    assert_eq!(
-        attr_hd, 5,
-        "pre-fix T200→DISK attribution (CURRENT buggy — should be 10 post-fix)"
-    );
-    assert_eq!(
-        attr_dh, 0,
-        "DISK→T200 return bookkeeping — already 0, fix preserves"
-    );
-
-    // Current-impl ratio does not meet the gate even on mixed workload.
-    assert!(ratio_both < 0.70, "pre-fix both-dirs ratio is below gate");
-    assert!(
-        ratio_inbound < 0.70,
-        "pre-fix inbound-only ratio ALSO below gate"
-    );
-}
-
-// ============================================================================
-// Edge-filter empirical simulation — closes Challenger Gap 1
-// ============================================================================
-//
-// Challenger flagged (2026-04-25 verdict): the post-fix attribution values
-// (0, 10, 0) are human trace, not measured. Until we measure, we cannot
-// claim ratio = 1.0 post-fix — could be 0.9, 0.8, or something else.
-//
-// The proposed edge-filter rule is: during `sweep_line_partition` (cascade
-// recursion) and `count_concurrent_waiters`, skip edges that are "synthetic
-// return edges" (src is a pseudo-thread + wait_type carries the ADR-009
-// marker). The observable effect on cascade is identical to REMOVING those
-// edges from the graph entirely, because:
-//   - sweep_line_partition iterates outgoing edges — filtered = removed
-//   - count_concurrent_waiters iterates incoming — filtered = removed
-//   - the outer `for edge in graph.all_edges()` loop still includes the
-//     edge, and its attribution is computed the same way as for any other
-//     edge (propagation through the filtered view, then `raw - propagated`)
-//
-// So running current cascade on `build_mixed_graph_no_return()` (same graph
-// minus the Disk→Holder edge) measures the exact attribution the edge-filter
-// fix would produce on the forward edges — empirical, not conjectured.
-// The return edge's own attribution is known separately (it was 0 pre-fix
-// and remains 0 post-fix — confirmed in the other probe).
-
-fn build_mixed_graph_no_return() -> WaitForGraph {
-    let mut g = WaitForGraph::new();
-    let user = ThreadId(100);
-    let holder = ThreadId(200);
-    let disk = ThreadId(DISK_TID);
-
-    g.add_node(user, NodeKind::UserThread);
-    g.add_node(holder, NodeKind::UserThread);
-    g.add_node(disk, NodeKind::PseudoDisk);
-
-    g.add_edge(user, holder, TimeWindow::new(0, 10));
-    g.add_edge_with_wait_type(holder, disk, TimeWindow::new(0, 10), WaitType::IoBlock);
-    // Intentionally NO Disk→Holder return edge (simulates edge-filter skipping it)
-
-    g
-}
-
-#[test]
-#[allow(clippy::similar_names)]
-fn probe_edge_filter_simulation_post_fix_values() {
-    let g = build_mixed_graph_no_return();
-    let result = cascade_engine(&g, None).expect("cascade must succeed");
-
-    println!("\n=== probe_edge_filter_simulation_post_fix_values ===");
-    for (_, src, dst, weight) in result.all_edges() {
-        println!(
-            "  {:>4} → {:<4}  raw={:>3}  attributed={:>3}  wait_type={:?}",
-            src.0, dst.0, weight.raw_wait_ms, weight.attributed_delay_ms, weight.wait_type,
-        );
-    }
-
-    let edges = result.all_edges();
-    let user = ThreadId(100);
-    let holder = ThreadId(200);
-    let disk = ThreadId(DISK_TID);
-
-    let attr_uh = edges
-        .iter()
-        .find(|(_, s, d, _)| *s == user && *d == holder)
-        .expect("T100→T200 edge present")
-        .3
-        .attributed_delay_ms;
-    let attr_hd = edges
-        .iter()
-        .find(|(_, s, d, _)| *s == holder && *d == disk)
-        .expect("T200→DISK edge present")
-        .3
-        .attributed_delay_ms;
-
-    println!();
-    println!("edge-filter simulation (post-fix expected):");
-    println!("  T100→T200: {attr_uh}   (claimed: 0)");
-    println!("  T200→DISK: {attr_hd}   (claimed: 10)");
-
-    let ratio_inbound = {
-        let raw: u64 = 10;
-        #[allow(clippy::cast_precision_loss)]
-        (attr_hd as f64 / raw as f64)
-    };
-    println!("  ratio (inbound-only): {ratio_inbound:.3}   (gate ≥ 0.70)");
-    println!();
-
-    // Challenger Gap 1: pin the measured post-fix values. If cascade has a
-    // secondary bug that gives (0, 9, 0) instead of (0, 10, 0), this test
-    // fails loudly and we know BEFORE touching spec.
+    // Pinned post-fix expectations — these are load-bearing per ADR-009
+    // Amendment Verification Provenance. Future modifications require
+    // re-justification at multi-reviewer hand-trace level.
     assert_eq!(
         attr_uh, 0,
-        "post-fix T100→T200 MUST be 0 (T200 is victim, all blame cascades to DISK)"
+        "post-fix T100→T200 must attribute 0 (T200 is victim, all blame cascades to DISK)"
     );
     assert_eq!(
         attr_hd, 10,
-        "post-fix T200→DISK MUST be 10 (DISK is root cause, full attribution)"
+        "post-fix T200→DISK must attribute 10 (DISK is root cause, full attribution)"
+    );
+    assert_eq!(
+        attr_dh, 0,
+        "post-fix DISK→T200 (SyntheticClosureReturn) must remain 0 — closure bookkeeping retains no semantic blame"
     );
     assert!(
         (ratio_inbound - 1.0).abs() < 1e-9,
-        "post-fix inbound-only ratio MUST be 1.0, got {ratio_inbound}"
+        "post-fix inbound-only ratio must be 1.0, got {ratio_inbound}"
+    );
+
+    // Edge-kind invariants — closure-return edge MUST carry the marker;
+    // forward edges MUST be Normal. Drift on either invariant would
+    // silently re-enable the pre-fix bug.
+    assert_eq!(
+        disk_holder.3.kind,
+        EdgeKind::SyntheticClosureReturn,
+        "DISK→T200 must be marked SyntheticClosureReturn"
+    );
+    assert_eq!(
+        holder_disk.3.kind,
+        EdgeKind::Normal,
+        "T200→DISK forward edge must be Normal"
+    );
+    assert_eq!(
+        user_holder.3.kind,
+        EdgeKind::Normal,
+        "T100→T200 user-wait edge must be Normal"
+    );
+}
+
+/// 3-node Knot fixture per Probe / Critic / Challenger requirement
+/// (PR #121 thread: Probe Gap 2, Challenger msg=296b39ab Gap 2). The
+/// 2-cycle test above only validates cascade attribution; this fixture
+/// exercises the SCC + critical-path DP path with a pseudo-thread inside
+/// the SCC, ensuring the bilateral edge-filter doesn't accidentally
+/// regress Knot detection or DP behavior on graphs that contain a real
+/// SCC closure plus an upstream entry edge.
+///
+/// Topology:
+///
+///     T1 ────[0, 10]────> T2 ←───[0, 10]─── DISK
+///                          │                  ↑
+///                          └───[0, 10]────────┘
+///                  forward (Normal)    return (SyntheticClosureReturn)
+///
+/// - {T2, DISK} forms an SCC (T2 → DISK forward + DISK → T2 closure).
+/// - T1 → T2 is the SCC entry edge.
+/// - The SCC is a sink in the condensation DAG (no outgoing from {T2, DISK}
+///   to anything outside the SCC), so it qualifies as a Knot per ADR-008
+///   if it contains ≥1 user thread (T2 is a `UserThread`).
+///
+/// Post-fix expected:
+///   T1→T2:   attributed=0  (T2 is victim, all blame cascades to DISK)
+///   T2→DISK: attributed=10 (DISK root cause)
+///   DISK→T2: attributed=0  (closure-return bookkeeping)
+///   The SCC {T2, DISK} is detected as a Knot containing a `UserThread`
+///   (T2). Critical-path DP super-node weight per ADR-008 MAX heuristic
+///   = max(attributed across internal edges) = max(10, 0) = 10.
+#[test]
+fn probe_3node_knot_with_pseudo_thread() {
+    use wperf::scc::knot::detect_knots;
+    use wperf::scc::tarjan::build_condensation;
+
+    let mut g = WaitForGraph::new();
+    let t1 = ThreadId(1);
+    let t2 = ThreadId(2);
+    let disk = ThreadId(DISK_TID);
+
+    g.add_node(t1, NodeKind::UserThread);
+    g.add_node(t2, NodeKind::UserThread);
+    g.add_node(disk, NodeKind::PseudoDisk);
+
+    g.add_edge(t1, t2, TimeWindow::new(0, 10));
+    g.add_edge_with_wait_type(t2, disk, TimeWindow::new(0, 10), WaitType::IoBlock);
+    g.add_synthetic_closure_return(disk, t2, TimeWindow::new(0, 10), WaitType::IoBlock);
+
+    let cascaded = cascade_engine(&g, None).expect("cascade must succeed");
+
+    // Cascade attribution post-fix.
+    let edges = cascaded.all_edges();
+    let attr = |s: ThreadId, d: ThreadId| -> u64 {
+        match edges.iter().find(|(_, src, dst, _)| *src == s && *dst == d) {
+            Some((_, _, _, w)) => w.attributed_delay_ms,
+            None => panic!("edge {}→{} not found", s.0, d.0),
+        }
+    };
+    assert_eq!(
+        attr(t1, t2),
+        0,
+        "T1→T2: T2 is victim, blame cascades to DISK"
+    );
+    assert_eq!(attr(t2, disk), 10, "T2→DISK: full attribution");
+    assert_eq!(
+        attr(disk, t2),
+        0,
+        "DISK→T2 (SyntheticClosureReturn): closure bookkeeping retains no blame"
+    );
+
+    // Tarjan SCC detection — the {T2, DISK} pair must form an SCC because
+    // both edges (forward + return) participate in adjacency analysis,
+    // even though the return edge is cascade-terminal.
+    let cdag = build_condensation(&cascaded);
+    let knots = detect_knots(&cdag, &cascaded);
+
+    // The {T2, DISK} SCC must be detected as a Knot:
+    // - It is a sink in the condensation DAG (no edges out)
+    // - It contains a UserThread (T2)
+    let knot_with_t2 = knots.iter().find(|k| k.members.contains(&t2));
+    assert!(
+        knot_with_t2.is_some(),
+        "{{T2, DISK}} SCC must be detected as Knot (sink + contains UserThread T2); got knots: {knots:?}"
+    );
+    let knot = knot_with_t2.unwrap();
+    assert!(
+        knot.members.contains(&disk),
+        "Knot must contain DISK pseudo-thread: {knot:?}"
+    );
+    assert_eq!(knot.members.len(), 2, "Knot is exactly {{T2, DISK}}");
+}
+
+#[test]
+fn probe_mixed_cascade_filter_must_apply_bilaterally() {
+    // Defense-in-depth check: if a future regression filters the SCR
+    // edge in sweep but not in count_concurrent_waiters (or vice versa),
+    // the divisor stays polluted and forward-edge attribution silently
+    // halves. This test would catch that — currently both filters are
+    // correctly applied so attribution is 10 (full); a single-side
+    // regression would push it down to 5 (the pre-fix value), which the
+    // strict equality assertion above also catches.
+    //
+    // We add a separate fixture here that adds an extra Normal incoming
+    // edge to T200 (a third user T300 also waiting on T200). With the
+    // bilateral filter correctly applied, count_concurrent_waiters(T200)
+    // = 2 (T100 + T300), not 3 (T100 + T300 + DISK-via-SCR). The forward
+    // edge T200→DISK still gets attribution = 10 because Disk's own sweep
+    // is empty (no Normal outgoing).
+
+    let mut g = WaitForGraph::new();
+    let t100 = ThreadId(100);
+    let t300 = ThreadId(300);
+    let holder = ThreadId(200);
+    let disk = ThreadId(DISK_TID);
+
+    g.add_node(t100, NodeKind::UserThread);
+    g.add_node(t300, NodeKind::UserThread);
+    g.add_node(holder, NodeKind::UserThread);
+    g.add_node(disk, NodeKind::PseudoDisk);
+
+    g.add_edge(t100, holder, TimeWindow::new(0, 10));
+    g.add_edge(t300, holder, TimeWindow::new(0, 10));
+    g.add_edge_with_wait_type(holder, disk, TimeWindow::new(0, 10), WaitType::IoBlock);
+    g.add_synthetic_closure_return(disk, holder, TimeWindow::new(0, 10), WaitType::IoBlock);
+
+    let result = cascade_engine(&g, None).expect("cascade must succeed");
+
+    let edges = result.all_edges();
+    let holder_disk = edges
+        .iter()
+        .find(|(_, s, d, _)| *s == holder && *d == disk)
+        .expect("T200→DISK edge present");
+
+    // T200→DISK forward attribution must still be 10 — the third user
+    // T300 doesn't change this because Disk is a leaf for cascade
+    // (its only outgoing is the SCR edge, which is filtered).
+    assert_eq!(
+        holder_disk.3.attributed_delay_ms, 10,
+        "T200→DISK forward attribution unaffected by additional concurrent waiters on T200"
     );
 }

--- a/tests/probe_mixed_cascade.rs
+++ b/tests/probe_mixed_cascade.rs
@@ -140,3 +140,107 @@ fn probe_mixed_cascade_current_behavior() {
         "pre-fix inbound-only ratio ALSO below gate"
     );
 }
+
+// ============================================================================
+// Edge-filter empirical simulation — closes Challenger Gap 1
+// ============================================================================
+//
+// Challenger flagged (2026-04-25 verdict): the post-fix attribution values
+// (0, 10, 0) are human trace, not measured. Until we measure, we cannot
+// claim ratio = 1.0 post-fix — could be 0.9, 0.8, or something else.
+//
+// The proposed edge-filter rule is: during `sweep_line_partition` (cascade
+// recursion) and `count_concurrent_waiters`, skip edges that are "synthetic
+// return edges" (src is a pseudo-thread + wait_type carries the ADR-009
+// marker). The observable effect on cascade is identical to REMOVING those
+// edges from the graph entirely, because:
+//   - sweep_line_partition iterates outgoing edges — filtered = removed
+//   - count_concurrent_waiters iterates incoming — filtered = removed
+//   - the outer `for edge in graph.all_edges()` loop still includes the
+//     edge, and its attribution is computed the same way as for any other
+//     edge (propagation through the filtered view, then `raw - propagated`)
+//
+// So running current cascade on `build_mixed_graph_no_return()` (same graph
+// minus the Disk→Holder edge) measures the exact attribution the edge-filter
+// fix would produce on the forward edges — empirical, not conjectured.
+// The return edge's own attribution is known separately (it was 0 pre-fix
+// and remains 0 post-fix — confirmed in the other probe).
+
+fn build_mixed_graph_no_return() -> WaitForGraph {
+    let mut g = WaitForGraph::new();
+    let user = ThreadId(100);
+    let holder = ThreadId(200);
+    let disk = ThreadId(DISK_TID);
+
+    g.add_node(user, NodeKind::UserThread);
+    g.add_node(holder, NodeKind::UserThread);
+    g.add_node(disk, NodeKind::PseudoDisk);
+
+    g.add_edge(user, holder, TimeWindow::new(0, 10));
+    g.add_edge_with_wait_type(holder, disk, TimeWindow::new(0, 10), WaitType::IoBlock);
+    // Intentionally NO Disk→Holder return edge (simulates edge-filter skipping it)
+
+    g
+}
+
+#[test]
+#[allow(clippy::similar_names)]
+fn probe_edge_filter_simulation_post_fix_values() {
+    let g = build_mixed_graph_no_return();
+    let result = cascade_engine(&g, None).expect("cascade must succeed");
+
+    println!("\n=== probe_edge_filter_simulation_post_fix_values ===");
+    for (_, src, dst, weight) in result.all_edges() {
+        println!(
+            "  {:>4} → {:<4}  raw={:>3}  attributed={:>3}  wait_type={:?}",
+            src.0, dst.0, weight.raw_wait_ms, weight.attributed_delay_ms, weight.wait_type,
+        );
+    }
+
+    let edges = result.all_edges();
+    let user = ThreadId(100);
+    let holder = ThreadId(200);
+    let disk = ThreadId(DISK_TID);
+
+    let attr_uh = edges
+        .iter()
+        .find(|(_, s, d, _)| *s == user && *d == holder)
+        .expect("T100→T200 edge present")
+        .3
+        .attributed_delay_ms;
+    let attr_hd = edges
+        .iter()
+        .find(|(_, s, d, _)| *s == holder && *d == disk)
+        .expect("T200→DISK edge present")
+        .3
+        .attributed_delay_ms;
+
+    println!();
+    println!("edge-filter simulation (post-fix expected):");
+    println!("  T100→T200: {attr_uh}   (claimed: 0)");
+    println!("  T200→DISK: {attr_hd}   (claimed: 10)");
+
+    let ratio_inbound = {
+        let raw: u64 = 10;
+        #[allow(clippy::cast_precision_loss)]
+        (attr_hd as f64 / raw as f64)
+    };
+    println!("  ratio (inbound-only): {ratio_inbound:.3}   (gate ≥ 0.70)");
+    println!();
+
+    // Challenger Gap 1: pin the measured post-fix values. If cascade has a
+    // secondary bug that gives (0, 9, 0) instead of (0, 10, 0), this test
+    // fails loudly and we know BEFORE touching spec.
+    assert_eq!(
+        attr_uh, 0,
+        "post-fix T100→T200 MUST be 0 (T200 is victim, all blame cascades to DISK)"
+    );
+    assert_eq!(
+        attr_hd, 10,
+        "post-fix T200→DISK MUST be 10 (DISK is root cause, full attribution)"
+    );
+    assert!(
+        (ratio_inbound - 1.0).abs() < 1e-9,
+        "post-fix inbound-only ratio MUST be 1.0, got {ratio_inbound}"
+    );
+}

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -10,6 +10,8 @@ use wperf::cascade::invariants::{
     check_idempotency, check_locality, check_non_amplification, check_non_negativity,
     check_termination, invariants_ok,
 };
+use wperf::correlate::correlate_events;
+use wperf::format::event::{EventType, WperfEvent};
 use wperf::graph::types::*;
 use wperf::graph::wfg::WaitForGraph;
 use wperf::scc::tarjan::build_condensation;
@@ -105,5 +107,128 @@ proptest! {
             petgraph::algo::toposort(&cdag.dag, None).is_ok(),
             "condensation DAG has a cycle"
         );
+    }
+}
+
+// =============================================================================
+// Phase 2b #38 commit-4 — Synthetic IO edge invariants
+// =============================================================================
+//
+// Property: graphs produced by correlate_events() from random IoIssue /
+// IoComplete event streams satisfy `invariants_ok` (I-2 ∧ I-7) after cascade.
+// ADR-009 specifies pseudo-threads participate fully in Tarjan analysis; this
+// proptest guards against regressions where synthetic edge generation drifts
+// away from the correlate → cascade contract.
+
+#[allow(clippy::similar_names)] // tgid / tid mirror WperfEvent field names
+fn io_event(ts_ns: u64, tgid: u32, tid: u32, dev: u32, sector: u64, kind: EventType) -> WperfEvent {
+    WperfEvent {
+        timestamp_ns: ts_ns,
+        pid: tgid,
+        tid,
+        // io_sector() packs prev_tid | next_tid<<32
+        prev_tid: u32::try_from(sector & 0xFFFF_FFFF).unwrap(),
+        next_tid: u32::try_from(sector >> 32).unwrap(),
+        // io_dev() reads prev_pid, io_nr_sector() reads next_pid
+        prev_pid: dev,
+        next_pid: 8,
+        cpu: 0,
+        event_type: kind as u8,
+        prev_state: 0,
+        flags: 0,
+    }
+}
+
+/// Generate a random sorted stream of `IoIssue` + (optional) `IoComplete` events.
+///
+/// Each I/O is characterized by `(issuer_tid, dev, sector, issue_ts, delta_ns,
+/// pairs)`. When `pairs` is true an `IoComplete` event follows at `issue_ts +
+/// delta_ns`; when false the issue dangles (pending-at-end — orphan counter
+/// scaffolding, commit-5).
+fn arb_io_stream() -> impl Strategy<Value = Vec<WperfEvent>> {
+    let io_spec = (
+        1u32..=8,                   // tid  (1..=8 keeps graphs small + diverse)
+        0x800_0001u32..=0x800_0008, // dev
+        0u64..=0xFFFF,              // sector
+        0u64..=10_000_000,          // issue_ts_ns (0..10ms range)
+        1_000u64..=5_000_000,       // delta_ns (1μs..5ms service time)
+        any::<bool>(),              // paired?
+    );
+
+    prop::collection::vec(io_spec, 1..=50)
+        .prop_map(|specs| {
+            let mut events: Vec<WperfEvent> = Vec::with_capacity(specs.len() * 2);
+            let mut seen_keys: std::collections::HashSet<(u32, u64)> =
+                std::collections::HashSet::new();
+
+            for (tid, dev, sector, issue_ts, delta, paired) in specs {
+                // Dedupe (dev, sector) within this shrink — the userspace
+                // IoKey = (dev, sector, nr_sector), and all nr_sector are fixed
+                // at 8 here so same (dev, sector) would collide on overwrite.
+                // The overwrite behavior is validated elsewhere; the proptest
+                // focuses on graph invariants, not last-writer-wins semantics.
+                if !seen_keys.insert((dev, sector)) {
+                    continue;
+                }
+                events.push(io_event(
+                    issue_ts,
+                    tid,
+                    tid,
+                    dev,
+                    sector,
+                    EventType::IoIssue,
+                ));
+                if paired {
+                    let complete_ts = issue_ts.saturating_add(delta);
+                    events.push(io_event(
+                        complete_ts,
+                        tid,
+                        tid,
+                        dev,
+                        sector,
+                        EventType::IoComplete,
+                    ));
+                }
+            }
+
+            events.sort_by_key(|e| e.timestamp_ns);
+            events
+        })
+        .prop_filter("stream must produce at least one IoIssue", |v| {
+            !v.is_empty()
+        })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2_000))]
+
+    #[test]
+    fn io_synthetic_edges_preserve_invariants_ok(events in arb_io_stream()) {
+        let (graph, _) = correlate_events(&events, 0);
+        if graph.edge_count() == 0 {
+            // Edge-less graphs are trivially invariant-preserving and the
+            // cascade engine asserts non-empty input.
+            return Ok(());
+        }
+
+        let result = cascade_engine(&graph, None).expect("cascade must not fail on valid WFG");
+
+        prop_assert!(
+            invariants_ok(&graph, &result),
+            "I-2 ∧ I-7 production sentinel failed on synthetic-edge graph"
+        );
+        prop_assert!(check_non_amplification(&result), "I-2 violated");
+        prop_assert!(check_non_negativity(&result), "I-3 violated");
+        prop_assert!(check_termination(&graph, &result), "I-4 violated");
+        prop_assert!(check_locality(&graph, &result), "I-7 violated");
+    }
+
+    #[test]
+    fn io_synthetic_edges_idempotent(events in arb_io_stream()) {
+        let (graph, _) = correlate_events(&events, 0);
+        if graph.edge_count() == 0 {
+            return Ok(());
+        }
+        prop_assert!(check_idempotency(&graph, 3), "I-5 (idempotency) failed");
     }
 }

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -258,7 +258,8 @@ fn snapshot_unmatched_wakeup_report() {
 
 #[test]
 fn snapshot_health_metrics_schema() {
-    // Verifies all 6 health fields: 3 actual + 3 null (unavailable in Phase 1).
+    // Verifies all 10 health fields: core set + 4 block-IO fields added in
+    // Phase 2b #38 commit-5. Phase 1 + #38 unavailable fields stay null.
     let events = vec![
         switch_event(1_000_000, 101, 202),
         wakeup_event(2_000_000, 201, 101),

--- a/tests/snapshots/snapshot_tests__snapshot_empty_trace_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_empty_trace_report.snap
@@ -13,10 +13,14 @@ cascade:
     total_raw_wait_ms: 0
 critical_path: ~
 health:
+  attributed_delay_ratio: ~
   cascade_depth_truncation_count: ~
   drop_count: 0
   false_wakeup_filtered_count: 0
   invariants_ok: true
+  io_orphan_complete_count: 0
+  io_pending_at_end_count: 0
+  io_userspace_pair_collision_count: 0
   partial_stack_count: ~
   unmatched_wakeup_count: 0
 knots: []
@@ -25,6 +29,9 @@ stats:
     edges_created: 0
     events_processed: 0
     false_wakeup_filtered_count: 0
+    io_orphan_complete_count: 0
+    io_pending_at_end_count: 0
+    io_userspace_pair_collision_count: 0
     switch_in_without_waker_count: 0
     unknown_event_type_count: 0
     unmatched_switch_in_count: 0

--- a/tests/snapshots/snapshot_tests__snapshot_empty_trace_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_empty_trace_report.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/snapshot_tests.rs
+assertion_line: 234
 expression: json
 ---
 cascade:
@@ -25,6 +26,7 @@ stats:
     events_processed: 0
     false_wakeup_filtered_count: 0
     switch_in_without_waker_count: 0
+    unknown_event_type_count: 0
     unmatched_switch_in_count: 0
     unmatched_wakeup_count: 0
   events_read: 0

--- a/tests/snapshots/snapshot_tests__snapshot_health_metrics_schema.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_health_metrics_schema.snap
@@ -2,9 +2,13 @@
 source: tests/snapshot_tests.rs
 expression: health_json
 ---
+attributed_delay_ratio: ~
 cascade_depth_truncation_count: ~
 drop_count: 7
 false_wakeup_filtered_count: 0
 invariants_ok: true
+io_orphan_complete_count: 0
+io_pending_at_end_count: 0
+io_userspace_pair_collision_count: 0
 partial_stack_count: ~
 unmatched_wakeup_count: 0

--- a/tests/snapshots/snapshot_tests__snapshot_single_edge_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_single_edge_report.snap
@@ -25,10 +25,14 @@ critical_path:
       weight: 2
   total_weight: 6
 health:
+  attributed_delay_ratio: ~
   cascade_depth_truncation_count: ~
   drop_count: 5
   false_wakeup_filtered_count: 0
   invariants_ok: true
+  io_orphan_complete_count: 0
+  io_pending_at_end_count: 0
+  io_userspace_pair_collision_count: 0
   partial_stack_count: ~
   unmatched_wakeup_count: 0
 knots: []
@@ -37,6 +41,9 @@ stats:
     edges_created: 1
     events_processed: 3
     false_wakeup_filtered_count: 0
+    io_orphan_complete_count: 0
+    io_pending_at_end_count: 0
+    io_userspace_pair_collision_count: 0
     switch_in_without_waker_count: 0
     unknown_event_type_count: 0
     unmatched_switch_in_count: 1

--- a/tests/snapshots/snapshot_tests__snapshot_single_edge_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_single_edge_report.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/snapshot_tests.rs
+assertion_line: 247
 expression: json
 ---
 cascade:
@@ -37,6 +38,7 @@ stats:
     events_processed: 3
     false_wakeup_filtered_count: 0
     switch_in_without_waker_count: 0
+    unknown_event_type_count: 0
     unmatched_switch_in_count: 1
     unmatched_wakeup_count: 0
   events_read: 3

--- a/tests/snapshots/snapshot_tests__snapshot_unmatched_wakeup_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_unmatched_wakeup_report.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/snapshot_tests.rs
+assertion_line: 256
 expression: json
 ---
 cascade:
@@ -25,6 +26,7 @@ stats:
     events_processed: 1
     false_wakeup_filtered_count: 0
     switch_in_without_waker_count: 0
+    unknown_event_type_count: 0
     unmatched_switch_in_count: 0
     unmatched_wakeup_count: 1
   events_read: 1

--- a/tests/snapshots/snapshot_tests__snapshot_unmatched_wakeup_report.snap
+++ b/tests/snapshots/snapshot_tests__snapshot_unmatched_wakeup_report.snap
@@ -13,10 +13,14 @@ cascade:
     total_raw_wait_ms: 0
 critical_path: ~
 health:
+  attributed_delay_ratio: ~
   cascade_depth_truncation_count: ~
   drop_count: 0
   false_wakeup_filtered_count: 0
   invariants_ok: true
+  io_orphan_complete_count: 0
+  io_pending_at_end_count: 0
+  io_userspace_pair_collision_count: 0
   partial_stack_count: ~
   unmatched_wakeup_count: 1
 knots: []
@@ -25,6 +29,9 @@ stats:
     edges_created: 0
     events_processed: 1
     false_wakeup_filtered_count: 0
+    io_orphan_complete_count: 0
+    io_pending_at_end_count: 0
+    io_userspace_pair_collision_count: 0
     switch_in_without_waker_count: 0
     unknown_event_type_count: 0
     unmatched_switch_in_count: 0

--- a/tests/workloads/run_cross_kernel_e2e.sh
+++ b/tests/workloads/run_cross_kernel_e2e.sh
@@ -247,6 +247,6 @@ fi
 echo ""
 echo "=== Cross-Kernel E2E Phase 2 (block_rq smoke): PASSED ==="
 echo "  kernel $(uname -r): block_rq path exercised"
-echo "  events=$IO_EVENTS edges=$IO_EDGE_COUNT ratio=$IO_RATIO"
+echo "  events=$IO_EVENTS edges=$IO_EDGE_COUNT ratio=$IO_RATIO_RAW"
 echo ""
 echo "=== Cross-Kernel E2E: ALL PHASES PASSED ==="

--- a/tests/workloads/run_cross_kernel_e2e.sh
+++ b/tests/workloads/run_cross_kernel_e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Cross-kernel E2E smoke test (W4 #25).
+# Cross-kernel E2E smoke test (W4 #25, extended for #38 P2b-01 commit-7).
 # Requires: root, BPF-enabled kernel, wperf built with --features bpf.
 #
 # Verifies the full pipeline (record → report) works on the current kernel:
@@ -9,6 +9,8 @@
 # - Feature probing selects correct transport + tracepoint variant
 # - Events captured from scheduler tracepoints
 # - Report generation produces valid output with health invariants
+# - block_rq tracepoints observable through synthetic User↔Disk edges and
+#   the `attributed_delay_ratio` / io_* HealthMetrics fields (commit-7)
 
 set -euo pipefail
 
@@ -18,12 +20,18 @@ WORKLOAD_SRC="$SCRIPT_DIR/mutex_knot.c"
 WORKLOAD_BIN="$SCRIPT_DIR/mutex_knot"
 TRACE_FILE="$(mktemp /tmp/cross_kernel_e2e_XXXXXX.wperf)"
 REPORT_FILE="$(mktemp /tmp/cross_kernel_e2e_XXXXXX.json)"
+IO_TRACE_FILE="$(mktemp /tmp/cross_kernel_io_XXXXXX.wperf)"
+IO_REPORT_FILE="$(mktemp /tmp/cross_kernel_io_XXXXXX.json)"
+IO_WORKLOAD_FILE="$(mktemp /tmp/cross_kernel_io_data_XXXXXX.bin)"
 WPERF="$REPO_DIR/target/release/wperf"
 DURATION=3
 
 cleanup() {
     [ -n "${WORKLOAD_PID:-}" ] && kill "$WORKLOAD_PID" 2>/dev/null || true
-    rm -f "$TRACE_FILE" "$REPORT_FILE" "$WORKLOAD_BIN" "${RECORD_STDERR:-}"
+    [ -n "${IO_WORKLOAD_PID:-}" ] && kill "$IO_WORKLOAD_PID" 2>/dev/null || true
+    rm -f "$TRACE_FILE" "$REPORT_FILE" "$WORKLOAD_BIN" "${RECORD_STDERR:-}" \
+          "$IO_TRACE_FILE" "$IO_REPORT_FILE" "$IO_WORKLOAD_FILE" \
+          "${IO_RECORD_STDERR:-}"
 }
 trap cleanup EXIT
 
@@ -126,6 +134,116 @@ TRACE_SIZE=$(stat -c%s "$TRACE_FILE" 2>/dev/null || stat -f%z "$TRACE_FILE")
 echo "  trace_size:     $TRACE_SIZE bytes"
 
 echo ""
-echo "=== Cross-Kernel E2E: PASSED ==="
+echo "=== Cross-Kernel E2E Phase 1 (mutex_knot): PASSED ==="
 echo "  kernel $(uname -r): record + report pipeline verified"
 echo "  events=$EVENTS_READ edges=$EDGE_COUNT invariants=ok drops=$DROP_COUNT"
+
+# =============================================================================
+# Phase 2 — block_rq runtime smoke (#38 P2b-01 commit-7)
+# =============================================================================
+# Exercises block_rq_issue / block_rq_complete end-to-end:
+#   1. wperf record runs during a `dd` pass that forces synchronous disk I/O
+#      via O_SYNC + conv=fsync so block_rq_issue/complete fire observably.
+#   2. wperf report produces the health fields introduced in commits 3-5:
+#      io_orphan_complete_count, io_pending_at_end_count,
+#      io_userspace_pair_collision_count, attributed_delay_ratio.
+#   3. Assertions: the IO health fields are non-null (tracing actually ran),
+#      attributed_delay_ratio is in [0.0, 1.0] (well-defined), and — if the
+#      ratio is a number — the graph contains at least one IoBlock-origin
+#      DISK_TID(-5) node or edge indicating real synthetic-edge generation.
+#
+# NOTE: on an idle GitHub runner a dd burst may still miss block_rq_issue on
+# tmpfs or very short-duration runs. We request a small but non-trivial
+# workload (4MB forced-fsync) and keep the assertions loose enough that the
+# test passes on kernels where block_rq didn't fire (fields are None rather
+# than populated) — that path is still a correctness signal.
+
+echo ""
+echo "=== Cross-Kernel E2E Phase 2: block_rq smoke ==="
+
+# Run wperf record during a sync-fsync dd pass. We write to a file on the
+# default tmpdir filesystem; on most GitHub runners this is a backing
+# filesystem that does hit block_rq tracepoints (not pure tmpfs).
+IO_RECORD_STDERR="$(mktemp /tmp/cross_kernel_io_record_XXXXXX.txt)"
+
+# Background the dd workload and sample during wperf recording. 4MB fsynced
+# in 4KB writes yields ~1024 block_rq_issue events on backing devices.
+(
+    sleep 0.2
+    dd if=/dev/zero of="$IO_WORKLOAD_FILE" bs=4K count=1024 conv=fsync 2>/dev/null || true
+    sync
+) &
+IO_WORKLOAD_PID=$!
+
+"$WPERF" record -o "$IO_TRACE_FILE" -d $((DURATION + 1)) 2>"$IO_RECORD_STDERR" || {
+    echo "FAIL: wperf record (IO phase) exited with error" >&2
+    cat "$IO_RECORD_STDERR" >&2
+    rm -f "$IO_RECORD_STDERR"
+    exit 1
+}
+wait "$IO_WORKLOAD_PID" || true
+
+echo "--- wperf record (IO phase) stderr ---"
+cat "$IO_RECORD_STDERR"
+rm -f "$IO_RECORD_STDERR"
+
+"$WPERF" report "$IO_TRACE_FILE" > "$IO_REPORT_FILE"
+
+IO_EVENTS=$(jq '.stats.events_read' "$IO_REPORT_FILE")
+IO_INVARIANTS=$(jq '.health.invariants_ok' "$IO_REPORT_FILE")
+IO_ORPHAN=$(jq '.health.io_orphan_complete_count' "$IO_REPORT_FILE")
+IO_PENDING=$(jq '.health.io_pending_at_end_count' "$IO_REPORT_FILE")
+IO_COLLISION=$(jq '.health.io_userspace_pair_collision_count' "$IO_REPORT_FILE")
+IO_RATIO=$(jq '.health.attributed_delay_ratio' "$IO_REPORT_FILE")
+IO_EDGE_COUNT=$(jq '.cascade.graph_metrics.edge_count' "$IO_REPORT_FILE")
+
+echo "  events_read:                    $IO_EVENTS"
+echo "  edge_count:                     $IO_EDGE_COUNT"
+echo "  invariants_ok:                  $IO_INVARIANTS"
+echo "  io_orphan_complete_count:       $IO_ORPHAN"
+echo "  io_pending_at_end_count:        $IO_PENDING"
+echo "  io_userspace_pair_collision:    $IO_COLLISION"
+echo "  attributed_delay_ratio:         $IO_RATIO"
+
+if [ "$IO_INVARIANTS" != "true" ]; then
+    echo "FAIL: IO-phase invariants violated" >&2
+    jq '.health' "$IO_REPORT_FILE" >&2
+    exit 1
+fi
+
+# IO health fields must always be present (Some(_)) — confirms the plumbing
+# is wired through build_report. Null values would mean the commit-5
+# wiring regressed.
+if [ "$IO_ORPHAN" = "null" ] || [ "$IO_PENDING" = "null" ] || [ "$IO_COLLISION" = "null" ]; then
+    echo "FAIL: HealthMetrics IO counter fields must be populated (commit-5 wiring)" >&2
+    jq '.health' "$IO_REPORT_FILE" >&2
+    exit 1
+fi
+
+# attributed_delay_ratio is either null (no IoBlock edges seen) or a number
+# in [0.0, 1.0]. Anything else is a regression. Use jq numeric comparison.
+if [ "$IO_RATIO" != "null" ]; then
+    RATIO_OK=$(jq -r '.health.attributed_delay_ratio | if . >= 0.0 and . <= 1.0 then "ok" else "bad" end' "$IO_REPORT_FILE")
+    if [ "$RATIO_OK" != "ok" ]; then
+        echo "FAIL: attributed_delay_ratio out of [0.0, 1.0]: $IO_RATIO" >&2
+        exit 1
+    fi
+fi
+
+# If attributed_delay_ratio is populated, block_rq actually fired and
+# DISK_TID(-5) should appear as src or dst of at least one edge.
+if [ "$IO_RATIO" != "null" ]; then
+    DISK_EDGES=$(jq '[.cascade.edges[] | select(.src == -5 or .dst == -5)] | length' "$IO_REPORT_FILE")
+    echo "  disk_pseudo_edges:              $DISK_EDGES"
+    if [ "$DISK_EDGES" -eq 0 ]; then
+        echo "FAIL: ratio populated but no DISK_TID(-5) edges present — synthetic edge injection inconsistent" >&2
+        exit 1
+    fi
+fi
+
+echo ""
+echo "=== Cross-Kernel E2E Phase 2 (block_rq smoke): PASSED ==="
+echo "  kernel $(uname -r): block_rq path exercised"
+echo "  events=$IO_EVENTS edges=$IO_EDGE_COUNT ratio=$IO_RATIO"
+echo ""
+echo "=== Cross-Kernel E2E: ALL PHASES PASSED ==="

--- a/tests/workloads/run_cross_kernel_e2e.sh
+++ b/tests/workloads/run_cross_kernel_e2e.sh
@@ -194,7 +194,11 @@ IO_INVARIANTS=$(jq '.health.invariants_ok' "$IO_REPORT_FILE")
 IO_ORPHAN=$(jq '.health.io_orphan_complete_count' "$IO_REPORT_FILE")
 IO_PENDING=$(jq '.health.io_pending_at_end_count' "$IO_REPORT_FILE")
 IO_COLLISION=$(jq '.health.io_userspace_pair_collision_count' "$IO_REPORT_FILE")
-IO_RATIO=$(jq '.health.attributed_delay_ratio' "$IO_REPORT_FILE")
+# attributed_delay_ratio is now a per-IO-pseudo-thread map (post-commit-10
+# per-P promotion per spec §7.3 (a) per-P quantification). JSON shape:
+#   null  — (b) hard precondition: no IO pseudo-thread has a defined ratio
+#   {"disk": <number>, "nic": <number>, ...}  — per-P entries in [0.0, 1.0]
+IO_RATIO_RAW=$(jq -c '.health.attributed_delay_ratio' "$IO_REPORT_FILE")
 IO_EDGE_COUNT=$(jq '.cascade.graph_metrics.edge_count' "$IO_REPORT_FILE")
 
 echo "  events_read:                    $IO_EVENTS"
@@ -203,7 +207,7 @@ echo "  invariants_ok:                  $IO_INVARIANTS"
 echo "  io_orphan_complete_count:       $IO_ORPHAN"
 echo "  io_pending_at_end_count:        $IO_PENDING"
 echo "  io_userspace_pair_collision:    $IO_COLLISION"
-echo "  attributed_delay_ratio:         $IO_RATIO"
+echo "  attributed_delay_ratio:         $IO_RATIO_RAW"
 
 if [ "$IO_INVARIANTS" != "true" ]; then
     echo "FAIL: IO-phase invariants violated" >&2
@@ -220,19 +224,18 @@ if [ "$IO_ORPHAN" = "null" ] || [ "$IO_PENDING" = "null" ] || [ "$IO_COLLISION" 
     exit 1
 fi
 
-# attributed_delay_ratio is either null (no IoBlock edges seen) or a number
-# in [0.0, 1.0]. Anything else is a regression. Use jq numeric comparison.
-if [ "$IO_RATIO" != "null" ]; then
-    RATIO_OK=$(jq -r '.health.attributed_delay_ratio | if . >= 0.0 and . <= 1.0 then "ok" else "bad" end' "$IO_REPORT_FILE")
+# Per-P validation: each value must be a number in [0.0, 1.0].
+if [ "$IO_RATIO_RAW" != "null" ]; then
+    RATIO_OK=$(jq -r '.health.attributed_delay_ratio | to_entries | all(.value | type == "number" and . >= 0.0 and . <= 1.0) | if . then "ok" else "bad" end' "$IO_REPORT_FILE")
     if [ "$RATIO_OK" != "ok" ]; then
-        echo "FAIL: attributed_delay_ratio out of [0.0, 1.0]: $IO_RATIO" >&2
+        echo "FAIL: per-P attributed_delay_ratio entries out of [0.0, 1.0]: $IO_RATIO_RAW" >&2
         exit 1
     fi
 fi
 
 # If attributed_delay_ratio is populated, block_rq actually fired and
 # DISK_TID(-5) should appear as src or dst of at least one edge.
-if [ "$IO_RATIO" != "null" ]; then
+if [ "$IO_RATIO_RAW" != "null" ]; then
     DISK_EDGES=$(jq '[.cascade.edges[] | select(.src == -5 or .dst == -5)] | length' "$IO_REPORT_FILE")
     echo "  disk_pseudo_edges:              $DISK_EDGES"
     if [ "$DISK_EDGES" -eq 0 ]; then

--- a/tests/workloads/run_cross_kernel_e2e.sh
+++ b/tests/workloads/run_cross_kernel_e2e.sh
@@ -248,5 +248,98 @@ echo ""
 echo "=== Cross-Kernel E2E Phase 2 (block_rq smoke): PASSED ==="
 echo "  kernel $(uname -r): block_rq path exercised"
 echo "  events=$IO_EVENTS edges=$IO_EDGE_COUNT ratio=$IO_RATIO_RAW"
+
+# =============================================================================
+# Phase 3 — multi-bio / large-IO partial-completion regression (#38 commit-11)
+# =============================================================================
+# Probe kernel-source audit (msg=8202789c §1-2) verified that
+# `trace_block_rq_complete` fires BEFORE `blk_update_request` mutates
+# `req->__sector` / `req->__data_len` on the FIRST call, but mutates them
+# BEFORE subsequent invocations during partial completion. Multi-bio
+# requests (large I/O > BIO_MAX_VECS, fragmented writes, NVMe retries,
+# multipath SAN) exercise the partial-completion path.
+#
+# Phase 2 used a 4MB workload through small 4K blocks (1024 paired I/Os);
+# this exercises the multi-bio path where real workloads might trip the
+# original (pre-commit-11) bug of reading mutated `__sector` at completion.
+# Phase 3 doubles the per-block size to encourage bio splits and verifies
+# that even with partial-completion paths, `io_orphan_complete_count`
+# remains zero (commit-11 BPF caches issue-time sector / nr_sector / dev
+# in `pending_io_val`, decoupling completion-side IoKey from in-flight
+# rq mutation).
+
+echo ""
+echo "=== Cross-Kernel E2E Phase 3: multi-bio partial-completion regression ==="
+
+LARGE_IO_TRACE_FILE="$(mktemp /tmp/cross_kernel_large_io_XXXXXX.wperf)"
+LARGE_IO_REPORT_FILE="$(mktemp /tmp/cross_kernel_large_io_XXXXXX.json)"
+LARGE_IO_WORKLOAD_FILE="$(mktemp /tmp/cross_kernel_large_io_data_XXXXXX.bin)"
+LARGE_IO_RECORD_STDERR="$(mktemp /tmp/cross_kernel_large_io_record_XXXXXX.txt)"
+
+# 1MB blocks × 16 = 16MB fsynced. 1MB is large enough to fragment into
+# multiple bios on most backing filesystems (BIO_MAX_VECS-bounded segments).
+(
+    sleep 0.2
+    dd if=/dev/zero of="$LARGE_IO_WORKLOAD_FILE" bs=1M count=16 conv=fsync 2>/dev/null || true
+    sync
+) &
+LARGE_IO_WORKLOAD_PID=$!
+
+"$WPERF" record -o "$LARGE_IO_TRACE_FILE" -d $((DURATION + 1)) 2>"$LARGE_IO_RECORD_STDERR" || {
+    echo "FAIL: wperf record (large-IO phase) exited with error" >&2
+    cat "$LARGE_IO_RECORD_STDERR" >&2
+    rm -f "$LARGE_IO_RECORD_STDERR" "$LARGE_IO_TRACE_FILE" "$LARGE_IO_REPORT_FILE" "$LARGE_IO_WORKLOAD_FILE"
+    exit 1
+}
+wait "$LARGE_IO_WORKLOAD_PID" || true
+
+echo "--- wperf record (large-IO phase) stderr ---"
+cat "$LARGE_IO_RECORD_STDERR"
+rm -f "$LARGE_IO_RECORD_STDERR"
+
+"$WPERF" report "$LARGE_IO_TRACE_FILE" > "$LARGE_IO_REPORT_FILE"
+
+LARGE_IO_INVARIANTS=$(jq '.health.invariants_ok' "$LARGE_IO_REPORT_FILE")
+LARGE_IO_ORPHAN=$(jq '.health.io_orphan_complete_count' "$LARGE_IO_REPORT_FILE")
+LARGE_IO_PENDING=$(jq '.health.io_pending_at_end_count' "$LARGE_IO_REPORT_FILE")
+LARGE_IO_COLLISION=$(jq '.health.io_userspace_pair_collision_count' "$LARGE_IO_REPORT_FILE")
+LARGE_IO_RATIO=$(jq -c '.health.attributed_delay_ratio' "$LARGE_IO_REPORT_FILE")
+LARGE_IO_EVENTS=$(jq '.stats.events_read' "$LARGE_IO_REPORT_FILE")
+LARGE_IO_EDGE_COUNT=$(jq '.cascade.graph_metrics.edge_count' "$LARGE_IO_REPORT_FILE")
+
+echo "  events_read:                    $LARGE_IO_EVENTS"
+echo "  edge_count:                     $LARGE_IO_EDGE_COUNT"
+echo "  invariants_ok:                  $LARGE_IO_INVARIANTS"
+echo "  io_orphan_complete_count:       $LARGE_IO_ORPHAN"
+echo "  io_pending_at_end_count:        $LARGE_IO_PENDING"
+echo "  io_userspace_pair_collision:    $LARGE_IO_COLLISION"
+echo "  attributed_delay_ratio:         $LARGE_IO_RATIO"
+
+if [ "$LARGE_IO_INVARIANTS" != "true" ]; then
+    echo "FAIL: large-IO phase invariants violated" >&2
+    jq '.health' "$LARGE_IO_REPORT_FILE" >&2
+    rm -f "$LARGE_IO_TRACE_FILE" "$LARGE_IO_REPORT_FILE" "$LARGE_IO_WORKLOAD_FILE"
+    exit 1
+fi
+
+# Commit-11 contract: even if multi-bio partial-completion path was triggered,
+# orphan count must remain zero because the IoKey is built from issue-time
+# fields cached in pending_io_val, not from rq fields at completion time.
+if [ "$LARGE_IO_ORPHAN" != "null" ] && [ "$LARGE_IO_ORPHAN" -gt 0 ]; then
+    echo "FAIL: io_orphan_complete_count=$LARGE_IO_ORPHAN > 0 on large-IO workload" >&2
+    echo "  commit-11 BPF should cache issue-time (sector, nr_sector, dev) in pending_io_val" >&2
+    echo "  so that completion-time IoKey matches issue-time, even when blk_update_request" >&2
+    echo "  has mutated rq->__sector / rq->__data_len during partial completion." >&2
+    jq '.health' "$LARGE_IO_REPORT_FILE" >&2
+    rm -f "$LARGE_IO_TRACE_FILE" "$LARGE_IO_REPORT_FILE" "$LARGE_IO_WORKLOAD_FILE"
+    exit 1
+fi
+
+rm -f "$LARGE_IO_TRACE_FILE" "$LARGE_IO_REPORT_FILE" "$LARGE_IO_WORKLOAD_FILE"
+
+echo ""
+echo "=== Cross-Kernel E2E Phase 3 (multi-bio partial-completion): PASSED ==="
+echo "  kernel $(uname -r): multi-bio IoKey pairing verified"
+echo "  events=$LARGE_IO_EVENTS edges=$LARGE_IO_EDGE_COUNT ratio=$LARGE_IO_RATIO orphans=$LARGE_IO_ORPHAN"
 echo ""
 echo "=== Cross-Kernel E2E: ALL PHASES PASSED ==="

--- a/tests/workloads/run_cross_kernel_e2e.sh
+++ b/tests/workloads/run_cross_kernel_e2e.sh
@@ -322,14 +322,52 @@ if [ "$LARGE_IO_INVARIANTS" != "true" ]; then
     exit 1
 fi
 
-# Commit-11 contract: even if multi-bio partial-completion path was triggered,
-# orphan count must remain zero because the IoKey is built from issue-time
-# fields cached in pending_io_val, not from rq fields at completion time.
+# Commit-12 pair-conservation invariant per Oracle msg=f39c50c7 §4
+# (strengthens commit-11's single `io_orphan_complete_count == 0` to a
+# three-way invariant covering both pairing failure modes + collision):
+#
+#   io_orphan_complete_count == 0  → every IoComplete paired with an IoIssue
+#                                    (commit-11 contract: completion-time
+#                                    IoKey comes from cached val, not from
+#                                    rq fields that blk_update_request may
+#                                    have mutated)
+#   io_pending_at_end_count == 0   → every IoIssue paired with an IoComplete
+#                                    (no IoIssue stranded in pending_io
+#                                    HashMap when capture ended; multi-bio
+#                                    requests fully drained)
+#   io_userspace_pair_collision_count == 0
+#                                  → no IoKey collisions in pending_io
+#                                    (would surface if (dev, sector,
+#                                    nr_sector) tuple isn't unique enough
+#                                    on this workload — last-writer-wins
+#                                    drops the prior pending entry)
+#
+# Conjunction = full pair-conservation invariant: every IoIssue maps 1-to-1
+# to an IoComplete with stable IoKey across the partial-completion path.
+PAIR_CONSERVATION_FAIL=0
 if [ "$LARGE_IO_ORPHAN" != "null" ] && [ "$LARGE_IO_ORPHAN" -gt 0 ]; then
     echo "FAIL: io_orphan_complete_count=$LARGE_IO_ORPHAN > 0 on large-IO workload" >&2
     echo "  commit-11 BPF should cache issue-time (sector, nr_sector, dev) in pending_io_val" >&2
     echo "  so that completion-time IoKey matches issue-time, even when blk_update_request" >&2
     echo "  has mutated rq->__sector / rq->__data_len during partial completion." >&2
+    PAIR_CONSERVATION_FAIL=1
+fi
+if [ "$LARGE_IO_PENDING" != "null" ] && [ "$LARGE_IO_PENDING" -gt 0 ]; then
+    echo "FAIL: io_pending_at_end_count=$LARGE_IO_PENDING > 0 on large-IO workload" >&2
+    echo "  IoIssue events without matching IoComplete — partial-completion bio chain" >&2
+    echo "  was not fully drained, OR IoKey at issue/complete diverged for this request." >&2
+    PAIR_CONSERVATION_FAIL=1
+fi
+if [ "$LARGE_IO_COLLISION" != "null" ] && [ "$LARGE_IO_COLLISION" -gt 0 ]; then
+    echo "FAIL: io_userspace_pair_collision_count=$LARGE_IO_COLLISION > 0 on large-IO workload" >&2
+    echo "  Two IoIssue events shared the same (dev, sector, nr_sector) IoKey before the" >&2
+    echo "  first paired with its IoComplete — last-writer-wins dropped the prior pending" >&2
+    echo "  entry. If this fires under realistic workloads, the IoKey is not unique enough" >&2
+    echo "  and the event ABI may need to carry struct request* (Gemini PR #120 review)." >&2
+    PAIR_CONSERVATION_FAIL=1
+fi
+if [ "$PAIR_CONSERVATION_FAIL" -ne 0 ]; then
+    echo "FAIL: pair-conservation invariant violated on multi-bio workload" >&2
     jq '.health' "$LARGE_IO_REPORT_FILE" >&2
     rm -f "$LARGE_IO_TRACE_FILE" "$LARGE_IO_REPORT_FILE" "$LARGE_IO_WORKLOAD_FILE"
     exit 1


### PR DESCRIPTION
## Summary
- Wires `block_rq_issue` / `block_rq_complete` tracepoints into the BPF skeleton (dual `tp_btf` + `raw_tp` CO-RE paths, matching the existing sched_switch precedent) and extends the 40-byte event ABI with `IoIssue` / `IoComplete` discriminants.
- Adds userspace dispatch: typed `(dev, sector, nr_sector)`-keyed `pending_io` lifecycle, bidirectional User↔DISK_TID synthetic edges (ADR-009 §Consequences, single pseudo-disk per the deferred per-device decision), and `WaitType::IoBlock` annotation.
- Surfaces block-IO health through `HealthMetrics`: `io_orphan_complete_count`, `io_pending_at_end_count`, `io_userspace_pair_collision_count` (Gemini's collision guardrail), and `attributed_delay_ratio` (Phase 2b gate ≥ 0.70 per final-design §3.8).
- **All six internal commits landed on the branch**; two open items before this moves out of draft — runtime smoke evidence (Oracle Directive 5) and the cascade-cycle design question (see below).

## Commits (on branch, ordered)
1. `293d502` feat(event): `IoIssue` / `IoComplete` event-type discriminants
2. `3737646` feat(correlate): `unknown_event_type_count` forward-compat bisect guard
3. `350d324` test(snapshots): accept new `unknown_event_type_count` field
4. `36d6805` feat(bpf): block_rq_issue / block_rq_complete via dual `tp_btf` + `raw_tp`
5. `2ba806a` style: cargo fmt — block_rq autoload gating + `BtfGuard` if-let
6. `75cb2bd` test(mutants): exclude commit-2 BPF-gated probes + `WperfEvent::io_sector` equivalent mutant
7. `d4cd8ec` feat(correlate): split IO dispatch + userspace `pending_io` lifecycle
8. `702359e` fix(io): address Gemini PR #120 review — IoKey += nr_sector + rename `SUBMITTER_MISS` → `COMPLETION_LOCALITY`
9. `9664f86` feat(correlate): bidirectional User↔PseudoDisk synthetic edges + `invariants_ok` proptest
10. `e50391b` feat(health): wire block-IO HealthMetrics counters + `attributed_delay_ratio`
11. `f0ce77e` test(io): end-to-end block-IO fixture suite + `clone_with_reset_attribution` wait_type preservation fix

## Authoritative Inputs
- `docs/design/final-design.md` §3.3 (synthetic edge injection — block I/O pseudo-thread), §3.8 (Phase 2b gates)
- [ADR-009: IO Attribution via Synthetic Edges](docs/decisions/ADR-009.md) §3, §Consequences (single DISK_TID; per-device deferred)
- [ADR-016](docs/decisions/ADR-016.md) (I-1 retirement, `invariants_ok` = I-2 ∧ I-7 production sentinel)
- `docs/audit/p2b-01/btf-matrix-5.4-5.8-6.18.md` (BTF arity matrix for block_rq_issue: 2-arg pre-5.11 vs 3-arg 5.11+)
- Issue #38 (P2b-01 parent tracker)

## Deviations
None from the accepted ADRs. One **design-level question** surfaced during fixture development — see "Open Design Question" below; not a deviation until the answer lands.

## Dependency Checklist
- [x] No new/modified direct dependencies in this PR
- [x] No new Cargo features
- [x] baseline `docs/lessons/REGISTRY.md` unaffected

## Review Checklist
- [x] **Design conformance**: implementation matches ADR-009 §3 submitter-attribution rule + final-design.md §3.3 block-IO pseudo-thread plan (+ §Consequences single-pseudo-disk choice)
- [x] **Deviations declared**: none (pending the cascade-cycle design call below)
- [x] **Code correctness**: BPF-side `pending_io` map + `PF_KTHREAD` early filter + `targ_single` rodata gating; userspace `(dev, sector, nr_sector)` pairing; bidirectional edge + `WaitType::IoBlock`; HealthMetrics wired
- [x] **Tests**: 6 new p2b_io_fixtures + 2 proptest cases (2_000× each) + all existing passing — 265 lib + 18 snapshot + 5 proptest
- [x] **CI green**: all 4 jobs pass up through `e50391b`; `f0ce77e` in progress
- [x] **External reviews**: Gemini reviewed; both medium-priority findings addressed in `702359e` and closed with explicit CONCUR from Gemini
- [ ] **Owner approval**: @Adrian-Mason approval required before ready-for-review + merge — also needs decision on open design question below

## Open Design Question (requires @Adrian-Mason)
**Pure block-IO 2-cycle workloads produce `attributed_delay_ratio = 0.0` under the current cascade algorithm.**

Mechanism: cascade walks `User→Disk`, recurses into `Disk→User`, finds `User` already in `path`, returns `(0, window.duration)` → propagated back → `attributed = raw - propagated = 0`. This is the correct behavior of `compute_cascade`'s cycle guard, but it means the Phase 2b gate `attributed_delay_ratio ≥ 0.70` (final-design §3.8) reads 0.0 on pure-IO fixtures, not ≥ 0.70.

Two interpretations:
1. **Gate semantic is workload-dependent**: the ≥ 0.70 gate is meant for mixed workloads where IoBlock edges connect into futex/switch chains that pull attribution into the IO subgraph. Pure-IO basecase = 0 is cascade-correct. No code changes needed; spec may need a clarifying note.
2. **Cascade special-cases IoBlock return edges**: treat the `Disk→User` return as non-recursive (or route attribution to the Disk node directly rather than through the cycle). This is an algorithmic change to `compute_cascade`.

I lean toward (1) based on the existing cascade invariant guarantees (I-2 / I-7 hold either way), but the decision affects Phase 2b gate validation and real-workload interpretation — flagging for your call before the PR leaves draft.

## Runtime Evidence
**Pending** — `sudo ./target/release/wperf record --... -- fio --randread ...` then `wperf report`, posting the resulting JSON (with `attributed_delay_ratio` + the three IO health counters populated) as a follow-up comment. Requires a BPF-capable kernel, out of reach from the sandboxed dev environment. Will land before ready-for-review.

## Test Plan
- [x] Gate 0 — `cargo fmt --all -- --check` (green)
- [x] Gate 1 — `cargo check` + `cargo check --features bpf` (both green)
- [x] Gate 2 — `cargo clippy --all-targets -- -D warnings` + `cargo clippy --features bpf --all-targets -- -D warnings` (both green)
- [x] Gate 3 — `cargo test` (265 lib + 6 fixture + 18 snapshot + 5 proptest × 2_000–10_000 cases, all green)
- [x] Gate 4 — Live-sentinel grep: `invariants_ok` + `verify_engine_postconditions` alive (16 hits in `src/cascade/`); `assert_weight_conserved` zero hits (ADR-016 retirement holds)
- [x] Gate 5 — `.cargo/mutants.toml` exclusions documented + kill rate at 90%+ (confirmed green on every commit)
- [ ] Runtime smoke (Oracle Directive 5) — pending real-kernel run + JSON paste
- [ ] Design call on cascade-cycle interpretation (blocks ready-for-review)

## Remaining Work (this PR)
- @Adrian-Mason: cascade-cycle design call (option 1 vs 2 above)
- Runtime smoke evidence posted as follow-up comment
- Then mark ready-for-review via `gh pr ready 120`

Closes #38 when runtime-smoke + design call + ready-for-review all land.

Signed-off-by: Adrian Mason <258563901+adrian-mason@users.noreply.github.com>